### PR TITLE
Updates to config / yaml structure and push / deploy commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,12 +72,16 @@ Required options:
 
 #### Launching a stack
 
-`hokusai stack_up {CONTEXT}` launches the stack defined in `hokusai/production.yml' for the given Kubernetes context
+`hokusai stack up {CONTEXT}` launches the stack defined in `hokusai/{CONTEXT}.yml' for the given Kubernetes context
 
 #### Deleting a stack
 
-`hokusai stack_down {CONTEXT}` deletes the stack defined in `hokusai/production.yml' for the given Kubernetes context
+`hokusai stack down {CONTEXT}` deletes the stack defined in `hokusai/{CONTEXT}.yml' for the given Kubernetes context
+
+#### Checking a stack status
+
+`hokusai stack status {CONTEXT}` prints the stack status defined in `hokusai/{CONTEXT}.yml' for the given Kubernetes context
 
 #### Rolling deployments
 
-`hokusai deploy {CONTEXT}` updates the Kubernetes deployment for the given context to `latest` or the given image tag
+`hokusai deploy {CONTEXT} {TAG}` updates the Kubernetes deployment for the given context to the given image tag

--- a/bin/hokusai
+++ b/bin/hokusai
@@ -49,20 +49,18 @@ def check(interactive):
   sys.exit(hokusai.check(interactive))
 
 @cli.command()
-@click.option('--docker-compose-yml', type=click.STRING, default=os.path.join(os.getcwd(), 'hokusai/development.yml'), help='docker-compose development file - defaults to hokusai/development.yml')
-def dev(docker_compose_yml):
+def dev():
   """
   Boot the development stack
   """
-  sys.exit(hokusai.development(docker_compose_yml))
+  sys.exit(hokusai.development())
 
 @cli.command()
-@click.option('--docker-compose-yml', type=click.STRING, default=os.path.join(os.getcwd(), 'hokusai/test.yml'), help='docker-compose test file - defaults to hokusai/test.yml')
-def test(docker_compose_yml):
+def test():
   """
   Boot the test stack and run the test suite
   """
-  sys.exit(hokusai.test(docker_compose_yml))
+  sys.exit(hokusai.test())
 
 @cli.command()
 def build():
@@ -97,21 +95,19 @@ def add_secret(context, key, value):
 
 @cli.command()
 @click.argument('context', type=click.STRING)
-@click.option('--kubernetes-yml', type=click.STRING, default=os.path.join(os.getcwd(), 'hokusai/production.yml'), help='kubernetes config file - defaults to hokusai/production.yml')
-def stack_up(context, kubernetes_yml):
+def stack_up(context):
   """
   Create the stack in the given context
   """
-  sys.exit(hokusai.stack_up(context, kubernetes_yml))
+  sys.exit(hokusai.stack_up(context))
 
 @cli.command()
 @click.argument('context', type=click.STRING)
-@click.option('--kubernetes-yml', type=click.STRING, default=os.path.join(os.getcwd(), 'hokusai/production.yml'), help='kubernetes config file - defaults to hokusai/production.yml')
-def stack_down(context, kubernetes_yml):
+def stack_down(context):
   """
   Delete the stack in the given context
   """
-  sys.exit(hokusai.stack_down(context, kubernetes_yml))
+  sys.exit(hokusai.stack_down(context))
 
 @cli.command()
 @click.argument('context', type=click.STRING)

--- a/bin/hokusai
+++ b/bin/hokusai
@@ -10,6 +10,7 @@ from distutils.dir_util import mkpath
 import click
 
 import hokusai
+from hokusai.common import *
 
 @click.group()
 def cli():
@@ -89,20 +90,24 @@ def add_secret(context, key, value):
   sys.exit(hokusai.add_secret(context, key, value))
 
 @cli.command()
+@click.argument('action', type=click.STRING)
 @click.argument('context', type=click.STRING)
-def stack_up(context):
+def stack(action, context):
   """
-  Create the stack in the given context
+  Actions:\n
+  up - Create / Update the stack in the given context\n
+  down - Delete the stack in the given context\n
+  status - Print the stack status in the given context
   """
-  sys.exit(hokusai.stack_up(context))
-
-@cli.command()
-@click.argument('context', type=click.STRING)
-def stack_down(context):
-  """
-  Delete the stack in the given context
-  """
-  sys.exit(hokusai.stack_down(context))
+  if action == 'up':
+    sys.exit(hokusai.stack_up(context))
+  elif action == 'down':
+    sys.exit(hokusai.stack_down(context))
+  elif action == 'status':
+    sys.exit(hokusai.stack_status(context))
+  else:
+    print_red("ERROR: invalid stack action %s" % action)
+    sys.exit(-1)
 
 @cli.command()
 @click.argument('context', type=click.STRING)

--- a/bin/hokusai
+++ b/bin/hokusai
@@ -70,18 +70,13 @@ def build():
   sys.exit(hokusai.build())
 
 @cli.command()
+@click.argument('tag', type=click.STRING)
 @click.option('--test-build', type=click.BOOL, is_flag=True, help="Push the latest image output by 'test' - otherwise the latest image output by 'build'")
-@click.option('--tag', '-t', type=click.STRING, multiple=True, help="Tags to apply to the pushed image - defaults to 'latest' if none specified")
-def push(test_build, tag):
+def push(tag, test_build):
   """
-  Push a docker image to ECR with the given tags
+  Push a docker image to ECR with the given tag
   """
-  if not len(tag):
-    tags = ['latest']
-  else:
-    tags = list(tag)
-
-  sys.exit(hokusai.push(test_build, tags))
+  sys.exit(hokusai.push(tag, test_build))
 
 @cli.command()
 @click.argument('context', type=click.STRING)
@@ -111,10 +106,10 @@ def stack_down(context):
 
 @cli.command()
 @click.argument('context', type=click.STRING)
-@click.option('--tag', '-t', type=click.STRING, default='latest', help="Image tag to deploy - (defaults to 'latest')")
+@click.argument('tag', type=click.STRING)
 def deploy(context, tag):
   """
-  Deploy an image to the given context
+  Deploy an image tag to the given context and update context tag to reference that image
   """
   sys.exit(hokusai.deploy(context, tag))
 

--- a/hokusai/__init__.py
+++ b/hokusai/__init__.py
@@ -263,6 +263,26 @@ def stack_down(context):
   print_green("Stack %s deleted" % kubernetes_yml)
   return 0
 
+def stack_status(context):
+  config = HokusaiConfig().check()
+  kubernetes_yml = os.path.join(os.getcwd(), "hokusai/%s.yml" % context)
+  if not os.path.isfile(kubernetes_yml):
+    print_red("Yaml file %s does not exist for given context." % kubernetes_yml)
+    return -1
+
+  try:
+    switch_context_result = check_output("kubectl config use-context %s" % context, stderr=STDOUT, shell=True)
+    print_green("Switched context to %s" % context)
+    if 'no context exists' in switch_context_result:
+      print_red("Context %s does not exist.  Check ~/.kube/config" % context)
+      return -1
+    elif 'switched to context' in switch_context_result:
+      check_call("kubectl describe -f %s" % kubernetes_yml, shell=True)
+  except CalledProcessError:
+    print_red('Stack status failed')
+    return -1
+  return 0
+
 def deploy(context, tag):
   config = HokusaiConfig().check()
 

--- a/hokusai/__init__.py
+++ b/hokusai/__init__.py
@@ -223,6 +223,9 @@ def add_secret(context, key, value):
 def stack_up(context):
   config = HokusaiConfig().check()
   kubernetes_yml = os.path.join(os.getcwd(), "hokusai/%s.yml" % context)
+  if not os.path.isfile(kubernetes_yml):
+    print_red("Yaml file %s does not exist for given context." % kubernetes_yml)
+    return -1
 
   try:
     switch_context_result = check_output("kubectl config use-context %s" % context, stderr=STDOUT, shell=True)
@@ -242,6 +245,9 @@ def stack_up(context):
 def stack_down(context):
   config = HokusaiConfig().check()
   kubernetes_yml = os.path.join(os.getcwd(), "hokusai/%s.yml" % context)
+  if not os.path.isfile(kubernetes_yml):
+    print_red("Yaml file %s does not exist for given context." % kubernetes_yml)
+    return -1
 
   try:
     switch_context_result = check_output("kubectl config use-context %s" % context, stderr=STDOUT, shell=True)
@@ -433,6 +439,9 @@ def init(project_name, aws_account_id, aws_ecr_region, framework, base_image,
 def development():
   config = HokusaiConfig().check()
   docker_compose_yml = os.path.join(os.getcwd(), 'hokusai/development.yml')
+  if not os.path.isfile(docker_compose_yml):
+    print_red("Yaml file %s does not exist." % docker_compose_yml)
+    return -1
 
   # exit cleanly
   def cleanup(*args):
@@ -448,6 +457,9 @@ def development():
 def test():
   config = HokusaiConfig().check()
   docker_compose_yml = os.path.join(os.getcwd(), 'hokusai/test.yml')
+  if not os.path.isfile(docker_compose_yml):
+    print_red("Yaml file %s does not exist." % docker_compose_yml)
+    return -1
 
   # stop any running containers
   def cleanup(*args):

--- a/hokusai/config.py
+++ b/hokusai/config.py
@@ -10,8 +10,7 @@ class HokusaiConfig(object):
     config = {
       'project-name': project_name,
       'aws-account-id': aws_account_id,
-      'aws-ecr-region': aws_ecr_region,
-      'aws-ecr-registry': "%s.dkr.ecr.%s.amazonaws.com/%s" % (aws_account_id, aws_ecr_region, project_name)
+      'aws-ecr-region': aws_ecr_region
     }
 
     with open(HOKUSAI_CONFIG_FILE, 'w') as f:
@@ -28,12 +27,10 @@ class HokusaiConfig(object):
 
   def get(self, key):
     self.check()
-
     config_file = open(HOKUSAI_CONFIG_FILE, 'r')
     config_data = config_file.read()
     config_file.close()
     config = yaml.safe_load(config_data)
-
     try:
       return config[key]
     except KeyError:
@@ -51,5 +48,20 @@ class HokusaiConfig(object):
     with open(HOKUSAI_CONFIG_FILE, 'w') as f:
       payload = YAML_HEADER + yaml.safe_dump(config, default_flow_style=False)
       f.write(payload)
-
     return key, value
+
+  @property
+  def project_name(self):
+    return self.get('project-name')
+
+  @property
+  def aws_account_id(self):
+    return self.get('aws-account-id')
+
+  @property
+  def aws_ecr_region(self):
+    return self.get('aws-ecr-region')
+
+  @property
+  def aws_ecr_registry(self):
+    return "%s.dkr.ecr.%s.amazonaws.com/%s" % (self.aws_account_id, self.aws_ecr_region, self.project_name)


### PR DESCRIPTION
Updates:

- Adds `hokusai/common.yml` and `hokusai/staging.yml`
- `hokusai build` command uses `hokusai/common.yml` - this allows for passing through environment variables as build args (see current use in Currents)
- `hokusai stack_up / stack_down` now take a context (staging or production) and implicitly look for the `{context}.yml` to create the stack, separating staging and production stacks
- `hokusai dev / test` commands now also implicitly look for `development.yml` / `test.yml` respectively
- `hokusai push` now accepts only one argument - the tag to push to the repo.  It should be called with the git SHA of the build.  The `--test-build` option should be called from CI and pushes the latest image output by the `hokusai test` command.  Otherwise it pushes the latest image output by the `hokusai build` command
- `hokusai deploy` now is invoked with `{context}` and `{tag}` as positional arguments.  Before the deploy, it updates the `{context}` tag (i.e. `staging` / `production`) to point to the tag it then deploys, keeping it up-to-date with the latest deployment
- merges `hokusai stack_up` / `hokusai stack_down` commands into `hokusai stack` command with subcommands `up / down / status`
