### PR TITLE
Updates to deploy, stack defaults and dev commands, add history command

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,16 @@ Required options:
 
 ### Development
 
-* `hokusai dev` - Boot a development stack as defined in `hokusai/development.yml`.
-* `hokusai test` - Boot a testing stack as defined in `hokusai/test.yml` and exits with the return code of the test command.
+* `hokusai dev start` - Start the development stack defined in `hokusai/development.yml`.
+* `hokusai dev stop` - Stop the development stack defined in ./hokusai/development.yml.
+* `hokusai dev status` - Print the status of the development stack.
+* `hokusai dev logs` - Print logs from the development stack.
+* `hokusai dev shell` - Attach a shell session to the stack's primary project container.
+* `hokusai dev clean` - Stop and remove all containers in the stack.
+
+### Testing
+
+* `hokusai test` - Start the testing stack defined `hokusai/test.yml` and exit with the return code of the test command.
 
 
 ### Working with Images

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Note: Environment variables will be automatically injected into containers creat
 * `hokusai deploy` - Update the Kubernetes deployment to a given image tag.
 * `hokusai promote` - Update the Kubernetes deployment on production to match the deployment on staging.
 * `hokusai refresh` - Refresh the project's deployment(s)
+* `hokusai history` - Print the project's deployment(s) history
 
 ### Running a command
 

--- a/bin/hokusai
+++ b/bin/hokusai
@@ -72,14 +72,42 @@ def check():
   hokusai.check()
 
 @cli.command(context_settings=CONTEXT_SETTINGS)
-@click.option('--skip-build', type=click.BOOL, is_flag=True, help='Do not build the project while launching the stack')
+@click.argument('action', type=click.STRING)
+@click.option('-s', '--skip-build', type=click.BOOL, is_flag=True, help='Do not build the project while launching the stack')
+@click.option('-f', '--follow', type=click.BOOL, is_flag=True, help="Follow stack output when running 'start' or 'logs'")
 @click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
-def dev(skip_build, verbose):
-  """
-  Boot the development stack
-  """
+def dev(action, skip_build, follow, verbose):
+  """Manage the development stack
+
+  Actions: [start|stop||status|logs|shell|clean]
+
+  start - Start the development stack defined in ./hokusai/development.yml
+
+  stop - Stop the development stack defined in ./hokusai/development.yml
+
+  status - Print the status of the development stack
+
+  logs - Print logs from the development stack
+
+  shell - Attach a shell session to the stack's primary project container
+
+  clean - Stop and remove all containers in the stack"""
   hokusai.lib.common.set_output(verbose)
-  hokusai.development(skip_build)
+  if action == 'start':
+    hokusai.dev_start(skip_build, follow)
+  elif action == 'stop':
+    hokusai.dev_stop()
+  elif action == 'status':
+    hokusai.dev_status()
+  elif action == 'logs':
+    hokusai.dev_logs(follow)
+  elif action == 'shell':
+    hokusai.dev_shell()
+  elif action == 'clean':
+    hokusai.dev_clean()
+  else:
+    hokusai.lib.common.print_red("Invalid action %s" % action)
+    sys.exit(-1)
 
 @cli.command(context_settings=CONTEXT_SETTINGS)
 @click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')

--- a/bin/hokusai
+++ b/bin/hokusai
@@ -204,15 +204,14 @@ def stack(action, staging, production, verbose):
 @click.argument('tag', type=click.STRING)
 @click.option('--staging', type=click.BOOL, is_flag=True, help='Target staging')
 @click.option('--production', type=click.BOOL, is_flag=True, help='Target production')
-@click.option('--skip-tags', type=click.BOOL, is_flag=True, help='Skip creating deploy tags')
 @click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
-def deploy(tag, staging, production, skip_tags, verbose):
+def deploy(tag, staging, production, verbose):
   """
   Update the project's deployment(s) to reference a named image tag and update the tag (staging/production) to reference the same image
   """
   hokusai.lib.common.set_output(verbose)
   context = select_context(staging, production)
-  hokusai.deploy(context, tag, skip_tags)
+  hokusai.deploy(context, tag)
 
 @cli.command(context_settings=CONTEXT_SETTINGS)
 @click.option('--staging', type=click.BOOL, is_flag=True, help='Target staging')

--- a/bin/hokusai
+++ b/bin/hokusai
@@ -226,6 +226,18 @@ def refresh(staging, production, verbose):
   hokusai.refresh(context)
 
 @cli.command(context_settings=CONTEXT_SETTINGS)
+@click.option('--staging', type=click.BOOL, is_flag=True, help='Target staging')
+@click.option('--production', type=click.BOOL, is_flag=True, help='Target production')
+@click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
+def history(staging, production, verbose):
+  """
+  Print the project's deployment(s) history
+  """
+  hokusai.lib.common.set_output(verbose)
+  context = select_context(staging, production)
+  hokusai.history(context)
+
+@cli.command(context_settings=CONTEXT_SETTINGS)
 @click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
 def promote(verbose):
   """

--- a/bin/hokusai
+++ b/bin/hokusai
@@ -176,14 +176,15 @@ def stack(action, staging, production, verbose):
 @click.argument('tag', type=click.STRING)
 @click.option('--staging', type=click.BOOL, is_flag=True, help='Target staging')
 @click.option('--production', type=click.BOOL, is_flag=True, help='Target production')
+@click.option('--skip-tags', type=click.BOOL, is_flag=True, help='Skip creating deploy tags')
 @click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
-def deploy(tag, staging, production, verbose):
+def deploy(tag, staging, production, skip_tags, verbose):
   """
   Update the project's deployment(s) to reference a named image tag and update the tag (staging/production) to reference the same image
   """
   hokusai.lib.common.set_output(verbose)
   context = select_context(staging, production)
-  hokusai.deploy(context, tag)
+  hokusai.deploy(context, tag, skip_tags)
 
 @cli.command(context_settings=CONTEXT_SETTINGS)
 @click.option('--staging', type=click.BOOL, is_flag=True, help='Target staging')

--- a/hokusai/commands/__init__.py
+++ b/hokusai/commands/__init__.py
@@ -1,7 +1,7 @@
 from hokusai.commands.check import check
 from hokusai.commands.configure import configure
 from hokusai.commands.deploy import deploy
-from hokusai.commands.development import development
+from hokusai.commands.development import dev_start, dev_stop, dev_status, dev_logs, dev_shell, dev_clean
 from hokusai.commands.env import create_env, delete_env, get_env, set_env, unset_env
 from hokusai.commands.images import images
 from hokusai.commands.logs import logs

--- a/hokusai/commands/__init__.py
+++ b/hokusai/commands/__init__.py
@@ -3,6 +3,7 @@ from hokusai.commands.configure import configure
 from hokusai.commands.deploy import deploy
 from hokusai.commands.development import dev_start, dev_stop, dev_status, dev_logs, dev_shell, dev_clean
 from hokusai.commands.env import create_env, delete_env, get_env, set_env, unset_env
+from hokusai.commands.history import history
 from hokusai.commands.images import images
 from hokusai.commands.logs import logs
 from hokusai.commands.promote import promote

--- a/hokusai/commands/deploy.py
+++ b/hokusai/commands/deploy.py
@@ -3,7 +3,7 @@ from hokusai.lib.common import print_green
 from hokusai.services.deployment import Deployment
 
 @command
-def deploy(context, tag, skip_tags):
+def deploy(context, tag):
   deployment = Deployment(context)
-  deployment.update(tag, skip_tags)
+  deployment.update(tag)
   print_green("Deployment updated to %s" % tag)

--- a/hokusai/commands/deploy.py
+++ b/hokusai/commands/deploy.py
@@ -3,7 +3,7 @@ from hokusai.lib.common import print_green
 from hokusai.services.deployment import Deployment
 
 @command
-def deploy(context, tag):
+def deploy(context, tag, skip_tags):
   deployment = Deployment(context)
-  deployment.update(tag)
+  deployment.update(tag, skip_tags)
   print_green("Deployment updated to %s" % tag)

--- a/hokusai/commands/development.py
+++ b/hokusai/commands/development.py
@@ -1,23 +1,68 @@
 import os
-import signal
 
 from hokusai.lib.command import command
 from hokusai.lib.config import config
-from hokusai.lib.common import print_red, EXIT_SIGNALS, shout
+from hokusai.lib.common import print_red, shout
 
 @command
-def development(skip_build):
+def dev_start(skip_build, follow):
   docker_compose_yml = os.path.join(os.getcwd(), 'hokusai/development.yml')
   if not os.path.isfile(docker_compose_yml):
     print_red("Yaml file %s does not exist." % docker_compose_yml)
     return -1
 
-  def cleanup(*args):
-    pass
-  for sig in EXIT_SIGNALS:
-    signal.signal(sig, cleanup)
-
   opts = ''
   if not skip_build:
     opts += ' --build'
-  shout("docker-compose -f %s up%s" % (docker_compose_yml, opts), print_output=True)
+
+  if follow:
+    shout("docker-compose -f %s up%s" % (docker_compose_yml, opts), print_output=True)
+  else:
+    shout("docker-compose -f %s create%s" % (docker_compose_yml, opts), print_output=True)
+    shout("docker-compose -f %s start" % docker_compose_yml, print_output=True)
+
+@command
+def dev_stop():
+  docker_compose_yml = os.path.join(os.getcwd(), 'hokusai/development.yml')
+  if not os.path.isfile(docker_compose_yml):
+    print_red("Yaml file %s does not exist." % docker_compose_yml)
+    return -1
+
+  shout("docker-compose -f %s stop" % docker_compose_yml, print_output=True)
+
+@command
+def dev_status():
+  docker_compose_yml = os.path.join(os.getcwd(), 'hokusai/development.yml')
+  if not os.path.isfile(docker_compose_yml):
+    print_red("Yaml file %s does not exist." % docker_compose_yml)
+    return -1
+  shout("docker-compose -f %s ps" % docker_compose_yml, print_output=True)
+
+@command
+def dev_logs(follow):
+  docker_compose_yml = os.path.join(os.getcwd(), 'hokusai/development.yml')
+  if not os.path.isfile(docker_compose_yml):
+    print_red("Yaml file %s does not exist." % docker_compose_yml)
+    return -1
+
+  opts = ''
+  if follow:
+    opts += ' --follow'
+  shout("docker-compose -f %s logs%s" % (docker_compose_yml, opts), print_output=True)
+
+@command
+def dev_shell():
+  docker_compose_yml = os.path.join(os.getcwd(), 'hokusai/development.yml')
+  if not os.path.isfile(docker_compose_yml):
+    print_red("Yaml file %s does not exist." % docker_compose_yml)
+    return -1
+  shout("docker-compose -f %s exec %s sh" % (docker_compose_yml, config.project_name), print_output=True)
+
+@command
+def dev_clean():
+  docker_compose_yml = os.path.join(os.getcwd(), 'hokusai/development.yml')
+  if not os.path.isfile(docker_compose_yml):
+    print_red("Yaml file %s does not exist." % docker_compose_yml)
+    return -1
+  shout("docker-compose -f %s stop" % docker_compose_yml, print_output=True)
+  shout("docker-compose -f %s rm --force" % docker_compose_yml, print_output=True)

--- a/hokusai/commands/history.py
+++ b/hokusai/commands/history.py
@@ -1,0 +1,15 @@
+from hokusai.lib.command import command
+from hokusai.lib.common import print_green
+from hokusai.services.deployment import Deployment
+
+@command
+def history(context):
+  deployment = Deployment(context)
+  for name in deployment.names:
+    print_green(name)
+    print("REVISION    CREATION TIMESTAMP            CONTAINER NAME - IMAGE TAG")
+    for replicaset in deployment.history(name):
+      revision = replicaset['metadata']['annotations']['deployment.kubernetes.io/revision']
+      created_at = replicaset['metadata']['creationTimestamp']
+      containers = ["%s - %s" % (container['name'], container['image'].rsplit(':', 1)[1]) for container in replicaset['spec']['template']['spec']['containers']]
+      print("%s           %s          %s" % (revision, created_at, ','.join(containers)))

--- a/hokusai/commands/setup.py
+++ b/hokusai/commands/setup.py
@@ -119,6 +119,7 @@ def setup(aws_account_id, project_type, project_name, aws_ecr_region, port,
       if compose_environment == 'development':
         services[config.project_name]['command'] = development_command
         services[config.project_name]['ports'] = ["%s:%s" % (port, port)]
+        services[config.project_name]['volumes'] = ['../:/app']
       if compose_environment == 'test':
         services[config.project_name]['command'] = test_command
 

--- a/hokusai/lib/common.py
+++ b/hokusai/lib/common.py
@@ -69,6 +69,13 @@ def build_deployment(name, image, target_port, layer='application', component='w
     ('metadata', {'name': "%s-%s" % (name, component)}),
     ('spec', {
       'replicas': 1,
+      'strategy': {
+        'rollingUpdate': {
+          'maxSurge': 1,
+          'maxUnavailable': 0
+        },
+        'type': 'RollingUpdate'
+      },
       'template': {
         'metadata': {
           'labels': {

--- a/hokusai/services/deployment.py
+++ b/hokusai/services/deployment.py
@@ -60,6 +60,15 @@ class Deployment(object):
       print_green("Refreshing %s..." % deployment['metadata']['name'])
       shout(self.kctl.command("patch deployment %s -p '%s'" % (deployment['metadata']['name'], json.dumps(patch))))
 
+  def history(self, deployment_name):
+    replicasets = self.kctl.get_object('replicaset', selector="app=%s,layer=application" % config.project_name)
+    replicasets = filter(lambda rs: rs['metadata']['ownerReferences'][0]['name'] == deployment_name, replicasets)
+    return sorted(replicasets, key=lambda rs: int(rs['metadata']['annotations']['deployment.kubernetes.io/revision']))
+
+  @property
+  def names(self):
+    return [deployment['metadata']['name'] for deployment in self.cache]
+
   @property
   def current_tag(self):
     images = []

--- a/hokusai/services/deployment.py
+++ b/hokusai/services/deployment.py
@@ -12,15 +12,14 @@ class Deployment(object):
     self.kctl = Kubectl(self.context)
     self.cache = self.kctl.get_object('deployment', selector="app=%s,layer=application" % config.project_name)
 
-  def update(self, tag, skip_tags):
+  def update(self, tag):
     print_green("Deploying %s to %s..." % (tag, self.context))
 
-    if skip_tags is None:
+    if self.context != tag:
       ecr = ECR()
 
-      if self.context != tag:
-        ecr.retag(tag, self.context)
-        print_green("Updated tag %s -> %s" % (tag, self.context))
+      ecr.retag(tag, self.context)
+      print_green("Updated tag %s -> %s" % (tag, self.context))
 
       deployment_tag = "%s--%s" % (self.context, datetime.datetime.utcnow().strftime("%Y-%m-%d--%H-%M-%S"))
       ecr.retag(tag, deployment_tag)

--- a/hokusai/services/deployment.py
+++ b/hokusai/services/deployment.py
@@ -12,14 +12,15 @@ class Deployment(object):
     self.kctl = Kubectl(self.context)
     self.cache = self.kctl.get_object('deployment', selector="app=%s,layer=application" % config.project_name)
 
-  def update(self, tag):
+  def update(self, tag, skip_tags):
     print_green("Deploying %s to %s..." % (tag, self.context))
 
-    if self.context != tag:
+    if skip_tags is None:
       ecr = ECR()
 
-      ecr.retag(tag, self.context)
-      print_green("Updated tag %s -> %s" % (tag, self.context))
+      if self.context != tag:
+        ecr.retag(tag, self.context)
+        print_green("Updated tag %s -> %s" % (tag, self.context))
 
       deployment_tag = "%s--%s" % (self.context, datetime.datetime.utcnow().strftime("%Y-%m-%d--%H-%M-%S"))
       ecr.retag(tag, deployment_tag)

--- a/hokusai/services/ecr.py
+++ b/hokusai/services/ecr.py
@@ -1,7 +1,7 @@
 import base64
 
 import boto3
-from botocore.exceptions import BotoCoreError
+from botocore.exceptions import BotoCoreError, ClientError
 
 from hokusai.lib.config import config
 
@@ -79,9 +79,13 @@ class ECR(object):
 
     image = res['images'][0]
 
-    self.client.put_image(
-        registryId=config.aws_account_id,
-        repositoryName=config.project_name,
-        imageManifest=image['imageManifest'],
-        imageTag=new_tag
-    )
+    try:
+      self.client.put_image(
+          registryId=config.aws_account_id,
+          repositoryName=config.project_name,
+          imageManifest=image['imageManifest'],
+          imageTag=new_tag
+      )
+    except ClientError as e:
+      if e.response['Error']['Code'] != 'ImageAlreadyExistsException':
+        raise


### PR DESCRIPTION
- Fix bug in retagging images so when redeploying so deployment update does not fail with an ECR error that the tag being deployed already exists for this image manifest

- Template Deployment strategy so that rolling updates ensure HA (always at least one container running)

- Refactor dev command to use actions `start|stop||status|logs|shell|clean` to better work with the docker-compose stack during development workflows

- Add a volume sync to the docker-compose file in `hokusai setup` - this should help local development, even if sync is slow it can be replaced with [docker-sync](http://docker-sync.io/) if a user wants to install and use that rather than docker's own volume syncing

- Add `history` command, printing out the revision history of the project's deployment(s).  I won't implement a rollback command per-se, as when managing multiple deployments, there is the possibility that their revision numbers will go out-of-sync, making relying on a `kubectl rollout undo` [command](http://vishh.github.io/docs/user-guide/kubectl/kubectl_rollout_undo/) worrysome. Let's leave it to devs to use the `history` and `images` commands to see what SHA1 was last deployed, and what they can rollback to.

cc @joeyAghion 