### PR TITLE
improve concision and scan-ability of readme. add about section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,106 +5,107 @@ Artsy Docker Development Toolkit
 
 <img height="300" src="hokusai.jpg">
 
+## About
+
+Hokusai works with [Kubernetes](https://kubernetes.io/) and [Docker](https://www.docker.com/) to manage a container driven workflow, from development to testing and deployment.
+
 ## Requirements
 
 1) [Docker](https://docs.docker.com/)
 
-2) [Docker Compose](https://docs.docker.com/compose/) If you install Docker for Mac, `docker-compose` is also installed. Otherwise install with: `sudo pip install docker-compose`
+2) [Docker Compose](https://docs.docker.com/compose/)
 
-3) [AWS CLI](http://docs.aws.amazon.com/cli/latest/userguide/installing.html) Install with: `pip install awscli`
+If you install Docker for Mac, `docker-compose` is also installed. Otherwise install with: `sudo pip install docker-compose`.
 
-4) [kubectl](http://kubernetes.io/docs/user-guide/prereqs/) Install the `kubectl` binary and kubectl configuration in `~/.kube/config` for your Kubernetes cluster - make sure the version of the `kubectl` binary matches your cluster
+3) [AWS CLI](http://docs.aws.amazon.com/cli/latest/userguide/installing.html) 
 
-4) Set the `$AWS_ACCESS_KEY_ID` and `$AWS_SECRET_ACCESS_KEY` environment variables.  You should have permissions to evaluate the `aws ecr get-login` comamnd for your ECR region and push access to your ECR repositories
+Install with: `pip install awscli`. Set the `$AWS_ACCESS_KEY_ID` and `$AWS_SECRET_ACCESS_KEY` environment variables. You should have permissions to evaluate the `aws ecr get-login` comamnd for your ECR region and push access to your ECR repositories.
+
+4) [kubectl](http://kubernetes.io/docs/user-guide/prereqs/) 
+
+Install the `kubectl` binary and kubectl configuration in `~/.kube/config` for your Kubernetes cluster - make sure the version of the `kubectl` binary matches your cluster.
 
 ## Setup
 
-Ensure `docker`, `docker-compose` and `aws` are installed to your PATH
+Ensure `docker`, `docker-compose`, `kubectl` and `aws` are installed to your PATH.
 
-Ensure Python-development headers are installed - (on Debian run `sudo apt-get install python-dev`)
+Ensure Python-development headers are installed. On Debian run
 
-Run either `pip install .` or `python setup.py install`
+```
+sudo apt-get install python-dev
+```
 
-`hokusai` should be installed on your PATH
+Now package Hokusai with
 
-To upgrade to the latest changes in this repo, run: `pip install --upgrade .`
+```
+pip install .
+```
+
+And `hokusai` should now be installed on your PATH.
+
+Now run
+
+```
+hokusai check --interactive
+```
+
+to ensure everything is set up correctly.
+
+To upgrade to the latest changes in this repo, just run
+
+```
+pip install --upgrade .
+```
 
 ## Use
 
-`hokusai --help` lists all available commands
-
-See `hokusai {command} --help` for command-specific options
+```
+hokusai --help
+hokusai {command} --help
+```
 
 ### Initializing a project
 
-`hokusai init` writes hokusai project config to `hokusai/config.yml`, creates `hokusai/test.yml', `hokusai/development.yml' and `hokusai/production.yml' and creates a Dockerfile in the current directory
+Run
+
+```
+hokusai init
+``` 
+
+This writes hokusai project config to `hokusai/config.yml`, creates test, development and production yaml files alongside it, and adds a Dockerfile to the current directory.
 
 Required options:
-  - `--aws-account-id`: Your AWS account ID - can be found in your AWS account console
-  - `--framework`: Either "rack" or "nodejs"
-  - `--base-image`: The base docker image for the project `Dockerfile` - i.e. "ruby:2.2" or "ruby:2.2-alpine" - see [Docker Hub](https://hub.docker.com/) for valid base images
-
-### Checking dependencies
-
-`hokusai check` makes sure everything is set up correctly in your local environment and for your project - the `--interactive` flag prompts to install `docker-compose`, `aws` and `kubectl`, if missing
+  - `--aws-account-id`: Your AWS account ID - can be found in your AWS account console.
+  - `--framework`: Either "rack" or "nodejs".
+  - `--base-image`: The base docker image for the project `Dockerfile` - i.e. "ruby:2.2" or "ruby:2.2-alpine" - see [Docker Hub](https://hub.docker.com/) for valid base images.
 
 ### Development
 
-`hokusai dev` boots a development stack as defined in `hokusai/development.yml`
-
-### Testing
-
-`hokusai test` boots a testing stack as defined in `hokusai/test.yml` and exits with the return code of the test command
-
+* `hokusai dev` - Boot a development stack as defined in `hokusai/development.yml`.
+* `hokusai test` - Boot a testing stack as defined in `hokusai/test.yml` and exits with the return code of the test command.
 
 ### Working with images
 
-#### Building an image
-
-`hokusai build` builds the latest docker image for the project
-
-#### Pulling images
-
-`hokusai pull` pulls images and tags for your project from your AWS account's ECR repo for the named project
-
-#### Pushing an image
-
-`hokusai push` pushes a locally built image to your AWS account's ECR repo for the named project
-
-#### Listing images
-
-`hokusai images` lists all project images in your local docker registry
-
+* `hokusai build` - Build the latest docker image for the project.
+* `hokusai pull` - Pull images for your project from your AWS ECR repo.
+* `hokusai push` - Push a locally built image to your AWS ECR repo.
+* `hokusai images` - List all project images in your local docker registry.
 
 ### Working with secrets
 
-#### Creating secrets
+* `hokusai add_secret` - Add a secret to Kubernetes for a given context. The secrets created are added to the Kubernetes secret object `{project}-secrets`.
 
-`hokusai add_secret {CONTEXT} {KEY} {VALUE}` adds a secret to Kubernetes for the given context.  The secrets created are added to the Kubernetes secret object `{project}-secrets`
+### Working with Stacks
 
+* `hokusai stack up` - Launch a stack for a given Kubernetes context.
+* `hokusai stack down` - Delete a stack defined for a given Kubernetes context.
+* `hokusai stack status` - Print the stack status.
 
-### Working with Kubernetes
+### Deployment
 
-#### Launching a stack
+* `hokusai deploy` - Update the Kubernetes deployment to a given image tag.
 
-`hokusai stack up {CONTEXT}` launches the stack defined in `hokusai/{CONTEXT}.yml' for the given Kubernetes context
+### Running a console
 
-#### Deleting a stack
-
-`hokusai stack down {CONTEXT}` deletes the stack defined in `hokusai/{CONTEXT}.yml' for the given Kubernetes context
-
-#### Checking a stack status
-
-`hokusai stack status {CONTEXT}` prints the stack status defined in `hokusai/{CONTEXT}.yml' for the given Kubernetes context
-
-#### Deploying
-
-`hokusai deploy {CONTEXT} {TAG}` updates the Kubernetes deployment for the given context to the given image tag
-
-#### Running a console
-
-`hokusai console {CONTEXT}` launches a container and attaches a shell session in the given context
-
-#### Running a command
-
-`hokusai run {CONTEXT} {COMMAND}` launches a container and runs the given command in the given context.  It exits with the status code of the command run in the container (useful for `rake` tasks, etc)
+* `hokusai console` - Launch a container and attach a shell session.
+* `hokusai run` - Launch a container and run a given command. It exits with the status code of the command run in the container (useful for `rake` tasks, etc).


### PR DESCRIPTION
There's a number of formatting fixes here too. 

In general i think there's no need to discuss cli command options in depth here as using the `--help` option will be far more practical and it complicates the readme. Just an overview of the avail commands is good enough.