### PR TITLE
Remove -e from docker login command

### DIFF
--- a/hokusai/services/ecr.py
+++ b/hokusai/services/ecr.py
@@ -45,7 +45,7 @@ class ECR(object):
     token = base64.b64decode(res['authorizationToken'])
     username = token.split(':')[0]
     password = token.split(':')[1]
-    return "docker login -u %s -p %s -e none %s" % (username, password, res['proxyEndpoint'])
+    return "docker login -u %s -p %s %s" % (username, password, res['proxyEndpoint'])
 
   def get_images(self):
     images = []


### PR DESCRIPTION
# Problem
Keep getting following error when trying `hokusai push`

```shell
ERROR: unknown shorthand flag: 'e' in -e
See 'docker login --help'.
```

Looks like `-e` is not an [option](https://docs.docker.com/engine/reference/commandline/login/) anymore.

# Solution
Remove it :) With removing it i was able to push an image to ECR.