### PR TITLE
Updates to verbosity, command outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Required options:
 ### Deployment
 
 * `hokusai deploy` - Update the Kubernetes deployment to a given image tag.
+* `hokusai promote` - Update the Kubernetes deployment in a given context to match the deployment in another context
 
 ### Running a console
 

--- a/README.md
+++ b/README.md
@@ -101,8 +101,9 @@ Required options:
 
 ### Working with Secrets
 
-* `hokusai secret pull` - Pulls secrets from the Kubernetes server and writes to the `hokusai` directory.
-* `hokusai secret push` - Pushes secrets from the hokusai directory to the Kubernetes server. Secrets are created for the project as the Kubernetes Secret object `{project}-secrets`
+* `hokusai secrets get` - Prints secrets stored on the Kubernetes server
+* `hokusai secrets set` - Sets secrets on the Kubernetes server. Secrets are stored for the project as key-value pairs in the Kubernetes Secret object `{project}-secrets`
+* `hokusai secrets unset` - Removes secrets stored on the Kubernetes server
 
 ### Working with Stacks
 

--- a/bin/hokusai
+++ b/bin/hokusai
@@ -172,10 +172,23 @@ def stack(action, context, verbose):
 @click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
 def deploy(context, tag, verbose):
   """
-  Deploy an image tag to the kubectl {CONTEXT} and update the tag {CONTEXT} to reference that image
+  Deploy an image tag to the kubectl {CONTEXT}
+  and update the tag named {CONTEXT} to reference that tag
   """
   set_output(verbose)
   sys.exit(hokusai.deploy(context, tag))
+
+@cli.command()
+@click.argument('context', type=click.STRING)
+@click.argument('from-context', type=click.STRING)
+@click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
+def promote(context, from_context, verbose):
+  """
+  Update the deployment on {CONTEXT} with the image tag currently deployed on {FROM_CONTEXT}
+  and update the tag named {CONTEXT} to reference that tag
+  """
+  set_output(verbose)
+  sys.exit(hokusai.promote(context, from_context))
 
 @cli.command()
 @click.argument('context', type=click.STRING)

--- a/bin/hokusai
+++ b/bin/hokusai
@@ -115,8 +115,8 @@ def secrets(action, context, secret):
   """
   Actions:\n
   get - print secrets in the kubectl {CONTEXT}\n
-  set - set {SECRET} in the kubectl {CONTEXT}\n
-  unset - Unset {SECRET} from the kubectl {CONTEXT}
+  set - set {SECRET} in the kubectl {CONTEXT} - each {SECRET} must be in of form 'KEY=VALUE'\n
+  unset - Unset {SECRET} from the kubectl {CONTEXT} - each {SECRET} must be of the form 'KEY'
   """
   if action == 'get':
     sys.exit(hokusai.get_secrets(context))

--- a/bin/hokusai
+++ b/bin/hokusai
@@ -179,16 +179,16 @@ def deploy(context, tag, verbose):
   sys.exit(hokusai.deploy(context, tag))
 
 @cli.command()
-@click.argument('context', type=click.STRING)
 @click.argument('from-context', type=click.STRING)
+@click.argument('context', type=click.STRING)
 @click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
-def promote(context, from_context, verbose):
+def promote(from_context, context, verbose):
   """
   Update the deployment on {CONTEXT} with the image tag currently deployed on {FROM_CONTEXT}
   and update the tag named {CONTEXT} to reference that tag
   """
   set_output(verbose)
-  sys.exit(hokusai.promote(context, from_context))
+  sys.exit(hokusai.promote(from_context, context))
 
 @cli.command()
 @click.argument('context', type=click.STRING)

--- a/bin/hokusai
+++ b/bin/hokusai
@@ -6,7 +6,7 @@ import sys
 import click
 
 import hokusai
-from hokusai.common import print_red
+from hokusai.common import print_red, set_output
 
 @click.group()
 def cli():
@@ -47,58 +47,72 @@ def check(interactive):
   sys.exit(hokusai.check(interactive))
 
 @cli.command()
-def dev():
+@click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
+def dev(verbose):
   """
   Boot the development stack
   """
+  set_output(verbose)
   sys.exit(hokusai.development())
 
 @cli.command()
-def test():
+@click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
+def test(verbose):
   """
   Boot the test stack and run the test suite
   """
+  set_output(verbose)
   sys.exit(hokusai.test())
 
 @cli.command()
-def build():
+@click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
+def build(verbose):
   """
   Build the latest docker image for the project
   """
+  set_output(verbose)
   sys.exit(hokusai.build())
 
 @cli.command()
-def pull():
+@click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
+def pull(verbose):
   """
   Pull all images and tags from the ECR
   """
+  set_output(verbose)
   sys.exit(hokusai.pull())
 
 @cli.command()
 @click.argument('tag', type=click.STRING)
 @click.option('--test-build', type=click.BOOL, is_flag=True, help="Push the latest image output by 'test' - otherwise the latest image output by 'build'")
-def push(tag, test_build):
+@click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
+def push(tag, test_build, verbose):
   """
   Push a docker image to ECR with the given tag
   """
+  set_output(verbose)
   sys.exit(hokusai.push(tag, test_build))
 
 @cli.command()
-def images():
+@click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
+def images(verbose):
   """
   Show images and tags
   """
+  set_output(verbose)
   sys.exit(hokusai.images())
 
 @cli.command()
 @click.argument('action', type=click.STRING)
 @click.argument('context', type=click.STRING)
-def config(action, context):
+@click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
+def config(action, context, verbose):
   """
   Actions:\n
   pull - Pull config from the kubectl {CONTEXT} and write to hokusai/{CONTEXT}-config.yml\n
   push - Push config from hokusai/{CONTEXT}-config.yml to the kubectl {CONTEXT}
   """
+  set_output(verbose)
   if action == 'pull':
     sys.exit(hokusai.pull_config(context))
   elif action == 'push':
@@ -111,13 +125,15 @@ def config(action, context):
 @click.argument('action', type=click.STRING)
 @click.argument('context', type=click.STRING)
 @click.argument('secret', type=click.STRING, nargs=-1)
-def secrets(action, context, secret):
+@click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
+def secrets(action, context, secret, verbose):
   """
   Actions:\n
   get - print secrets in the kubectl {CONTEXT}\n
   set - set {SECRET} in the kubectl {CONTEXT} - each {SECRET} must be in of form 'KEY=VALUE'\n
   unset - Unset {SECRET} from the kubectl {CONTEXT} - each {SECRET} must be of the form 'KEY'
   """
+  set_output(verbose)
   if action == 'get':
     sys.exit(hokusai.get_secrets(context))
   elif action == 'set':
@@ -131,13 +147,15 @@ def secrets(action, context, secret):
 @cli.command()
 @click.argument('action', type=click.STRING)
 @click.argument('context', type=click.STRING)
-def stack(action, context):
+@click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
+def stack(action, context, verbose):
   """
   Actions:\n
   up - Create / Update the stack in the kubectl {CONTEXT}\n
   down - Delete the stack in the kubectl {CONTEXT}\n
   status - Print the stack status in the kubectl {CONTEXT}
   """
+  set_output(verbose)
   if action == 'up':
     sys.exit(hokusai.stack_up(context))
   elif action == 'down':
@@ -151,10 +169,12 @@ def stack(action, context):
 @cli.command()
 @click.argument('context', type=click.STRING)
 @click.argument('tag', type=click.STRING)
-def deploy(context, tag):
+@click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
+def deploy(context, tag, verbose):
   """
   Deploy an image tag to the kubectl {CONTEXT} and update the tag {CONTEXT} to reference that image
   """
+  set_output(verbose)
   sys.exit(hokusai.deploy(context, tag))
 
 @cli.command()
@@ -164,10 +184,12 @@ def deploy(context, tag):
 @click.option('--with-config/--without-config', default=True, help="Inject config as environment variables")
 @click.option('--with-secrets/--without-secrets', default=True, help="Inject secrets as environment variables")
 @click.option('--env', type=click.STRING, multiple=True, help='Environment variables in the form of "KEY=VALUE"')
-def console(context, shell, tag, with_config, with_secrets, env):
+@click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
+def console(context, shell, tag, with_config, with_secrets, env, verbose):
   """
   Launch a new container and attach a shell in the kubectl {CONTEXT}
   """
+  set_output(verbose)
   sys.exit(hokusai.console(context, shell, tag, with_config, with_secrets, env))
 
 @cli.command()
@@ -177,10 +199,12 @@ def console(context, shell, tag, with_config, with_secrets, env):
 @click.option('--with-config/--without-config', default=True, help="Inject config as environment variables")
 @click.option('--with-secrets/--without-secrets', default=True, help="Inject secrets as environment variables")
 @click.option('--env', type=click.STRING, multiple=True, help='Environment variables in the form of "KEY=VALUE"')
-def run(context, command, tag, with_config, with_secrets, env):
+@click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
+def run(context, command, tag, with_config, with_secrets, env, verbose):
   """
   Launch a new container and run a command in the kubectl {CONTEXT}
   """
+  set_output(verbose)
   sys.exit(hokusai.run(context, command, tag, with_config, with_secrets, env))
 
 if __name__ == '__main__':

--- a/bin/hokusai
+++ b/bin/hokusai
@@ -96,32 +96,36 @@ def images():
 def config(action, context):
   """
   Actions:\n
-  pull - Pull config from CONTEXT and write to hokusai/{CONTEXT}-config.yml\n
-  push - Push config from hokusai/{CONTEXT}-config.yml to CONTEXT
+  pull - Pull config from the kubectl {CONTEXT} and write to hokusai/{CONTEXT}-config.yml\n
+  push - Push config from hokusai/{CONTEXT}-config.yml to the kubectl {CONTEXT}
   """
   if action == 'pull':
     sys.exit(hokusai.pull_config(context))
   elif action == 'push':
     sys.exit(hokusai.push_config(context))
   else:
-    print_red("Invalid config action %s" % action)
+    print_red("Error: Invalid action %s" % action)
     sys.exit(-1)
 
 @cli.command()
 @click.argument('action', type=click.STRING)
 @click.argument('context', type=click.STRING)
-def secrets(action, context):
+@click.argument('secret', type=click.STRING, nargs=-1)
+def secrets(action, context, secret):
   """
   Actions:\n
-  pull - Pull secrets from CONTEXT and write to hokusai/{CONTEXT}-secrets.yml\n
-  push - Push secrets from hokusai/{CONTEXT}-secrets.yml to CONTEXT
+  get - print secrets in the kubectl {CONTEXT}\n
+  set - set {SECRET} in the kubectl {CONTEXT}\n
+  unset - Unset {SECRET} from the kubectl {CONTEXT}
   """
-  if action == 'pull':
-    sys.exit(hokusai.pull_secrets(context))
-  elif action == 'push':
-    sys.exit(hokusai.push_secrets(context))
+  if action == 'get':
+    sys.exit(hokusai.get_secrets(context))
+  elif action == 'set':
+    sys.exit(hokusai.set_secrets(context, secret))
+  elif action == 'unset':
+    sys.exit(hokusai.unset_secrets(context, secret))
   else:
-    print_red("Invalid secret action %s" % action)
+    print_red("Error: Invalid action %s" % action)
     sys.exit(-1)
 
 @cli.command()
@@ -130,9 +134,9 @@ def secrets(action, context):
 def stack(action, context):
   """
   Actions:\n
-  up - Create / Update the stack in the given context\n
-  down - Delete the stack in the given context\n
-  status - Print the stack status in the given context
+  up - Create / Update the stack in the kubectl {CONTEXT}\n
+  down - Delete the stack in the kubectl {CONTEXT}\n
+  status - Print the stack status in the kubectl {CONTEXT}
   """
   if action == 'up':
     sys.exit(hokusai.stack_up(context))
@@ -141,7 +145,7 @@ def stack(action, context):
   elif action == 'status':
     sys.exit(hokusai.stack_status(context))
   else:
-    print_red("ERROR: invalid stack action %s" % action)
+    print_red("Error: Invalid action %s" % action)
     sys.exit(-1)
 
 @cli.command()
@@ -149,7 +153,7 @@ def stack(action, context):
 @click.argument('tag', type=click.STRING)
 def deploy(context, tag):
   """
-  Deploy an image tag to the given context and update context tag to reference that image
+  Deploy an image tag to the kubectl {CONTEXT} and update the tag {CONTEXT} to reference that image
   """
   sys.exit(hokusai.deploy(context, tag))
 
@@ -162,7 +166,7 @@ def deploy(context, tag):
 @click.option('--env', type=click.STRING, multiple=True, help='Environment variables in the form of "KEY=VALUE"')
 def console(context, shell, tag, with_config, with_secrets, env):
   """
-  Launch a new container and attach a shell in the given context
+  Launch a new container and attach a shell in the kubectl {CONTEXT}
   """
   sys.exit(hokusai.console(context, shell, tag, with_config, with_secrets, env))
 
@@ -175,7 +179,7 @@ def console(context, shell, tag, with_config, with_secrets, env):
 @click.option('--env', type=click.STRING, multiple=True, help='Environment variables in the form of "KEY=VALUE"')
 def run(context, command, tag, with_config, with_secrets, env):
   """
-  Launch a new container and run a command in the given context
+  Launch a new container and run a command in the kubectl {CONTEXT}
   """
   sys.exit(hokusai.run(context, command, tag, with_config, with_secrets, env))
 

--- a/hokusai/commands/__init__.py
+++ b/hokusai/commands/__init__.py
@@ -6,6 +6,7 @@ from hokusai.commands.deploy import deploy
 from hokusai.commands.development import development
 from hokusai.commands.images import images
 from hokusai.commands.init import init
+from hokusai.commands.promote import promote
 from hokusai.commands.pull import pull
 from hokusai.commands.push import push
 from hokusai.commands.run import run

--- a/hokusai/commands/__init__.py
+++ b/hokusai/commands/__init__.py
@@ -9,6 +9,6 @@ from hokusai.commands.init import init
 from hokusai.commands.pull import pull
 from hokusai.commands.push import push
 from hokusai.commands.run import run
-from hokusai.commands.secrets import pull_secrets, push_secrets
+from hokusai.commands.secrets import get_secrets, set_secrets, unset_secrets
 from hokusai.commands.stack import stack_up, stack_down, stack_status
 from hokusai.commands.test import test

--- a/hokusai/commands/build.py
+++ b/hokusai/commands/build.py
@@ -3,13 +3,13 @@ import os
 from subprocess import check_call, CalledProcessError
 
 from hokusai.config import HokusaiConfig
-from hokusai.common import print_red, print_green
+from hokusai.common import print_red, print_green, verbose
 
 def build():
   config = HokusaiConfig().check()
   docker_compose_yml = os.path.join(os.getcwd(), 'hokusai/common.yml')
   try:
-    check_call("docker-compose -f %s -p build build" % docker_compose_yml, shell=True)
+    check_call(verbose("docker-compose -f %s -p build build" % docker_compose_yml), shell=True)
     print_green("Built build_%s:latest" % config.project_name)
   except CalledProcessError:
     print_red('Build failed')

--- a/hokusai/commands/check.py
+++ b/hokusai/commands/check.py
@@ -95,12 +95,6 @@ def check(interactive):
     check_err('~/.kube/config')
     return_code += 1
 
-  if os.path.isfile(os.path.join(os.getcwd(), 'hokusai/.gitignore')):
-    check_ok('hokusai/.gitignore')
-  else:
-    check_err('hokusai/.gitignore')
-    return_code += 1
-
   if os.path.isfile(os.path.join(os.getcwd(), 'hokusai/config.yml')):
     check_ok('hokusai/config.yml')
   else:

--- a/hokusai/commands/config.py
+++ b/hokusai/commands/config.py
@@ -6,46 +6,41 @@ from subprocess import check_output, CalledProcessError, STDOUT
 import yaml
 
 from hokusai.config import HokusaiConfig
-from hokusai.common import print_red, print_green
+from hokusai.common import print_red, print_green, verbose, select_context, HokusaiCommandError
 
 def pull_config(context):
   config = HokusaiConfig().check()
 
   try:
-    switch_context_result = check_output("kubectl config use-context %s"
-                                         % context, stderr=STDOUT, shell=True)
-    print_green("Switched context to %s" % context)
-    if 'no context exists' in switch_context_result:
-      print_red("Context %s does not exist.  Check ~/.kube/config" % context)
-      return -1
-    elif 'switched to context' in switch_context_result:
-      try:
-        existing_configmap = check_output("kubectl get configmap %s-config -o yaml"
-                                        % config.project_name, stderr=STDOUT, shell=True)
-        configmap_data = yaml.load(existing_configmap)['data']
-      except CalledProcessError, e:
-        if 'Error from server: configmaps "%s-config" not found' % config.project_name in e.output:
-          print("ConfigMap %s-config not found. Creating..." % config.project_name)
-          configmap_data = {}
-        else:
-          return -1
-
-      configmap_yaml = OrderedDict([
-        ('apiVersion', 'v1'),
-        ('kind', 'ConfigMap'),
-        ('metadata', {
-          'labels': {'app': config.project_name},
-          'name': "%s-config" % config.project_name
-        }),
-        ('data', configmap_data)
-      ])
-
-      with open(os.path.join(os.getcwd(), 'hokusai', "%s-config.yml" % context), 'w') as f:
-        f.write(yaml.safe_dump(configmap_yaml, default_flow_style=False))
-
-  except CalledProcessError:
-    print_red("Failed to pull configmap hokusai/%s-config.yml" % context)
+    select_context(context)
+  except HokusaiCommandError, e:
+    print_red(repr(e))
     return -1
+
+  try:
+    existing_configmap = check_output(verbose("kubectl get configmap %s-config -o yaml"
+                                                % config.project_name), stderr=STDOUT, shell=True)
+    configmap_data = yaml.load(existing_configmap)['data']
+  except CalledProcessError, e:
+    if 'Error from server: configmaps "%s-config" not found' % config.project_name in e.output:
+      print("ConfigMap %s-config not found. Creating..." % config.project_name)
+      configmap_data = {}
+    else:
+      print_red("Failed to pull configmap hokusai/%s-config.yml" % context)
+      return -1
+
+  configmap_yaml = OrderedDict([
+    ('apiVersion', 'v1'),
+    ('kind', 'ConfigMap'),
+    ('metadata', {
+      'labels': {'app': config.project_name},
+      'name': "%s-config" % config.project_name
+    }),
+    ('data', configmap_data)
+  ])
+
+  with open(os.path.join(os.getcwd(), 'hokusai', "%s-config.yml" % context), 'w') as f:
+    f.write(yaml.safe_dump(configmap_yaml, default_flow_style=False))
 
   print_green("Pulled configmap hokusai/%s-config.yml" % context)
   return 0
@@ -58,15 +53,13 @@ def push_config(context):
     return -1
 
   try:
-    switch_context_result = check_output("kubectl config use-context %s"
-                                         % context, stderr=STDOUT, shell=True)
-    print_green("Switched context to %s" % context)
-    if 'no context exists' in switch_context_result:
-      print_red("Context %s does not exist.  Check ~/.kube/config" % context)
-      return -1
-    elif 'switched to context' in switch_context_result:
-      check_output("kubectl apply -f %s" % os.path.join(os.getcwd(), 'hokusai', "%s-config.yml" % context), stderr=STDOUT, shell=True)
+    select_context(context)
+  except HokusaiCommandError, e:
+    print_red(repr(e))
+    return -1
 
+  try:
+    check_output(verbose("kubectl apply -f %s" % os.path.join(os.getcwd(), 'hokusai', "%s-config.yml" % context)), stderr=STDOUT, shell=True)
   except CalledProcessError:
     print_red("Failed to push configmap hokusai/%s-config.yml" % context)
     return -1

--- a/hokusai/commands/console.py
+++ b/hokusai/commands/console.py
@@ -6,65 +6,67 @@ from subprocess import call, check_output, CalledProcessError, STDOUT
 import yaml
 
 from hokusai.config import HokusaiConfig
-from hokusai.common import print_red, print_green, k8s_uuid
+from hokusai.common import print_red, print_green, k8s_uuid, verbose, select_context, HokusaiCommandError
 
 def console(context, shell, tag, with_config, with_secrets, env):
   config = HokusaiConfig().check()
 
   try:
-    switch_context_result = check_output("kubectl config use-context %s" % context, stderr=STDOUT, shell=True)
-    print_green("Switched context to %s" % context)
-    if 'no context exists' in switch_context_result:
-      print_red("Context %s does not exist.  Check ~/.kube/config" % context)
-      return -1
+    select_context(context)
+  except HokusaiCommandError, e:
+    print_red(repr(e))
+    return -1
 
-    if tag is not None:
-      image_tag = tag
-    else:
-      image_tag = context
+  if tag is not None:
+    image_tag = tag
+  else:
+    image_tag = context
 
-    env = list(env)
+  env = list(env)
 
-    if with_config:
+  if with_config:
+    try:
+      existing_configmap = check_output(verbose("kubectl get configmap %s-config -o yaml"
+                                                  % config.project_name), stderr=STDOUT, shell=True)
+      configmap_data = yaml.load(existing_configmap)['data']
+    except CalledProcessError, e:
+      if 'Error from server: configmaps "%s-config" not found' % config.project_name in e.output:
+        configmap_data = {}
+      else:
+        print_red("Error fetching config: %s" % e.output)
+        return -1
+
+    for k, v in configmap_data.iteritems():
+      env.append("%s=%s" % (k, v))
+
+  if with_secrets:
+    try:
+      existing_secrets = check_output(verbose("kubectl get secret %s-secrets -o yaml"
+                                              % config.project_name), stderr=STDOUT, shell=True)
+      secret_data = yaml.load(existing_secrets)['data']
+    except CalledProcessError, e:
+      if 'Error from server: secrets "%s-secrets" not found' % config.project_name in e.output:
+        secret_data = {}
+      else:
+        print_red("Error fetching secrets: %s" % e.output)
+        return -1
+
+    for k, v in secret_data.iteritems():
       try:
-        existing_configmap = check_output("kubectl get configmap %s-config -o yaml"
-                                            % config.project_name, stderr=STDOUT, shell=True)
-        configmap_data = yaml.load(existing_configmap)['data']
-      except CalledProcessError, e:
-          if 'Error from server: configmaps "%s-config" not found' % config.project_name in e.output:
-            configmap_data = {}
-          else:
-            raise
+        env.append("%s=%s" % (k, base64.b64decode(v)))
+      except TypeError:
+        continue
 
-      for k, v in configmap_data.iteritems():
-        env.append("%s=%s" % (k, v))
+  environment = ' '.join(map(lambda x: '--env="%s"' % x, env))
 
-    if with_secrets:
-      try:
-        existing_secrets = check_output("kubectl get secret %s-secrets -o yaml"
-                                        % config.project_name, stderr=STDOUT, shell=True)
-        secret_data = yaml.load(existing_secrets)['data']
-      except CalledProcessError, e:
-        if 'Error from server: secrets "%s-secrets" not found' % config.project_name in e.output:
-          secret_data = {}
-        else:
-          raise
+  if os.environ.get('USER') is not None:
+    job_id = "%s-%s" % (os.environ.get('USER'), k8s_uuid())
+  else:
+    job_id = k8s_uuid()
 
-      for k, v in secret_data.iteritems():
-        try:
-          env.append("%s=%s" % (k, base64.b64decode(v)))
-        except TypeError:
-          continue
-
-    environment = ' '.join(map(lambda x: '--env="%s"' % x, env))
-
-    if os.environ.get('USER') is not None:
-      job_id = "%s-%s" % (os.environ.get('USER'), k8s_uuid())
-    else:
-      job_id = k8s_uuid()
-
-    call("kubectl run %s-shell-%s -t -i --image=%s:%s --restart=OnFailure --rm %s -- %s" %
-         (config.project_name, job_id, config.aws_ecr_registry, image_tag, environment, shell), shell=True)
-  except CalledProcessError:
-    print_red("Failed to launch console")
+  try:
+    call(verbose("kubectl run %s-shell-%s -t -i --image=%s:%s --restart=OnFailure --rm %s -- %s" %
+             (config.project_name, job_id, config.aws_ecr_registry, image_tag, environment, shell)), shell=True)
+  except CalledProcessError, e:
+    print_red("Launching console failed with error %s" % e.output)
     return -1

--- a/hokusai/commands/deploy.py
+++ b/hokusai/commands/deploy.py
@@ -3,44 +3,43 @@ import datetime
 from subprocess import check_output, check_call, CalledProcessError, STDOUT
 
 from hokusai.config import HokusaiConfig
-from hokusai.common import print_red, print_green
+from hokusai.common import print_red, print_green, verbose, select_context, HokusaiCommandError
 
 def deploy(context, tag):
   config = HokusaiConfig().check()
 
-  switch_context_result = check_output("kubectl config use-context %s" % context, stderr=STDOUT, shell=True)
-  print_green("Switched context to %s" % context)
-  if 'no context exists' in switch_context_result:
-    print_red("Context %s does not exist.  Check ~/.kube/config" % context)
+  try:
+    select_context(context)
+  except HokusaiCommandError, e:
+    print_red(repr(e))
     return -1
 
   if context != tag:
     try:
-      login_command = check_output("aws ecr get-login --region %s" % config.aws_ecr_region, shell=True)
+      login_command = check_output(verbose("aws ecr get-login --region %s" % config.aws_ecr_region), shell=True)
       check_call(login_command, shell=True)
 
-      check_call("docker tag %s:%s %s:%s" %
-                 (config.aws_ecr_registry, tag, config.aws_ecr_registry, context), shell=True)
-      check_call("docker push %s:%s" % (config.aws_ecr_registry, context), shell=True)
+      check_call(verbose("docker tag %s:%s %s:%s" %
+                       (config.aws_ecr_registry, tag, config.aws_ecr_registry, context)), shell=True)
+      check_call(verbose("docker push %s:%s" % (config.aws_ecr_registry, context)), shell=True)
       print_green("Updated tag %s:%s -> %s:%s" %
                   (config.aws_ecr_registry, tag, config.aws_ecr_registry, context))
 
       deployment_tag = "%s--%s" % (context, datetime.datetime.utcnow().strftime("%Y-%m-%d--%H-%M-%S"))
-      check_call("docker tag %s:%s %s:%s"
-                 % (config.aws_ecr_registry, tag, config.aws_ecr_registry, deployment_tag), shell=True)
-      check_call("docker push %s:%s" % (config.aws_ecr_registry, deployment_tag), shell=True)
+      check_call(verbose("docker tag %s:%s %s:%s"
+                       % (config.aws_ecr_registry, tag, config.aws_ecr_registry, deployment_tag)), shell=True)
+      check_call(verbose("docker push %s:%s" % (config.aws_ecr_registry, deployment_tag)), shell=True)
       print_green("Updated tag %s:%s -> %s:%s"
                   % (config.aws_ecr_registry, tag, config.aws_ecr_registry, deployment_tag))
-
-    except CalledProcessError:
-      print_red('Failed to update tags')
+    except CalledProcessError, e:
+      print_red("Updating tags failed with error: %s" % e.output)
       return -1
 
   try:
-    check_call("kubectl set image deployment/%s %s=%s" % (config.project_name, config.project_name, "%s:%s"
-                                                          % (config.aws_ecr_registry, tag)), shell=True)
-  except CalledProcessError:
-    print_red('Deployment failed')
+    check_call(verbose("kubectl set image deployment/%s %s=%s" % (config.project_name, config.project_name, "%s:%s"
+                                                              % (config.aws_ecr_registry, tag))), shell=True)
+  except CalledProcessError, e:
+    print_red("Deployment failed with error: %s" % e.output)
     return -1
 
   print_green("Deployment updated to %s" % tag)

--- a/hokusai/commands/deploy.py
+++ b/hokusai/commands/deploy.py
@@ -39,7 +39,7 @@ def deploy(context, tag):
 
 
   deployments = kubernetes_object('deployment', selector="app=%s" % config.project_name)
-  if len(deployment['items']) != 1:
+  if len(deployments['items']) != 1:
     print_red("Multiple deployments found for %s" % config.project_name)
     return -1
 

--- a/hokusai/commands/development.py
+++ b/hokusai/commands/development.py
@@ -4,7 +4,7 @@ import signal
 from subprocess import call
 
 from hokusai.config import HokusaiConfig
-from hokusai.common import print_red, EXIT_SIGNALS
+from hokusai.common import print_red, EXIT_SIGNALS, verbose
 
 def development():
   HokusaiConfig().check()
@@ -19,4 +19,4 @@ def development():
   for sig in EXIT_SIGNALS:
     signal.signal(sig, cleanup)
 
-  call("docker-compose -f %s up --build" % docker_compose_yml, shell=True)
+  call(verbose("docker-compose -f %s up --build" % docker_compose_yml), shell=True)

--- a/hokusai/commands/init.py
+++ b/hokusai/commands/init.py
@@ -64,9 +64,6 @@ def init(project_name, aws_account_id, aws_ecr_region, framework, base_image,
       'production': [{'name': 'MIX_ENV', 'value': 'prod'}]
     }
 
-  with open(os.path.join(os.getcwd(), 'hokusai', '.gitignore'), 'w') as f:
-    f.write('*-secrets.yml\n')
-
   with open(os.path.join(os.getcwd(), 'Dockerfile'), 'w') as f:
     f.write(dockerfile.render(base_image=base_image, command=run_command, target_port=target_port))
 

--- a/hokusai/commands/promote.py
+++ b/hokusai/commands/promote.py
@@ -1,0 +1,78 @@
+import os
+import datetime
+
+from subprocess import check_output, check_call, CalledProcessError, STDOUT
+
+from hokusai.config import HokusaiConfig
+from hokusai.common import print_red, print_green, verbose, select_context, HokusaiCommandError, kubernetes_object
+
+def promote(context, from_context):
+  config = HokusaiConfig().check()
+
+  try:
+    select_context(from_context)
+  except HokusaiCommandError, e:
+    print_red(repr(e))
+    return -1
+
+  deployments = kubernetes_object('deployment', selector="app=%s" % config.project_name)
+  if len(deployments['items']) != 1:
+    print_red("Multiple deployments found for %s" % config.project_name)
+    return -1
+
+  deployment = deployments['items'][0]
+  containers = deployment['spec']['template']['spec']['containers']
+  container_names = [container['name'] for container in containers]
+  container_images = [container['image'] for container in containers]
+
+  if not all(x == container_images[0] for x in container_images):
+    print_red("Deployment's containers do not reference the same image tag - aborting...")
+    return -1
+
+  base_image = containers[0]['image']
+  if config.aws_ecr_registry not in base_image:
+    print_red("Refusing to deploy unmanaged image %s - aborting..." % base_image)
+    return -1
+
+  tag = base_image.split(':')[1]
+
+  print_green("Deploying %s to %s" % (tag, context))
+
+  try:
+    select_context(context)
+  except HokusaiCommandError, e:
+    print_red(repr(e))
+    return -1
+
+  try:
+    login_command = check_output(verbose("aws ecr get-login --region %s" % config.aws_ecr_region), shell=True)
+    check_call(login_command, shell=True)
+
+    check_call(verbose("docker pull %s:%s" % (config.aws_ecr_registry, tag)), shell=True)
+
+    check_call(verbose("docker tag %s:%s %s:%s" %
+                       (config.aws_ecr_registry, tag, config.aws_ecr_registry, context)), shell=True)
+    check_call(verbose("docker push %s:%s" % (config.aws_ecr_registry, context)), shell=True)
+    print_green("Updated tag %s:%s -> %s:%s" %
+                (config.aws_ecr_registry, tag, config.aws_ecr_registry, context))
+
+    deployment_tag = "%s--%s" % (context, datetime.datetime.utcnow().strftime("%Y-%m-%d--%H-%M-%S"))
+    check_call(verbose("docker tag %s:%s %s:%s"
+                     % (config.aws_ecr_registry, tag, config.aws_ecr_registry, deployment_tag)), shell=True)
+    check_call(verbose("docker push %s:%s" % (config.aws_ecr_registry, deployment_tag)), shell=True)
+    print_green("Updated tag %s:%s -> %s:%s"
+                % (config.aws_ecr_registry, tag, config.aws_ecr_registry, deployment_tag))
+  except CalledProcessError, e:
+    print_red("Updating tags failed with error: %s" % e.output)
+    return -1
+
+  deployment_targets = ["%s=%s" % (name, "%s:%s" % (config.aws_ecr_registry, tag)) for name in container_names]
+
+  try:
+    check_call(verbose("kubectl set image deployment/%s %s" % (config.project_name, ' '.join(deployment_targets))), shell=True)
+  except CalledProcessError, e:
+    print_red("Promotion failed with error: %s" % e.output)
+    return -1
+
+  print_green("Promoted %s to %s from %s" % (context, tag, from_context))
+  return 0

--- a/hokusai/commands/promote.py
+++ b/hokusai/commands/promote.py
@@ -6,7 +6,7 @@ from subprocess import check_output, check_call, CalledProcessError, STDOUT
 from hokusai.config import HokusaiConfig
 from hokusai.common import print_red, print_green, verbose, select_context, HokusaiCommandError, kubernetes_object
 
-def promote(context, from_context):
+def promote(from_context, context):
   config = HokusaiConfig().check()
 
   try:

--- a/hokusai/commands/pull.py
+++ b/hokusai/commands/pull.py
@@ -1,17 +1,16 @@
 from subprocess import check_output, check_call, CalledProcessError
 
 from hokusai.config import HokusaiConfig
-from hokusai.common import print_red, print_green
+from hokusai.common import print_red, print_green, verbose
 
 def pull():
   config = HokusaiConfig().check()
 
   try:
-    login_command = check_output("aws ecr get-login --region %s" % config.aws_ecr_region, shell=True)
-    check_call(login_command, shell=True)
-
-    print("Pulling from %s..." % config.aws_ecr_registry)
-    check_output("docker pull %s --all-tags" % config.aws_ecr_registry, shell=True)
+    login_command = check_output(verbose("aws ecr get-login --region %s" % config.aws_ecr_region), shell=True)
+    check_call(verbose(login_command), shell=True)
+    print_green("Pulling from %s..." % config.aws_ecr_registry)
+    check_output(verbose("docker pull %s --all-tags" % config.aws_ecr_registry), shell=True)
     print_green("Pull succeeded")
   except CalledProcessError:
     print_red('Pull failed')

--- a/hokusai/commands/run.py
+++ b/hokusai/commands/run.py
@@ -6,65 +6,67 @@ from subprocess import call, check_output, CalledProcessError, STDOUT
 import yaml
 
 from hokusai.config import HokusaiConfig
-from hokusai.common import print_red, print_green, k8s_uuid
+from hokusai.common import print_red, print_green, k8s_uuid, verbose, select_context, HokusaiCommandError
 
 def run(context, command, tag, with_config, with_secrets, env):
   config = HokusaiConfig().check()
 
   try:
-    switch_context_result = check_output("kubectl config use-context %s" % context, stderr=STDOUT, shell=True)
-    print_green("Switched context to %s" % context)
-    if 'no context exists' in switch_context_result:
-      print_red("Context %s does not exist.  Check ~/.kube/config" % context)
-      return -1
+    select_context(context)
+  except HokusaiCommandError, e:
+    print_red(repr(e))
+    return -1
 
-    if tag is not None:
-      image_tag = tag
-    else:
-      image_tag = context
+  if tag is not None:
+    image_tag = tag
+  else:
+    image_tag = context
 
-    env = list(env)
+  env = list(env)
 
-    if with_config:
-      try:
-        existing_configmap = check_output("kubectl get configmap %s-config -o yaml"
-                                            % config.project_name, stderr=STDOUT, shell=True)
-        configmap_data = yaml.load(existing_configmap)['data']
-      except CalledProcessError, e:
-          if 'Error from server: configmaps "%s-config" not found' % config.project_name in e.output:
-            configmap_data = {}
-          else:
-            raise
-
-      for k, v in configmap_data.iteritems():
-        env.append("%s=%s" % (k, v))
-
-    if with_secrets:
-      try:
-        existing_secrets = check_output("kubectl get secret %s-secrets -o yaml"
-                                        % config.project_name, stderr=STDOUT, shell=True)
-        secret_data = yaml.load(existing_secrets)['data']
-      except CalledProcessError, e:
-        if 'Error from server: secrets "%s-secrets" not found' % config.project_name in e.output:
-          secret_data = {}
+  if with_config:
+    try:
+      existing_configmap = check_output(verbose("kubectl get configmap %s-config -o yaml"
+                                                % config.project_name), stderr=STDOUT, shell=True)
+      configmap_data = yaml.load(existing_configmap)['data']
+    except CalledProcessError, e:
+        if 'Error from server: configmaps "%s-config" not found' % config.project_name in e.output:
+          configmap_data = {}
         else:
-          raise
+          print_red("Error fetching config: %s" % e.output)
+          return -1
 
-      for k, v in secret_data.iteritems():
-        try:
-          env.append("%s=%s" % (k, base64.b64decode(v)))
-        except TypeError:
-          continue
+    for k, v in configmap_data.iteritems():
+      env.append("%s=%s" % (k, v))
 
-    environment = ' '.join(map(lambda x: '--env="%s"' % x, env))
+  if with_secrets:
+    try:
+      existing_secrets = check_output(verbose("kubectl get secret %s-secrets -o yaml"
+                                            % config.project_name), stderr=STDOUT, shell=True)
+      secret_data = yaml.load(existing_secrets)['data']
+    except CalledProcessError, e:
+      if 'Error from server: secrets "%s-secrets" not found' % config.project_name in e.output:
+        secret_data = {}
+      else:
+        print_red("Error fetching secrets: %s" % e.output)
+        return -1
 
-    if os.environ.get('USER') is not None:
-      job_id = "%s-%s" % (os.environ.get('USER'), k8s_uuid())
-    else:
-      job_id = k8s_uuid()
+    for k, v in secret_data.iteritems():
+      try:
+        env.append("%s=%s" % (k, base64.b64decode(v)))
+      except TypeError:
+        continue
 
-    return call("kubectl run %s-run-%s --attach --image=%s:%s --restart=OnFailure --rm %s -- %s" %
-                (config.project_name, job_id, config.aws_ecr_registry, image_tag, environment, command), shell=True)
-  except CalledProcessError:
-    print_red("Failed to run command")
+  environment = ' '.join(map(lambda x: '--env="%s"' % x, env))
+
+  if os.environ.get('USER') is not None:
+    job_id = "%s-%s" % (os.environ.get('USER'), k8s_uuid())
+  else:
+    job_id = k8s_uuid()
+
+  try:
+    return call(verbose("kubectl run %s-run-%s --attach --image=%s:%s --restart=OnFailure --rm %s -- %s" %
+                    (config.project_name, job_id, config.aws_ecr_registry, image_tag, environment, command)), shell=True)
+  except CalledProcessError, e:
+    print_red("Running command failed with error %s" % e.output)
     return -1

--- a/hokusai/commands/secrets.py
+++ b/hokusai/commands/secrets.py
@@ -8,25 +8,23 @@ from tempfile import NamedTemporaryFile
 import yaml
 
 from hokusai.config import HokusaiConfig
-from hokusai.common import print_red, print_green
+from hokusai.common import print_red, print_green, verbose, select_context, HokusaiCommandError
 
 def get_secrets(context):
   config = HokusaiConfig().check()
 
   try:
-    switch_context_result = check_output("kubectl config use-context %s"
-                                         % context, stderr=STDOUT, shell=True)
-    print_green("Switched context to %s" % context)
-    if 'no context exists' in switch_context_result:
-      print_red("Context %s does not exist.  Check ~/.kube/config" % context)
-      return -1
-    elif 'switched to context' in switch_context_result:
-      existing_secrets = check_output("kubectl get secret %s-secrets -o yaml"
-                                      % config.project_name, stderr=STDOUT, shell=True)
-      secret_data = yaml.load(existing_secrets)['data']
-      for k, v in secret_data.iteritems():
-        print("%s=%s" % (k, base64.b64decode(v)))
+    select_context(context)
+  except HokusaiCommandError, e:
+    print_red(repr(e))
+    return -1
 
+  try:
+    existing_secrets = check_output(verbose("kubectl get secret %s-secrets -o yaml"
+                                        % config.project_name), stderr=STDOUT, shell=True)
+    secret_data = yaml.load(existing_secrets)['data']
+    for k, v in secret_data.iteritems():
+      print("%s=%s" % (k, base64.b64decode(v)))
   except CalledProcessError, e:
     print_red("Error: %s" % e.output)
     return -1
@@ -36,51 +34,50 @@ def set_secrets(context, secrets):
   config = HokusaiConfig().check()
 
   try:
-    switch_context_result = check_output("kubectl config use-context %s"
-                                         % context, stderr=STDOUT, shell=True)
-    print_green("Switched context to %s" % context)
-    if 'no context exists' in switch_context_result:
-      print_red("Context %s does not exist.  Check ~/.kube/config" % context)
+    select_context(context)
+  except HokusaiCommandError, e:
+    print_red(repr(e))
+    return -1
+
+  try:
+    existing_secrets = check_output(verbose("kubectl get secret %s-secrets -o yaml"
+                                        % config.project_name), stderr=STDOUT, shell=True)
+    secret_data = yaml.load(existing_secrets)['data']
+  except CalledProcessError, e:
+    if 'Error from server: secrets "%s-secrets" not found' % config.project_name in e.output:
+      print_green("%s-secrets not found. Creating..." % config.project_name)
+      secret_data = {}
+    else:
+      print_red("Server error: %s" % e.output)
       return -1
-    elif 'switched to context' in switch_context_result:
-      try:
-        existing_secrets = check_output("kubectl get secret %s-secrets -o yaml"
-                                        % config.project_name, stderr=STDOUT, shell=True)
-        secret_data = yaml.load(existing_secrets)['data']
-      except CalledProcessError, e:
-        if 'Error from server: secrets "%s-secrets" not found' % config.project_name in e.output:
-          print("Secret %s-secrets not found. Creating..." % config.project_name)
-          secret_data = {}
-        else:
-          print_red("Server error: %s" % e.output)
-          return -1
 
-      for secret in secrets:
-        if '=' not in secret:
-          print_red("Error: secrets must be of the form 'KEY=VALUE'")
-          return -1
-        split_secret = secret.split('=')
-        secret_data.update({split_secret[0]: base64.b64encode(split_secret[1])})
+  for secret in secrets:
+    if '=' not in secret:
+      print_red("Error: secrets must be of the form 'KEY=VALUE'")
+      return -1
+    split_secret = secret.split('=')
+    secret_data.update({split_secret[0]: base64.b64encode(split_secret[1])})
 
-      secret_yaml = OrderedDict([
-        ('apiVersion', 'v1'),
-        ('kind', 'Secret'),
-        ('metadata', {
-          'labels': {'app': config.project_name},
-          'name': "%s-secrets" % config.project_name
-        }),
-        ('type', 'Opaque'),
-        ('data', secret_data)
-      ])
+  secret_yaml = OrderedDict([
+    ('apiVersion', 'v1'),
+    ('kind', 'Secret'),
+    ('metadata', {
+      'labels': {'app': config.project_name},
+      'name': "%s-secrets" % config.project_name
+    }),
+    ('type', 'Opaque'),
+    ('data', secret_data)
+  ])
 
-      f = NamedTemporaryFile(delete=False)
-      f.write(yaml.safe_dump(secret_yaml, default_flow_style=False))
-      f.close()
-      check_output("kubectl apply -f %s" % f.name, stderr=STDOUT, shell=True)
-      os.unlink(f.name)
-
+  f = NamedTemporaryFile(delete=False)
+  f.write(yaml.safe_dump(secret_yaml, default_flow_style=False))
+  f.close()
+  try:
+    check_output(verbose("kubectl apply -f %s" % f.name), stderr=STDOUT, shell=True)
+    os.unlink(f.name)
   except CalledProcessError, e:
     print_red("Error: %s" % e.output)
+    os.unlink(f.name)
     return -1
   return 0
 
@@ -88,41 +85,50 @@ def unset_secrets(context, secrets):
   config = HokusaiConfig().check()
 
   try:
-    switch_context_result = check_output("kubectl config use-context %s"
-                                         % context, stderr=STDOUT, shell=True)
-    print_green("Switched context to %s" % context)
-    if 'no context exists' in switch_context_result:
-      print_red("Context %s does not exist.  Check ~/.kube/config" % context)
+    select_context(context)
+  except HokusaiCommandError, e:
+    print_red(repr(e))
+    return -1
+
+  try:
+    existing_secrets = check_output(verbose("kubectl get secret %s-secrets -o yaml"
+                                    % config.project_name), stderr=STDOUT, shell=True)
+  except CalledProcessError, e:
+    if 'Error from server: secrets "%s-secrets" not found' % config.project_name in e.output:
+      print_red("%s-secrets not found" % config.project_name)
       return -1
-    elif 'switched to context' in switch_context_result:
-      existing_secrets = check_output("kubectl get secret %s-secrets -o yaml"
-                                      % config.project_name, stderr=STDOUT, shell=True)
-      secret_data = yaml.load(existing_secrets)['data']
+    else:
+      print_red("Server error: %s" % e.output)
+      return -1
 
-      for secret in secrets:
-        try:
-          del secret_data[secret]
-        except KeyError:
-          print("Cannot unset '%s' as it does not exist..." % secret)
+  secret_data = yaml.load(existing_secrets)['data']
 
-      secret_yaml = OrderedDict([
-        ('apiVersion', 'v1'),
-        ('kind', 'Secret'),
-        ('metadata', {
-          'labels': {'app': config.project_name},
-          'name': "%s-secrets" % config.project_name
-        }),
-        ('type', 'Opaque'),
-        ('data', secret_data)
-      ])
+  for secret in secrets:
+    try:
+      del secret_data[secret]
+    except KeyError:
+      print_red("Cannot unset '%s' as it does not exist..." % secret)
 
-      f = NamedTemporaryFile(delete=False)
-      f.write(yaml.safe_dump(secret_yaml, default_flow_style=False))
-      f.close()
-      check_output("kubectl apply -f %s" % f.name, stderr=STDOUT, shell=True)
-      os.unlink(f.name)
+  secret_yaml = OrderedDict([
+    ('apiVersion', 'v1'),
+    ('kind', 'Secret'),
+    ('metadata', {
+      'labels': {'app': config.project_name},
+      'name': "%s-secrets" % config.project_name
+    }),
+    ('type', 'Opaque'),
+    ('data', secret_data)
+  ])
 
+  f = NamedTemporaryFile(delete=False)
+  f.write(yaml.safe_dump(secret_yaml, default_flow_style=False))
+  f.close()
+
+  try:
+    check_output(verbose("kubectl apply -f %s" % f.name), stderr=STDOUT, shell=True)
+    os.unlink(f.name)
   except CalledProcessError, e:
     print_red("Error: %s" % e.output)
+    os.unlink(f.name)
     return -1
   return 0

--- a/hokusai/commands/secrets.py
+++ b/hokusai/commands/secrets.py
@@ -1,14 +1,38 @@
 import os
+import base64
 
 from collections import OrderedDict
 from subprocess import check_output, CalledProcessError, STDOUT
+from tempfile import NamedTemporaryFile
 
 import yaml
 
 from hokusai.config import HokusaiConfig
 from hokusai.common import print_red, print_green
 
-def pull_secrets(context):
+def get_secrets(context):
+  config = HokusaiConfig().check()
+
+  try:
+    switch_context_result = check_output("kubectl config use-context %s"
+                                         % context, stderr=STDOUT, shell=True)
+    print_green("Switched context to %s" % context)
+    if 'no context exists' in switch_context_result:
+      print_red("Context %s does not exist.  Check ~/.kube/config" % context)
+      return -1
+    elif 'switched to context' in switch_context_result:
+      existing_secrets = check_output("kubectl get secret %s-secrets -o yaml"
+                                      % config.project_name, stderr=STDOUT, shell=True)
+      secret_data = yaml.load(existing_secrets)['data']
+      for k, v in secret_data.iteritems():
+        print("%s=%s" % (k, base64.b64decode(v)))
+
+  except CalledProcessError, e:
+    print_red("Error: %s" % e.output)
+    return -1
+  return 0
+
+def set_secrets(context, secrets):
   config = HokusaiConfig().check()
 
   try:
@@ -28,7 +52,15 @@ def pull_secrets(context):
           print("Secret %s-secrets not found. Creating..." % config.project_name)
           secret_data = {}
         else:
+          print_red("Server error: %s" % e.output)
           return -1
+
+      for secret in secrets:
+        if '=' not in secret:
+          print_red("Error: secrets must be of the form 'KEY=VALUE'")
+          return -1
+        split_secret = secret.split('=')
+        secret_data.update({split_secret[0]: base64.b64encode(split_secret[1])})
 
       secret_yaml = OrderedDict([
         ('apiVersion', 'v1'),
@@ -41,22 +73,19 @@ def pull_secrets(context):
         ('data', secret_data)
       ])
 
-      with open(os.path.join(os.getcwd(), 'hokusai', "%s-secrets.yml" % context), 'w') as f:
-        f.write(yaml.safe_dump(secret_yaml, default_flow_style=False))
+      f = NamedTemporaryFile(delete=False)
+      f.write(yaml.safe_dump(secret_yaml, default_flow_style=False))
+      f.close()
+      check_output("kubectl apply -f %s" % f.name, stderr=STDOUT, shell=True)
+      os.unlink(f.name)
 
-  except CalledProcessError:
-    print_red("Failed to pull hokusai/%s-secrets.yml" % context)
+  except CalledProcessError, e:
+    print_red("Error: %s" % e.output)
     return -1
-
-  print_green("Pulled hokusai/%s-secrets.yml" % context)
   return 0
 
-def push_secrets(context):
-  HokusaiConfig().check()
-
-  if not os.path.isfile(os.path.join(os.getcwd(), 'hokusai', "%s-secrets.yml" % context)):
-    print_red("Secrets file hokusai/%s-secrets.yml does not exist" % context)
-    return -1
+def unset_secrets(context, secrets):
+  config = HokusaiConfig().check()
 
   try:
     switch_context_result = check_output("kubectl config use-context %s"
@@ -66,11 +95,34 @@ def push_secrets(context):
       print_red("Context %s does not exist.  Check ~/.kube/config" % context)
       return -1
     elif 'switched to context' in switch_context_result:
-      check_output("kubectl apply -f %s" % os.path.join(os.getcwd(), 'hokusai', "%s-secrets.yml" % context), stderr=STDOUT, shell=True)
+      existing_secrets = check_output("kubectl get secret %s-secrets -o yaml"
+                                      % config.project_name, stderr=STDOUT, shell=True)
+      secret_data = yaml.load(existing_secrets)['data']
 
-  except CalledProcessError:
-    print_red("Failed to push hokusai/%s-secrets.yml" % context)
+      for secret in secrets:
+        try:
+          del secret_data[secret]
+        except KeyError:
+          print("Cannot unset '%s' as it does not exist..." % secret)
+
+      secret_yaml = OrderedDict([
+        ('apiVersion', 'v1'),
+        ('kind', 'Secret'),
+        ('metadata', {
+          'labels': {'app': config.project_name},
+          'name': "%s-secrets" % config.project_name
+        }),
+        ('type', 'Opaque'),
+        ('data', secret_data)
+      ])
+
+      f = NamedTemporaryFile(delete=False)
+      f.write(yaml.safe_dump(secret_yaml, default_flow_style=False))
+      f.close()
+      check_output("kubectl apply -f %s" % f.name, stderr=STDOUT, shell=True)
+      os.unlink(f.name)
+
+  except CalledProcessError, e:
+    print_red("Error: %s" % e.output)
     return -1
-
-  print_green("Pushed hokusai/%s-secrets.yml" % context)
   return 0

--- a/hokusai/commands/stack.py
+++ b/hokusai/commands/stack.py
@@ -3,7 +3,7 @@ import os
 from subprocess import check_output, check_call, CalledProcessError, STDOUT
 
 from hokusai.config import HokusaiConfig
-from hokusai.common import print_red, print_green
+from hokusai.common import print_red, print_green, verbose, select_context, HokusaiCommandError
 
 def stack_up(context):
   HokusaiConfig().check()
@@ -13,15 +13,15 @@ def stack_up(context):
     return -1
 
   try:
-    switch_context_result = check_output("kubectl config use-context %s" % context, stderr=STDOUT, shell=True)
-    print_green("Switched context to %s" % context)
-    if 'no context exists' in switch_context_result:
-      print_red("Context %s does not exist.  Check ~/.kube/config" % context)
-      return -1
-    elif 'switched to context' in switch_context_result:
-      check_call("kubectl apply -f %s" % kubernetes_yml, shell=True)
-  except CalledProcessError:
-    print_red('Stack up failed')
+    select_context(context)
+  except HokusaiCommandError, e:
+    print_red(repr(e))
+    return -1
+
+  try:
+    check_call(verbose("kubectl apply -f %s" % kubernetes_yml), shell=True)
+  except CalledProcessError, e:
+    print_red("Stack up failed with error: %s" % e.output)
     return -1
 
   print_green("Stack %s created" % kubernetes_yml)
@@ -29,21 +29,22 @@ def stack_up(context):
 
 def stack_down(context):
   HokusaiConfig().check()
+
   kubernetes_yml = os.path.join(os.getcwd(), "hokusai/%s.yml" % context)
   if not os.path.isfile(kubernetes_yml):
     print_red("Yaml file %s does not exist for given context." % kubernetes_yml)
     return -1
 
   try:
-    switch_context_result = check_output("kubectl config use-context %s" % context, stderr=STDOUT, shell=True)
-    print_green("Switched context to %s" % context)
-    if 'no context exists' in switch_context_result:
-      print_red("Context %s does not exist.  Check ~/.kube/config" % context)
-      return -1
-    elif 'switched to context' in switch_context_result:
-      check_call("kubectl delete -f %s" % kubernetes_yml, shell=True)
-  except CalledProcessError:
-    print_red('Stack down failed')
+    select_context(context)
+  except HokusaiCommandError, e:
+    print_red(repr(e))
+    return -1
+
+  try:
+    check_call(verbose("kubectl delete -f %s" % kubernetes_yml), shell=True)
+  except CalledProcessError, e:
+    print_red("Stack down failed with error: %s" % e.output)
     return -1
 
   print_green("Stack %s deleted" % kubernetes_yml)
@@ -51,21 +52,21 @@ def stack_down(context):
 
 def stack_status(context):
   HokusaiConfig().check()
+
   kubernetes_yml = os.path.join(os.getcwd(), "hokusai/%s.yml" % context)
   if not os.path.isfile(kubernetes_yml):
     print_red("Yaml file %s does not exist for given context." % kubernetes_yml)
     return -1
 
   try:
-    switch_context_result = check_output("kubectl config use-context %s" % context, stderr=STDOUT, shell=True)
-    print_green("Switched context to %s" % context)
-    if 'no context exists' in switch_context_result:
-      print_red("Context %s does not exist.  Check ~/.kube/config" % context)
-      return -1
-    elif 'switched to context' in switch_context_result:
-      check_call("kubectl describe -f %s" % kubernetes_yml, shell=True)
-  except CalledProcessError:
-    print_red('Stack status failed')
+    select_context(context)
+  except HokusaiCommandError, e:
+    print_red(repr(e))
+    return -1
+
+  try:
+    check_call(verbose("kubectl describe -f %s" % kubernetes_yml), shell=True)
+  except CalledProcessError, e:
+    print_red("Stack status failed with error: %s" % e.output)
     return -1
   return 0
-

--- a/hokusai/commands/test.py
+++ b/hokusai/commands/test.py
@@ -4,7 +4,7 @@ import signal
 from subprocess import call, check_output, CalledProcessError
 
 from hokusai.config import HokusaiConfig
-from hokusai.common import print_red, print_green, EXIT_SIGNALS
+from hokusai.common import print_red, print_green, EXIT_SIGNALS, verbose
 
 def test():
   config = HokusaiConfig().check()
@@ -16,7 +16,7 @@ def test():
   # stop any running containers
   def cleanup(*args):
     print_red('Tests Failed For Unexpected Reasons\n')
-    call("docker-compose -f %s -p ci stop" % docker_compose_yml, shell=True)
+    call(verbose("docker-compose -f %s -p ci stop" % docker_compose_yml), shell=True)
     return -1
 
   # catch exit, do cleanup
@@ -24,20 +24,20 @@ def test():
     signal.signal(sig, cleanup)
 
   # build and run the composed services
-  if call("docker-compose -f %s -p ci up --build -d" % docker_compose_yml, shell=True) != 0:
+  if call(verbose("docker-compose -f %s -p ci up --build -d" % docker_compose_yml), shell=True) != 0:
     print_red("Docker Compose Failed\n")
     return -1
 
   # wait for the test service to complete and grab the exit code
   try:
-    test_exit_code = int(check_output("docker wait ci_%s_1" % config.project_name, shell=True))
+    test_exit_code = int(check_output(verbose("docker wait ci_%s_1" % config.project_name), shell=True))
   except CalledProcessError:
     print_red('Docker wait failed.')
-    call("docker-compose -f %s -p ci stop" % docker_compose_yml, shell=True)
+    call(verbose("docker-compose -f %s -p ci stop" % docker_compose_yml), shell=True)
     return -1
 
   # output the logs for the test (for clarity)
-  call("docker logs ci_%s_1" % config.project_name, shell=True)
+  call(verbose("docker logs ci_%s_1" % config.project_name), shell=True)
 
   # inspect the output of the test and display respective message
   if test_exit_code != 0:
@@ -46,6 +46,6 @@ def test():
     print_green("Tests Passed")
 
   # cleanup
-  call("docker-compose -f %s -p ci stop" % docker_compose_yml, shell=True)
+  call(verbose("docker-compose -f %s -p ci stop" % docker_compose_yml), shell=True)
 
   return test_exit_code

--- a/hokusai/common.py
+++ b/hokusai/common.py
@@ -5,23 +5,47 @@ import random
 
 from collections import OrderedDict
 
+from subprocess import check_output, CalledProcessError, STDOUT
+
 import yaml
+
+from termcolor import cprint
 
 HOKUSAI_CONFIG_FILE = os.path.join(os.getcwd(), 'hokusai', 'config.yml')
 
 EXIT_SIGNALS = [signal.SIGHUP, signal.SIGINT, signal.SIGQUIT, signal.SIGPIPE, signal.SIGTERM]
 
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-NC='\033[0m'
-
 YAML_HEADER = '---\n'
 
+VERBOSE = False
+
+class HokusaiCommandError(Exception):
+  pass
+
 def print_green(msg):
-  print(GREEN + msg + NC)
+  cprint(msg, 'green')
 
 def print_red(msg):
-  print(RED + msg + NC)
+  cprint(msg, 'red')
+
+def set_output(v):
+  if v:
+    global VERBOSE
+    VERBOSE = True
+
+def verbose(msg):
+  if VERBOSE: cprint("==> hokusai exec `%s`" % msg, 'yellow')
+  return msg
+
+def select_context(context):
+  try:
+    context_result = check_output(verbose("kubectl config use-context %s" % context), stderr=STDOUT, shell=True)
+  except CalledProcessError, e:
+    raise HokusaiCommandError("Error selecting context %s: %s" % (context, e.output))
+  if 'no context exists' in context_result:
+    raise HokusaiCommandError("Context %s does not exist.  Check ~/.kube/config" % context)
+  if 'switched to context' not in context_result:
+    raise HokusaiCommandError("Could not select context %s" % context)
 
 def k8s_uuid():
   uuid = []

--- a/hokusai/common.py
+++ b/hokusai/common.py
@@ -2,6 +2,7 @@ import os
 import signal
 import string
 import random
+import json
 
 from collections import OrderedDict
 
@@ -46,6 +47,21 @@ def select_context(context):
     raise HokusaiCommandError("Context %s does not exist.  Check ~/.kube/config" % context)
   if 'switched to context' not in context_result:
     raise HokusaiCommandError("Could not select context %s" % context)
+
+def kubernetes_object(obj, selector=None):
+  if selector is not None:
+    cmd = "kubectl get %s --selector %s -o json" % (obj, selector)
+  else:
+    cmd = "kubectl get %s -o json" % obj
+
+  try:
+    payload = check_output(verbose(cmd), stderr=STDOUT, shell=True)
+  except CalledProcessError:
+    raise HokusaiCommandError("Could not get object %s" % obj)
+  try:
+    return json.loads(payload)
+  except ValueError:
+    raise HokusaiCommandError("Could not parse object %s" % obj)
 
 def k8s_uuid():
   uuid = []

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,8 @@ setup(name='hokusai',
           'click==6.6',
           'MarkupSafe==0.23',
           'Jinja2==2.8',
-          'PyYAML==3.12'
+          'PyYAML==3.12',
+          'termcolor==1.1.0'
       ],
       zip_safe=False,
       include_package_data = True,


### PR DESCRIPTION
- Most hokusai commands now accept a `-v` / `--verbose` flag
- Adds `hokusai promote` to copy the deployment from one context to another. Use: `hokusai promote production staging` promotes production from staging
- Updates to `deploy` command to handle multiple containers in a deployment (currently affects Currents)

Coming soon! Support for multiple deployments in a given app so as to scale web / async workers independently by using Label Selectors https://kubernetes.io/docs/user-guide/labels/

cc @bhoggard @cavvia 