### PR TITLE
Fix deployments and shell

### DIFF
--- a/hokusai/commands/console.py
+++ b/hokusai/commands/console.py
@@ -65,7 +65,7 @@ def console(context, shell, tag, with_config, with_secrets, env):
     job_id = k8s_uuid()
 
   try:
-    call(verbose("kubectl run %s-shell-%s -t -i --image=%s:%s --restart=OnFailure --rm %s -- %s" %
+    call(verbose("kubectl run %s-shell-%s -t -i --image=%s:%s --image-pull-policy=Always --restart=OnFailure --rm %s -- %s" %
              (config.project_name, job_id, config.aws_ecr_registry, image_tag, environment, shell)), shell=True)
   except CalledProcessError, e:
     print_red("Launching console failed with error %s" % e.output)

--- a/hokusai/commands/run.py
+++ b/hokusai/commands/run.py
@@ -65,7 +65,7 @@ def run(context, command, tag, with_config, with_secrets, env):
     job_id = k8s_uuid()
 
   try:
-    return call(verbose("kubectl run %s-run-%s --attach --image=%s:%s --restart=OnFailure --rm %s -- %s" %
+    return call(verbose("kubectl run %s-run-%s --attach --image=%s:%s --image-pull-policy=Always --restart=OnFailure --rm %s -- %s" %
                     (config.project_name, job_id, config.aws_ecr_registry, image_tag, environment, command)), shell=True)
   except CalledProcessError, e:
     print_red("Running command failed with error %s" % e.output)


### PR DESCRIPTION
- Uses a `kubectl patch` for deployments: `hokusai deploy` / `hokusai promote` adding the "deploymentTimestamp" label to the deployment metadata, which always triggers a rollout, even if the pod image is the same

- Adds "ImagePullPolicy": "Always" to `hokusai console` and `hokusai run` commands, ensuring newest image is always run for the given tag

Update your hokusai installation with: `git pull upstream master` / `pip install --upgrade .`

cc @joeyAghion @ashkan18 @cavvia 