### PR TITLE
add pull, images, console and run commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,19 +56,34 @@ Required options:
 
 `hokusai test` boots a testing stack as defined in `hokusai/test.yml` and exits with the return code of the test command
 
-### Production
+
+### Working with images
 
 #### Building an image
 
 `hokusai build` builds the latest docker image for the project
 
+#### Pulling images
+
+`hokusai pull` pulls images and tags for your project from your AWS account's ECR repo for the named project
+
 #### Pushing an image
 
 `hokusai push` pushes a locally built image to your AWS account's ECR repo for the named project
 
+#### Listing images
+
+`hokusai images` lists all project images in your local docker registry
+
+
+### Working with secrets
+
 #### Creating secrets
 
 `hokusai add_secret {CONTEXT} {KEY} {VALUE}` adds a secret to Kubernetes for the given context.  The secrets created are added to the Kubernetes secret object `{project}-secrets`
+
+
+### Working with Kubernetes
 
 #### Launching a stack
 
@@ -82,6 +97,14 @@ Required options:
 
 `hokusai stack status {CONTEXT}` prints the stack status defined in `hokusai/{CONTEXT}.yml' for the given Kubernetes context
 
-#### Rolling deployments
+#### Deploying
 
 `hokusai deploy {CONTEXT} {TAG}` updates the Kubernetes deployment for the given context to the given image tag
+
+#### Running a console
+
+`hokusai console {CONTEXT}` launches a container and attaches a shell session in the given context
+
+#### Running a command
+
+`hokusai run {CONTEXT} {COMMAND}` launches a container and runs the given command in the given context.  It exits with the status code of the command run in the container (useful for `rake` tasks, etc)

--- a/bin/hokusai
+++ b/bin/hokusai
@@ -71,6 +71,13 @@ def build():
   sys.exit(hokusai.build())
 
 @cli.command()
+def pull():
+  """
+  Pull all images and tags from the ECR
+  """
+  sys.exit(hokusai.pull())
+
+@cli.command()
 @click.argument('tag', type=click.STRING)
 @click.option('--test-build', type=click.BOOL, is_flag=True, help="Push the latest image output by 'test' - otherwise the latest image output by 'build'")
 def push(tag, test_build):
@@ -78,6 +85,13 @@ def push(tag, test_build):
   Push a docker image to ECR with the given tag
   """
   sys.exit(hokusai.push(tag, test_build))
+
+@cli.command()
+def images():
+  """
+  Show images and tags
+  """
+  sys.exit(hokusai.images())
 
 @cli.command()
 @click.argument('context', type=click.STRING)
@@ -117,6 +131,26 @@ def deploy(context, tag):
   Deploy an image tag to the given context and update context tag to reference that image
   """
   sys.exit(hokusai.deploy(context, tag))
+
+@cli.command()
+@click.argument('context', type=click.STRING)
+@click.option('--shell', type=click.STRING, default='bash', help='The shell to run (defaults to bash)')
+@click.option('--env', type=click.STRING, multiple=True, help='Environment variables in the form of "KEY=VALUE"')
+def console(context, shell, env):
+  """
+  Launch a new container and attach a shell in the given context
+  """
+  sys.exit(hokusai.console(context, shell, env))
+
+@cli.command()
+@click.argument('context', type=click.STRING)
+@click.argument('command', type=click.STRING)
+@click.option('--env', type=click.STRING, multiple=True, help='Environment variables in the form of "KEY=VALUE"')
+def run(context, command, env):
+  """
+  Launch a new container and run a command in the given context
+  """
+  sys.exit(hokusai.run(context, command, env))
 
 if __name__ == '__main__':
   cli(obj={})

--- a/bin/hokusai
+++ b/bin/hokusai
@@ -135,22 +135,24 @@ def deploy(context, tag):
 @cli.command()
 @click.argument('context', type=click.STRING)
 @click.option('--shell', type=click.STRING, default='bash', help='The shell to run (defaults to bash)')
+@click.option('--tag', type=click.STRING, help='The image tag to run (defaults to the value of context)')
 @click.option('--env', type=click.STRING, multiple=True, help='Environment variables in the form of "KEY=VALUE"')
-def console(context, shell, env):
+def console(context, shell, tag, env):
   """
   Launch a new container and attach a shell in the given context
   """
-  sys.exit(hokusai.console(context, shell, env))
+  sys.exit(hokusai.console(context, shell, tag, env))
 
 @cli.command()
 @click.argument('context', type=click.STRING)
 @click.argument('command', type=click.STRING)
+@click.option('--tag', type=click.STRING, help='The image tag to run (defaults to the value of context)')
 @click.option('--env', type=click.STRING, multiple=True, help='Environment variables in the form of "KEY=VALUE"')
-def run(context, command, env):
+def run(context, command, tag, env):
   """
   Launch a new container and run a command in the given context
   """
-  sys.exit(hokusai.run(context, command, env))
+  sys.exit(hokusai.run(context, command, tag, env))
 
 if __name__ == '__main__':
   cli(obj={})

--- a/hokusai/__init__.py
+++ b/hokusai/__init__.py
@@ -331,7 +331,7 @@ def deploy(context, tag):
   print_green("Deployment updated to %s" % tag)
   return 0
 
-def console(context, shell, env):
+def console(context, shell, tag, env):
   config = HokusaiConfig().check()
 
   switch_context_result = check_output("kubectl config use-context %s" % context, stderr=STDOUT, shell=True)
@@ -341,9 +341,13 @@ def console(context, shell, env):
     return -1
 
   environment = ' '.join(map(lambda x: '--env="%s"' % x, env))
-  call("kubectl run %s-shell-%s -t -i --image=%s:%s --restart=OnFailure --rm %s -- %s" % (config.project_name, os.environ.get('USER'), config.aws_ecr_registry, context, environment, shell), shell=True)
+  if tag is not None:
+    image_tag = tag
+  else:
+    image_tag = context
+  call("kubectl run %s-shell-%s -t -i --image=%s:%s --restart=OnFailure --rm %s -- %s" % (config.project_name, os.environ.get('USER'), config.aws_ecr_registry, image_tag, environment, shell), shell=True)
 
-def run(context, command, env):
+def run(context, command, tag, env):
   config = HokusaiConfig().check()
 
   switch_context_result = check_output("kubectl config use-context %s" % context, stderr=STDOUT, shell=True)
@@ -353,7 +357,11 @@ def run(context, command, env):
     return -1
 
   environment = ' '.join(map(lambda x: '--env="%s"' % x, env))
-  return call("kubectl run %s-run-%s --attach --image=%s:%s --restart=OnFailure --rm %s -- %s" % (config.project_name, os.environ.get('USER'), config.aws_ecr_registry, context, environment, command), shell=True)
+  if tag is not None:
+    image_tag = tag
+  else:
+    image_tag = context
+  return call("kubectl run %s-run-%s --attach --image=%s:%s --restart=OnFailure --rm %s -- %s" % (config.project_name, os.environ.get('USER'), config.aws_ecr_registry, image_tag, environment, command), shell=True)
 
 def init(project_name, aws_account_id, aws_ecr_region, framework, base_image,
           run_command, development_command, test_command, port, target_port,


### PR DESCRIPTION
New commands:

`hokusai pull` pulls images and tags for your project from your AWS account's ECR repo for the named project

`hokusai images` lists all project images in your local docker registry

`hokusai console {CONTEXT}` launches a container and attaches a shell session in the given context

`hokusai run {CONTEXT} {COMMAND}` launches a container and runs the given command in the given context.  It exits with the status code of the command run in the container (useful for `rake` tasks, etc)

Also:
- don't update tag on deploy if it matches context
- create a tag `{CONTEXT}-utc-timestamp` on deploy

cc @cavvia 