### PR TITLE
Use pod spec in run and console commands

### DIFF
--- a/hokusai/commands/console.py
+++ b/hokusai/commands/console.py
@@ -67,29 +67,25 @@ def console(context, shell, tag, with_config, with_secrets, env):
   image_name = "%s:%s" % (config.aws_ecr_registry, image_tag)
 
   overrides = {
-    "apiVersion": "batch/v1",
-    "spec": {
-      "template": {
-        "spec": {
-          "containers": [
-            {
-              "args": [ shell ],
-              "name": job_name,
-              "image": image_name,
-              "imagePullPolicy": "Always",
-              "env": environment,
-              "stdin": True,
-              "stdinOnce": True,
-              "tty": True
-            }
-          ]
-        }
+    "apiVersion": "v1",
+      "spec": {
+        "containers": [
+          {
+            "args": [ shell ],
+            "name": job_name,
+            "image": image_name,
+            "imagePullPolicy": "Always",
+            "env": environment,
+            "stdin": True,
+            "stdinOnce": True,
+            "tty": True
+          }
+        ]
       }
     }
-  }
 
   try:
-    call(verbose("kubectl run %s -t -i --image=%s --restart=OnFailure --overrides='%s' --rm" %
+    call(verbose("kubectl run %s -t -i --image=%s --restart=Never --overrides='%s' --rm" %
              (job_name, image_name, json.dumps(overrides))), shell=True)
   except CalledProcessError, e:
     print_red("Launching console failed with error %s" % e.output)

--- a/hokusai/commands/run.py
+++ b/hokusai/commands/run.py
@@ -67,26 +67,22 @@ def run(context, command, tag, with_config, with_secrets, env):
   image_name = "%s:%s" % (config.aws_ecr_registry, image_tag)
 
   overrides = {
-    "apiVersion": "batch/v1",
+    "apiVersion": "v1",
     "spec": {
-      "template": {
-        "spec": {
-          "containers": [
-            {
-              "args": command.split(' '),
-              "name": job_name,
-              "image": image_name,
-              "imagePullPolicy": "Always",
-              "env": environment
-            }
-          ]
+      "containers": [
+        {
+          "args": command.split(' '),
+          "name": job_name,
+          "image": image_name,
+          "imagePullPolicy": "Always",
+          "env": environment
         }
-      }
+      ]
     }
   }
 
   try:
-    return call(verbose("kubectl run %s --attach --image=%s --overrides='%s' --restart=OnFailure --rm" %
+    return call(verbose("kubectl run %s --attach --image=%s --overrides='%s' --restart=Never --rm" %
                     (job_name, image_name, json.dumps(overrides))), shell=True)
   except CalledProcessError, e:
     print_red("Running command failed with error %s" % e.output)


### PR DESCRIPTION
Run and console commands should use the pod spec, as the job spec doesn't properly return the exit code of the command in newer kubectl versions, and the console command sometimes leaves behind lingering jobs

cc @joeyAghion @cavvia 