### PR TITLE
Add migration flag to promote and deploy - fix env injection in run command - update production default replicas

### DIFF
--- a/bin/hokusai
+++ b/bin/hokusai
@@ -202,16 +202,17 @@ def stack(action, staging, production, verbose):
 
 @cli.command(context_settings=CONTEXT_SETTINGS)
 @click.argument('tag', type=click.STRING)
+@click.option('--migration', type=click.STRING, help='Run a migration before deploying')
 @click.option('--staging', type=click.BOOL, is_flag=True, help='Target staging')
 @click.option('--production', type=click.BOOL, is_flag=True, help='Target production')
 @click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
-def deploy(tag, staging, production, verbose):
+def deploy(tag, migration, staging, production, verbose):
   """
   Update the project's deployment(s) to reference a named image tag and update the tag (staging/production) to reference the same image
   """
   hokusai.lib.common.set_output(verbose)
   context = select_context(staging, production)
-  hokusai.deploy(context, tag)
+  hokusai.deploy(context, tag, migration)
 
 @cli.command(context_settings=CONTEXT_SETTINGS)
 @click.option('--staging', type=click.BOOL, is_flag=True, help='Target staging')
@@ -238,6 +239,7 @@ def history(staging, production, verbose):
   hokusai.history(context)
 
 @cli.command(context_settings=CONTEXT_SETTINGS)
+@click.option('--migration', type=click.STRING, help='Run a migration before deploying')
 @click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
 def promote(verbose):
   """
@@ -245,7 +247,7 @@ def promote(verbose):
   and update the production tag to reference the same image
   """
   hokusai.lib.common.set_output(verbose)
-  hokusai.promote()
+  hokusai.promote(migration)
 
 @cli.command(context_settings=CONTEXT_SETTINGS)
 @click.argument('command', type=click.STRING)

--- a/hokusai/commands/deploy.py
+++ b/hokusai/commands/deploy.py
@@ -1,9 +1,16 @@
 from hokusai.lib.command import command
-from hokusai.lib.common import print_green
+from hokusai.lib.common import print_red, print_green
 from hokusai.services.deployment import Deployment
+from hokusai.services.command_runner import CommandRunner
 
 @command
-def deploy(context, tag):
+def deploy(context, tag, migration):
+  if migration is not None:
+    retval = CommandRunner(context).run(tag, migration)
+    if retval != 0:
+      print_red("Migration failed with return code %s" % retval)
+      return retval
+
   deployment = Deployment(context)
   deployment.update(tag)
   print_green("Deployment updated to %s" % tag)

--- a/hokusai/commands/promote.py
+++ b/hokusai/commands/promote.py
@@ -1,13 +1,20 @@
 from hokusai.lib.command import command
-from hokusai.lib.common import print_green
+from hokusai.lib.common import print_red, print_green
 from hokusai.services.deployment import Deployment
+from hokusai.services.command_runner import CommandRunner
 
 @command
-def promote():
+def promote(migration):
   deploy_from = Deployment('staging')
   tag = deploy_from.current_tag
   if tag is None:
     return -1
+
+  if migration is not None:
+    retval = CommandRunner('production').run(tag, migration)
+    if retval != 0:
+      print_red("Migration failed with return code %s" % retval)
+      return retval
 
   deploy_to = Deployment('production')
   deploy_to.update(tag)

--- a/hokusai/commands/run.py
+++ b/hokusai/commands/run.py
@@ -25,41 +25,40 @@ def run(context, command, tty, tag, env):
 
   name = "%s-hokusai-run-%s" % (config.project_name, uuid)
   image_name = "%s:%s" % (config.aws_ecr_registry, image_tag)
+  container = {
+    "args": command.split(' '),
+    "name": name,
+    "image": image_name,
+    "imagePullPolicy": "Always",
+    'envFrom': [{'configMapRef': {'name': "%s-environment" % config.project_name}}]
+  }
 
   if tty:
-    overrides = {
-      "apiVersion": "v1",
-      "spec": {
-        "containers": [
-          {
-            "args": command.split(' '),
-            "name": name,
-            "image": image_name,
-            "imagePullPolicy": "Always",
-            'envFrom': [{'configMapRef': {'name': "%s-environment" % config.project_name}}],
-            "stdin": True,
-            "stdinOnce": True,
-            "tty": True
-          }
-        ]
-      }
+    container.update({
+      "stdin": True,
+      "stdinOnce": True,
+      "tty": True
+    })
+
+  if len(env):
+    container['env'] = []
+    for s in env:
+      if '=' not in s:
+        print_red("Error: environment variables must be of the form 'KEY=VALUE'")
+        return -1
+      split = s.split('=', 1)
+      container['env'].append({'name': split[0], 'value': split[1]})
+
+  overrides = {
+    "apiVersion": "v1",
+    "spec": {
+      "containers": [container]
     }
+  }
+
+  if tty:
     shout(kctl.command("run %s -t -i --image=%s --restart=Never --overrides='%s' --rm" %
                    (name, image_name, json.dumps(overrides))), print_output=True)
   else:
-    overrides = {
-      "apiVersion": "v1",
-      "spec": {
-        "containers": [
-          {
-            "args": command.split(' '),
-            "name": name,
-            "image": image_name,
-            "imagePullPolicy": "Always",
-            'envFrom': [{'configMapRef': {'name': "%s-environment" % config.project_name}}]
-          }
-        ]
-      }
-    }
     return returncode(kctl.command("run %s --attach --image=%s --overrides='%s' --restart=Never --rm" %
                                       (name, image_name, json.dumps(overrides))))

--- a/hokusai/commands/run.py
+++ b/hokusai/commands/run.py
@@ -1,64 +1,11 @@
-import os
-import base64
-import json
-
-import yaml
-
 from hokusai.lib.command import command
-from hokusai.lib.config import config
-from hokusai.lib.common import shout, returncode, k8s_uuid
-from hokusai.services.kubectl import Kubectl
+from hokusai.services.command_runner import CommandRunner
 
 @command
-def run(context, command, tty, tag, env):
-  kctl = Kubectl(context)
-
+def run(context, cmd, tty, tag, env):
   if tag is not None:
     image_tag = tag
   else:
     image_tag = context
 
-  if os.environ.get('USER') is not None:
-    uuid = "%s-%s" % (os.environ.get('USER'), k8s_uuid())
-  else:
-    uuid = k8s_uuid()
-
-  name = "%s-hokusai-run-%s" % (config.project_name, uuid)
-  image_name = "%s:%s" % (config.aws_ecr_registry, image_tag)
-  container = {
-    "args": command.split(' '),
-    "name": name,
-    "image": image_name,
-    "imagePullPolicy": "Always",
-    'envFrom': [{'configMapRef': {'name': "%s-environment" % config.project_name}}]
-  }
-
-  if tty:
-    container.update({
-      "stdin": True,
-      "stdinOnce": True,
-      "tty": True
-    })
-
-  if len(env):
-    container['env'] = []
-    for s in env:
-      if '=' not in s:
-        print_red("Error: environment variables must be of the form 'KEY=VALUE'")
-        return -1
-      split = s.split('=', 1)
-      container['env'].append({'name': split[0], 'value': split[1]})
-
-  overrides = {
-    "apiVersion": "v1",
-    "spec": {
-      "containers": [container]
-    }
-  }
-
-  if tty:
-    shout(kctl.command("run %s -t -i --image=%s --restart=Never --overrides='%s' --rm" %
-                   (name, image_name, json.dumps(overrides))), print_output=True)
-  else:
-    return returncode(kctl.command("run %s --attach --image=%s --overrides='%s' --restart=Never --rm" %
-                                      (name, image_name, json.dumps(overrides))))
+  return CommandRunner(context).run(image_tag, cmd, tty=tty, env=env)

--- a/hokusai/commands/setup.py
+++ b/hokusai/commands/setup.py
@@ -196,9 +196,14 @@ def setup(aws_account_id, project_type, project_name, aws_ecr_region, port,
       if with_rabbitmq:
         environment.append({'name': 'RABBITMQ_URL', 'value': "amqp://%s-rabbitmq/%s" % (config.project_name, urllib.quote_plus('/'))})
 
+      if stack == 'production':
+        replicas = 2
+      else:
+        replicas = 1
+
       deployment_data = build_deployment(config.project_name,
                                           "%s:%s" % (config.aws_ecr_registry, stack),
-                                          port, environment=environment, always_pull=True)
+                                          port, environment=environment, always_pull=True, replicas=replicas)
 
       service_data = build_service(config.project_name, port, target_port=port, internal=False)
 

--- a/hokusai/lib/common.py
+++ b/hokusai/lib/common.py
@@ -47,7 +47,7 @@ def k8s_uuid():
     uuid.append(random.choice(string.lowercase))
   return ''.join(uuid)
 
-def build_deployment(name, image, target_port, layer='application', component='web', environment=None, always_pull=False):
+def build_deployment(name, image, target_port, layer='application', component='web', environment=None, always_pull=False, replicas=1):
   container = {
     'name': "%s-%s" % (name, component),
     'image': image,
@@ -68,7 +68,7 @@ def build_deployment(name, image, target_port, layer='application', component='w
     ('kind', 'Deployment'),
     ('metadata', {'name': "%s-%s" % (name, component)}),
     ('spec', {
-      'replicas': 1,
+      'replicas': replicas,
       'strategy': {
         'rollingUpdate': {
           'maxSurge': 1,

--- a/hokusai/services/command_runner.py
+++ b/hokusai/services/command_runner.py
@@ -1,0 +1,57 @@
+import os
+import json
+
+from hokusai.lib.config import config
+from hokusai.lib.common import shout, returncode, k8s_uuid
+from hokusai.services.kubectl import Kubectl
+
+class CommandRunner(object):
+  def __init__(self, context):
+    self.context = context
+    self.kctl = Kubectl(self.context)
+
+  def run(self, image_tag, cmd, tty=False, env=()):
+    if os.environ.get('USER') is not None:
+      uuid = "%s-%s" % (os.environ.get('USER'), k8s_uuid())
+    else:
+      uuid = k8s_uuid()
+
+    name = "%s-hokusai-run-%s" % (config.project_name, uuid)
+    image_name = "%s:%s" % (config.aws_ecr_registry, image_tag)
+    container = {
+      "args": cmd.split(' '),
+      "name": name,
+      "image": image_name,
+      "imagePullPolicy": "Always",
+      'envFrom': [{'configMapRef': {'name': "%s-environment" % config.project_name}}]
+    }
+
+    if tty:
+      container.update({
+        "stdin": True,
+        "stdinOnce": True,
+        "tty": True
+      })
+
+    if len(env):
+      container['env'] = []
+      for s in env:
+        if '=' not in s:
+          print_red("Error: environment variables must be of the form 'KEY=VALUE'")
+          return -1
+        split = s.split('=', 1)
+        container['env'].append({'name': split[0], 'value': split[1]})
+
+    overrides = {
+      "apiVersion": "v1",
+      "spec": {
+        "containers": [container]
+      }
+    }
+
+    if tty:
+      shout(self.kctl.command("run %s -t -i --image=%s --restart=Never --overrides='%s' --rm" %
+                     (name, image_name, json.dumps(overrides))), print_output=True)
+    else:
+      return returncode(self.kctl.command("run %s --attach --image=%s --overrides='%s' --restart=Never --rm" %
+                                        (name, image_name, json.dumps(overrides))))

--- a/test/unit/test_common.py
+++ b/test/unit/test_common.py
@@ -79,6 +79,10 @@ class TestCommon(HokusaiUnitTestCase):
     self.assertEqual(basic_deployment['spec']['template']['spec']['containers'], [{'image': 'nginx:latest', 'name': 'foo-web', 'envFrom': [{'configMapRef': {'name': 'foo-environment'}}], 'ports': [{'containerPort': '80'}]}])
     self.assertEqual(basic_deployment['spec']['template']['metadata'], {'labels': {'app': 'foo', 'layer': 'application', 'component': 'web'}, 'namespace': 'default', 'name': 'foo-web'})
     self.assertEqual(basic_deployment['spec']['replicas'], 1)
+    self.assertEqual(basic_deployment['spec']['strategy'], {'rollingUpdate': { 'maxSurge': 1, 'maxUnavailable': 0 }, 'type': 'RollingUpdate'})
+
+    replicated_deployment = yaml.load(build_deployment('foo', 'nginx:latest', '80', replicas=2))
+    self.assertEqual(replicated_deployment['spec']['replicas'], 2)
 
     environmental_deployment = yaml.load(build_deployment('foo', 'nginx:latest', '80', environment={'FOO': 'BAR'}))
     self.assertEqual(environmental_deployment['spec']['template']['spec']['containers'], [{'image': 'nginx:latest', 'name': 'foo-web', 'env': {'FOO': 'BAR'}, 'envFrom': [{'configMapRef': {'name': 'foo-environment'}}], 'ports': [{'containerPort': '80'}]}])


### PR DESCRIPTION
- Add a `--migration` flag to `deploy` and `promote` commands i.e. `hokusai deploy {SHA1} --migration bundle exec rake db:migrate` - this will launch a container at the tag specified, run the command, and only continue with the deployment / promotion if it succeeds
- Fix injecting env vars to `run` command via the `--env` flag - now verified that it will override any env vars that are present in the existing environment configmap... i.e. if `REDIS_URL=foo` is set prior, via `hokusai env set`, and the command `hokusai run bash --env REDIS_URL=bar` is run, the container will be launched with the environment `REDIS_URL=bar`
- Update `setup` to default to 2 replicas for production deployments