### PR TITLE
Add gitlog, rename diff to gitdiff

### DIFF
--- a/bin/hokusai
+++ b/bin/hokusai
@@ -251,13 +251,23 @@ def promote(migration, verbose):
 
 @cli.command(context_settings=CONTEXT_SETTINGS)
 @click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
-def diff(verbose):
+def gitdiff(verbose):
   """
   Print a git diff between the tag currently deployed on production
   and the tag currently deployed on staging
   """
   hokusai.lib.common.set_verbosity(verbose)
-  hokusai.diff()
+  hokusai.gitdiff()
+
+@cli.command(context_settings=CONTEXT_SETTINGS)
+@click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
+def gitlog(verbose):
+  """
+  Print a git log between the tag currently deployed on production
+  and the tag currently deployed on staging
+  """
+  hokusai.lib.common.set_verbosity(verbose)
+  hokusai.gitlog()
 
 @cli.command(context_settings=CONTEXT_SETTINGS)
 @click.argument('command', type=click.STRING)

--- a/docs/Command_Reference.md
+++ b/docs/Command_Reference.md
@@ -80,7 +80,8 @@ Note: Environment variables will be automatically injected into containers creat
 * `hokusai promote` - Update the Kubernetes deployment on production to match the deployment running on staging.
 * `hokusai refresh` - Refresh the project's deployment(s).
 * `hokusai history` - Print the project's deployment(s) history.
-* `hokusai diff` - Print a git diff between the tags deployed on production vs staging
+* `hokusai gitdiff` - Print a git diff between the tags deployed on production vs staging.
+* `hokusai gitlog`  - Print a git log comparing the tags deployed on production vs staging, can be used to see what commits are going to be promoted.
 
 ### Running a command
 

--- a/hokusai/commands/__init__.py
+++ b/hokusai/commands/__init__.py
@@ -2,7 +2,8 @@ from hokusai.commands.check import check
 from hokusai.commands.configure import configure
 from hokusai.commands.deploy import deploy
 from hokusai.commands.development import dev_start, dev_stop, dev_build, dev_status, dev_logs, dev_shell, dev_clean
-from hokusai.commands.diff import diff
+from hokusai.commands.diff import gitdiff
+from hokusai.commands.gitlog import gitlog
 from hokusai.commands.env import create_env, delete_env, get_env, set_env, unset_env
 from hokusai.commands.history import history
 from hokusai.commands.images import images

--- a/hokusai/commands/gitdiff.py
+++ b/hokusai/commands/gitdiff.py
@@ -1,0 +1,31 @@
+from hokusai.lib.command import command
+from hokusai.lib.common import print_red, print_green, shout
+from hokusai.services.deployment import Deployment
+from hokusai.services.ecr import ECR
+
+@command
+def gitdiff():
+  ecr = ECR()
+
+  staging_deployment = Deployment('staging')
+  staging_tag = staging_deployment.current_tag
+  if staging_tag is None:
+    return -1
+  if staging_tag == 'staging':
+    staging_tag = ecr.find_git_sha1_image_tag('staging')
+    if staging_tag is None:
+      print_red("Cound not find a git SHA1 tag for 'staging'.  Aborting.")
+      return -1
+
+  production_deployment = Deployment('production')
+  production_tag = production_deployment.current_tag
+  if production_tag is None:
+    return -1
+  if production_tag == 'production':
+    production_tag = ecr.find_git_sha1_image_tag('production')
+    if production_tag is None:
+      print_red("Cound not find a git SHA1 tag for 'production'.  Aborting.")
+      return -1
+
+  print_green("Comparing %s to %s" % (production_tag, staging_tag))
+  shout("git diff %s %s" % (production_tag, staging_tag), print_output=True)

--- a/hokusai/commands/gitlog.py
+++ b/hokusai/commands/gitlog.py
@@ -4,7 +4,7 @@ from hokusai.services.deployment import Deployment
 from hokusai.services.ecr import ECR
 
 @command
-def diff():
+def gitlog():
   ecr = ECR()
 
   staging_deployment = Deployment('staging')
@@ -28,4 +28,4 @@ def diff():
       return -1
 
   print_green("Comparing %s to %s" % (production_tag, staging_tag))
-  shout("git diff %s %s" % (production_tag, staging_tag), print_output=True)
+  shout("git log --right-only %s..%s" % (production_tag, staging_tag), print_output=True)


### PR DESCRIPTION
Follow up after #30 

# Change
We want to be able to see commit level diff between production..staging so we can see what's going to be deployed on next `hokusai promote`.

Added new `hokusai gitlog` and also renamed `hokusai diff` to `hokusai gitdiff` so its more descriptive. 