### PR TITLE
Add `pr_only` option to `hokusai diff`

### DIFF
--- a/bin/hokusai
+++ b/bin/hokusai
@@ -246,14 +246,15 @@ def promote(migration, verbose):
   hokusai.promote(migration)
 
 @cli.command(context_settings=CONTEXT_SETTINGS)
+@click.option('--pr-only', type=click.BOOL, is_flag=True, help='Show only PR merge commits')
 @click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
-def diff(verbose):
+def diff(pr_only, verbose):
   """
   Print a git diff between the tag currently deployed on production
   and the tag currently deployed on staging
   """
   hokusai.lib.common.set_output(verbose)
-  hokusai.diff()
+  hokusai.diff(pr_only)
 
 @cli.command(context_settings=CONTEXT_SETTINGS)
 @click.argument('command', type=click.STRING)

--- a/docs/Command_Reference.md
+++ b/docs/Command_Reference.md
@@ -79,7 +79,7 @@ Note: Environment variables will be automatically injected into containers creat
 * `hokusai promote` - Update the Kubernetes deployment on production to match the deployment running on staging.
 * `hokusai refresh` - Refresh the project's deployment(s).
 * `hokusai history` - Print the project's deployment(s) history.
-* `hokusai diff` - Print a git diff between the tags deployed on production vs staging
+* `hokusai diff` - Print a git diff between the tags deployed on production vs staging, you can pass `pr_only` to only see PR's merge commits
 
 ### Running a command
 

--- a/hokusai/commands/diff.py
+++ b/hokusai/commands/diff.py
@@ -4,7 +4,7 @@ from hokusai.services.deployment import Deployment
 from hokusai.services.ecr import ECR
 
 @command
-def diff():
+def diff(pr_only=False):
   ecr = ECR()
 
   staging_deployment = Deployment('staging')
@@ -28,4 +28,7 @@ def diff():
       return -1
 
   print_green("Comparing %s to %s" % (production_tag, staging_tag))
-  shout("git diff %s %s" % (production_tag, staging_tag), print_output=True)
+  if pr_only:
+    shout("git log --merges --right-only %s..%s" % (production_tag, staging_tag), print_output=True)
+  else:
+    shout("git diff %s %s" % (production_tag, staging_tag), print_output=True)


### PR DESCRIPTION
# Feature
Current `hokusai diff` shows file diffs of whats going to get promoted, while thats awesome, it's little hard to find what where the commits/PRs.

# Solution
Add ` --pr_only` flag to `hokusai diff` command, using `--pr-only` we will use `git log --merges` instead of `git diff` so we should be able to see what PRs are going live.