### PR TITLE
Review apps

### DIFF
--- a/docs/Command_Reference.md
+++ b/docs/Command_Reference.md
@@ -116,7 +116,12 @@ hokusai registry push --tag <name>
 hokusai review_app create <name>
 ```
 
-5) Update review app:
+5) Copy staging `configMap` to new namespace:
+```shell
+hokusai review_app copy_env <name>
+```
+
+6) Update review app:
 If you have made changes to your review app's yaml file, you need to update deployment for that do:
 ```shell
 hokusai review_app update <name>

--- a/docs/Command_Reference.md
+++ b/docs/Command_Reference.md
@@ -100,7 +100,7 @@ Hokusai provides a command for managing review apps. Review apps are useful for 
 In order to start a review app you will need to follow these steps:
 1) Create new review app
 ```shell
-hokusai review_app create <name> # we recommend using branch name or pr number as name
+hokusai review_app setup <name> # we recommend using branch name or pr number as name
 ```
 This command will create a new `<name>.yaml` under `hokusai/` folder.
 
@@ -113,7 +113,13 @@ hokusai registry push --tag <name>
 
 4) Create new deployment on k8s:
 ```shell
-hokusai review_app apply <name>
+hokusai review_app create <name>
+```
+
+5) Update review app:
+If you have made changes to your review app's yaml file, you need to update deployment for that do:
+```shell
+hokusai review_app update <name>
 ```
 
 ### Working with the Staging -> Production pipeline

--- a/docs/Command_Reference.md
+++ b/docs/Command_Reference.md
@@ -60,7 +60,7 @@ Note: `hokusai staging` `hokusai production` subcommands such as `create`, `upda
 ### Testing and building images
 
 * `hokusai test` - Start the testing environment defined `hokusai/test.yml` and exit with the return code of the test command.
-* `hokusai build` - Build the docker image defined in ./hokusai/common.yml. 
+* `hokusai build` - Build the docker image defined in ./hokusai/common.yml.
 
 
 ### Managing images in the registry
@@ -93,6 +93,28 @@ Note: `hokusai staging` `hokusai production` subcommands such as `create`, `upda
   - Use the flag `--tty` to attach your terminal, if your command is interactive. E.g. `hokusai production run --tty 'bundle exec rails c'` launches an interactive console for a Rails project.
   - The flag `--help` shows other flags that might be helpful.
 * `hokusai [staging|production] logs` - Print the logs from your application containers
+
+
+### Working with review apps
+Hokusai provides a command for managing review apps. Review apps are useful for testing feature branches that are not yet ready to be deployed to staging but we do want to test them on a staging-like environment.
+In order to start a review app you will need to follow these steps:
+1) Create new review app
+```shell
+hokusai review_app create <name> # we recommend using branch name or pr number as name
+```
+This command will create a new `<name>.yaml` under `hokusai/` folder.
+
+2) Check newly created `<name>.yaml` file and make sure everything looks good. Note that we use Kubernetes [`namespace`](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/) for review apps. Basically each review app will end up being in its own namespace to not collide with staging.
+
+3) Push an image with this review app tag:
+```shell
+hokusai registry push --tag <name>
+```
+
+4) Create new deployment on k8s:
+```shell
+hokusai review_app apply <name>
+```
 
 ### Working with the Staging -> Production pipeline
 

--- a/hokusai/cli/__init__.py
+++ b/hokusai/cli/__init__.py
@@ -4,3 +4,4 @@ from hokusai.cli.registry import registry
 from hokusai.cli.staging import staging
 from hokusai.cli.production import production
 from hokusai.cli.pipeline import pipeline
+from hokusai.cli.review_app import review_app

--- a/hokusai/cli/review_app.py
+++ b/hokusai/cli/review_app.py
@@ -16,8 +16,8 @@ def review_app(context_settings=CONTEXT_SETTINGS):
 @review_app.command(context_settings=CONTEXT_SETTINGS)
 @click.argument('app_name', type=click.STRING)
 @click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
-@click.option('-sf', '--source-file', type=click.STRING, default='hokusai/staging.yml', help='Source deployment file')
-@click.option('-dn', '--destination-namespace', type=click.STRING, default=None, help='Target Namespace')
+@click.option('-sf', '--source-file', type=click.STRING, default='hokusai/staging.yml')
+@click.option('-dn', '--destination-namespace', type=click.STRING, default=None)
 def setup(app_name, verbose, source_file, destination_namespace):
   set_verbosity(verbose)
   # create app_name.yaml file based on source_file
@@ -29,7 +29,7 @@ def setup(app_name, verbose, source_file, destination_namespace):
 @review_app.command(context_settings=CONTEXT_SETTINGS)
 @click.argument('app_name', type=click.STRING)
 @click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
-@click.option('-dn', '--destination-namespace', type=click.STRING, default=None, help='Target Namespace')
+@click.option('-dn', '--destination-namespace', type=click.STRING, default=None)
 def create(app_name, verbose, destination_namespace):
   if destination_namespace is None: destination_namespace = app_name
   destination_namespace = clean_string(destination_namespace)
@@ -38,7 +38,7 @@ def create(app_name, verbose, destination_namespace):
 @review_app.command(context_settings=CONTEXT_SETTINGS)
 @click.argument('app_name', type=click.STRING)
 @click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
-@click.option('-dn', '--destination-namespace', type=click.STRING, default=None, help='Target Namespace')
+@click.option('-dn', '--destination-namespace', type=click.STRING, default=None)
 def env_copy(app_name, verbose, destination_namespace):
   if destination_namespace is None: destination_namespace = app_name
   destination_namespace = clean_string(destination_namespace)

--- a/hokusai/cli/review_app.py
+++ b/hokusai/cli/review_app.py
@@ -6,8 +6,9 @@ import hokusai
 
 from hokusai.cli.base import base
 from hokusai.cli.staging import KUBE_CONTEXT
-from hokusai.lib.common import set_verbosity, CONTEXT_SETTINGS
+from hokusai.lib.common import set_verbosity, CONTEXT_SETTINGS, clean_string
 from hokusai.lib.config import config
+from hokusai.lib.exceptions import HokusaiError
 
 @base.group()
 def review_app(context_settings=CONTEXT_SETTINGS):
@@ -19,20 +20,31 @@ def review_app(context_settings=CONTEXT_SETTINGS):
 @click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
 @click.option('-sf', '--source-file', type=click.STRING, default='hokusai/staging.yml', help='Source deployment file')
 @click.option('-dn', '--destination-namespace', type=click.STRING, default=None, help='Target Namespace')
-def create(app_name, verbose, source_file, destination_namespace):
+def setup(app_name, verbose, source_file, destination_namespace):
   set_verbosity(verbose)
-  # copy staging yml file
+  # create app_name.yaml file based on source_file
   if destination_namespace is None: destination_namespace = app_name
+  destination_namespace = clean_string(destination_namespace)
   create_new_app_yaml(source_file, app_name, destination_namespace)
+
 
 @review_app.command(context_settings=CONTEXT_SETTINGS)
 @click.argument('app_name', type=click.STRING)
 @click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
-def apply(app_name, verbose):
-  """Create the Kubernetes resources defined in ./hokusai/%s.yml""" % app_name
-  set_verbosity(verbose)
+@click.option('-dn', '--destination-namespace', type=click.STRING, default=None, help='Target Namespace')
+def create(app_name, verbose, destination_namespace):
+  if destination_namespace is None: destination_namespace = app_name
+  destination_namespace = clean_string(destination_namespace)
   hokusai.k8s_create(KUBE_CONTEXT, app_name, app_name)
+  hokusai.k8s_copy_config(KUBE_CONTEXT, destination_namespace)
 
+@review_app.command(context_settings=CONTEXT_SETTINGS)
+@click.argument('app_name', type=click.STRING)
+@click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
+def update(app_name, verbose):
+  """Updates the Kubernetes based resources defined in ./hokusai/%s.yml""" % app_name
+  set_verbosity(verbose)
+  hokusai.k8s_update(KUBE_CONTEXT, app_name)
 
 def create_new_app_yaml(source_file, app_name, destination_namespace):
   with open(source_file, 'r') as stream:
@@ -40,22 +52,21 @@ def create_new_app_yaml(source_file, app_name, destination_namespace):
       yaml_content = list(yaml.load_all(stream))
       # update namespace to destination namespace
       for c in yaml_content: update_namespace(c, destination_namespace)
-      # prepend new namespace definition to yaml
       new_namespace = OrderedDict([
           ('apiVersion', 'v1'),
           ('kind', 'Namespace'),
           ('metadata', {
-            'name': str(app_name)
+            'name': destination_namespace
           })
         ])
       yaml_content = [new_namespace] + yaml_content
       with open("hokusai/%s.yml" % app_name, 'w') as output:
         yaml.safe_dump_all(yaml_content, output, default_flow_style=False)
     except yaml.YAMLError as exc:
-      print(exc)
+      raise HokusaiError("Cannot read source yaml.")
 
 def update_namespace(yaml_section, destination_namespace):
   if 'namespace' in yaml_section: yaml_section['namespace'] = destination_namespace
-  for k, v in yaml_section.iteritems():
+  for _k, v in yaml_section.iteritems():
     if isinstance(v, dict):
       update_namespace(v, destination_namespace)

--- a/hokusai/cli/review_app.py
+++ b/hokusai/cli/review_app.py
@@ -1,0 +1,37 @@
+import click
+from shutil import copyfile, rmtree
+import fileinput
+
+import hokusai
+
+from hokusai.cli.staging import staging, KUBE_CONTEXT
+from hokusai.lib.common import set_verbosity, CONTEXT_SETTINGS
+from hokusai.lib.config import config
+
+@staging.group()
+def review_app(verbose):
+  """Manage/Create review apps"""
+  set_verbosity(verbose)
+  hokusai.k8s_status(KUBE_CONTEXT)
+
+@review_app.comand(context_settings=CONTEXT_SETTINGS)
+@click.argument('pr_number', type=click.STRING)
+@click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
+def create(pr_number, verbose):
+  set_verbosity(verbose)
+  # copy staging yml file
+  pr_file_name = "hokusai/%s.yml" % pr_number
+  pr_project_name = "{0}_{1}".format(config.project_name, pr_number)
+  copyfile('hokusai/staging.yml', pr_file_name)
+  # rename app name
+  for line in fileinput.input(pr_file_name, inplace=True):
+    print line.replace(config.project_name, pr_project_name)
+  hokusai.k8s_create(KUBE_CONTEXT, pr_number, pr_number)
+  # delete pr file
+  rmtree(pr_file_name)
+
+@review_app.comand(context_settings=CONTEXT_SETTINGS)
+@click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
+def list(verbose):
+  set_verbosity(verbose)
+  

--- a/hokusai/cli/review_app.py
+++ b/hokusai/cli/review_app.py
@@ -1,6 +1,4 @@
-from collections import OrderedDict
 import click
-import yaml
 
 import hokusai
 
@@ -8,7 +6,7 @@ from hokusai.cli.base import base
 from hokusai.cli.staging import KUBE_CONTEXT
 from hokusai.lib.common import set_verbosity, CONTEXT_SETTINGS, clean_string
 from hokusai.lib.config import config
-from hokusai.lib.exceptions import HokusaiError
+from hokusai.lib.namespace import create_new_app_yaml
 
 @base.group()
 def review_app(context_settings=CONTEXT_SETTINGS):
@@ -36,6 +34,14 @@ def create(app_name, verbose, destination_namespace):
   if destination_namespace is None: destination_namespace = app_name
   destination_namespace = clean_string(destination_namespace)
   hokusai.k8s_create(KUBE_CONTEXT, app_name, app_name)
+
+@review_app.command(context_settings=CONTEXT_SETTINGS)
+@click.argument('app_name', type=click.STRING)
+@click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
+@click.option('-dn', '--destination-namespace', type=click.STRING, default=None, help='Target Namespace')
+def env_copy(app_name, verbose, destination_namespace):
+  if destination_namespace is None: destination_namespace = app_name
+  destination_namespace = clean_string(destination_namespace)
   hokusai.k8s_copy_config(KUBE_CONTEXT, destination_namespace)
 
 @review_app.command(context_settings=CONTEXT_SETTINGS)
@@ -45,28 +51,3 @@ def update(app_name, verbose):
   """Updates the Kubernetes based resources defined in ./hokusai/%s.yml""" % app_name
   set_verbosity(verbose)
   hokusai.k8s_update(KUBE_CONTEXT, app_name)
-
-def create_new_app_yaml(source_file, app_name, destination_namespace):
-  with open(source_file, 'r') as stream:
-    try:
-      yaml_content = list(yaml.load_all(stream))
-      # update namespace to destination namespace
-      for c in yaml_content: update_namespace(c, destination_namespace)
-      new_namespace = OrderedDict([
-          ('apiVersion', 'v1'),
-          ('kind', 'Namespace'),
-          ('metadata', {
-            'name': destination_namespace
-          })
-        ])
-      yaml_content = [new_namespace] + yaml_content
-      with open("hokusai/%s.yml" % app_name, 'w') as output:
-        yaml.safe_dump_all(yaml_content, output, default_flow_style=False)
-    except yaml.YAMLError as exc:
-      raise HokusaiError("Cannot read source yaml.")
-
-def update_namespace(yaml_section, destination_namespace):
-  if 'namespace' in yaml_section: yaml_section['namespace'] = destination_namespace
-  for _k, v in yaml_section.iteritems():
-    if isinstance(v, dict):
-      update_namespace(v, destination_namespace)

--- a/hokusai/cli/review_app.py
+++ b/hokusai/cli/review_app.py
@@ -1,10 +1,5 @@
 from collections import OrderedDict
 import click
-<<<<<<< HEAD
-=======
-
->>>>>>> 026377db6f5958ef9b6b7f30b7e89ad256609ceb
-from shutil import copyfile
 import yaml
 
 import hokusai
@@ -24,11 +19,20 @@ def review_app(context_settings=CONTEXT_SETTINGS):
 @click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
 @click.option('-sf', '--source-file', type=click.STRING, default='hokusai/staging.yml', help='Source deployment file')
 @click.option('-dn', '--destination-namespace', type=click.STRING, default=None, help='Target Namespace')
-def create(app_name, verbose, source_file, source_namespace, destination_namespace):
+def create(app_name, verbose, source_file, destination_namespace):
   set_verbosity(verbose)
   # copy staging yml file
   if destination_namespace is None: destination_namespace = app_name
   create_new_app_yaml(source_file, app_name, destination_namespace)
+
+@review_app.command(context_settings=CONTEXT_SETTINGS)
+@click.argument('app_name', type=click.STRING)
+@click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
+def apply(app_name, verbose):
+  """Create the Kubernetes resources defined in ./hokusai/%s.yml""" % app_name
+  set_verbosity(verbose)
+  hokusai.k8s_create(KUBE_CONTEXT, app_name, app_name)
+
 
 def create_new_app_yaml(source_file, app_name, destination_namespace):
   with open(source_file, 'r') as stream:

--- a/hokusai/cli/review_app.py
+++ b/hokusai/cli/review_app.py
@@ -1,6 +1,6 @@
 import click
-from shutil import copyfile, rmtree
-import fileinput
+from shutil import copyfile
+import yaml
 
 import hokusai
 
@@ -9,29 +9,22 @@ from hokusai.lib.common import set_verbosity, CONTEXT_SETTINGS
 from hokusai.lib.config import config
 
 @staging.group()
-def review_app(verbose):
+def review_app(context_settings=CONTEXT_SETTINGS):
   """Manage/Create review apps"""
-  set_verbosity(verbose)
-  hokusai.k8s_status(KUBE_CONTEXT)
+  pass
 
-@review_app.comand(context_settings=CONTEXT_SETTINGS)
-@click.argument('pr_number', type=click.STRING)
+@review_app.command(context_settings=CONTEXT_SETTINGS)
+@click.argument('app_name', type=click.STRING)
 @click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
-def create(pr_number, verbose):
+def create(app_name, verbose):
   set_verbosity(verbose)
   # copy staging yml file
-  pr_file_name = "hokusai/%s.yml" % pr_number
-  pr_project_name = "{0}_{1}".format(config.project_name, pr_number)
+  pr_file_name = "hokusai/%s.yml" % app_name
   copyfile('hokusai/staging.yml', pr_file_name)
-  # rename app name
-  for line in fileinput.input(pr_file_name, inplace=True):
-    print line.replace(config.project_name, pr_project_name)
-  hokusai.k8s_create(KUBE_CONTEXT, pr_number, pr_number)
-  # delete pr file
-  rmtree(pr_file_name)
 
-@review_app.comand(context_settings=CONTEXT_SETTINGS)
-@click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
-def list(verbose):
-  set_verbosity(verbose)
-  
+def change_namespace(original_yaml_file, new_namespace, current_namespace='default'):
+  with open(original_yaml_file, 'r') as stream:
+    try:
+      yaml_content = yaml.load(stream)
+    except yaml.YAMLError as exc:
+      print(exc)

--- a/hokusai/commands/__init__.py
+++ b/hokusai/commands/__init__.py
@@ -11,6 +11,6 @@ from hokusai.commands.logs import logs
 from hokusai.commands.push import push
 from hokusai.commands.run import run
 from hokusai.commands.setup import setup
-from hokusai.commands.kubernetes import k8s_create, k8s_update, k8s_delete, k8s_status
+from hokusai.commands.kubernetes import k8s_create, k8s_update, k8s_delete, k8s_status, k8s_copy_config
 from hokusai.commands.test import test
 from hokusai.commands.version import version

--- a/hokusai/commands/kubernetes.py
+++ b/hokusai/commands/kubernetes.py
@@ -12,8 +12,10 @@ from hokusai.services.kubectl import Kubectl
 from hokusai.lib.exceptions import HokusaiError
 
 @command
-def k8s_create(context):
-  kubernetes_yml = os.path.join(os.getcwd(), "hokusai/%s.yml" % context)
+def k8s_create(context, tag='latest', yaml_file_name=None):
+  if yaml_file_name is None:
+    yaml_file_name = context
+  kubernetes_yml = os.path.join(os.getcwd(), "hokusai/%s.yml" % yaml_file_name)
   if not os.path.isfile(kubernetes_yml):
     raise HokusaiError("Yaml file %s does not exist for given context." % kubernetes_yml)
 
@@ -21,11 +23,11 @@ def k8s_create(context):
   if not ecr.project_repository_exists():
     raise HokusaiError("ECR repository %s does not exist... did you run `hokusai setup` for this project?" % config.project_name)
 
-  if not ecr.tag_exists('latest'):
-    raise HokusaiError("Image tag 'latest' does not exist... did you run `hokusai push`?")
+  if not ecr.tag_exists(tag):
+    raise HokusaiError("Image tag %s does not exist... did you run `hokusai push`?" % tag)
 
   if not ecr.tag_exists(context):
-    ecr.retag('latest', context)
+    ecr.retag(tag, context)
     print_green("Updated tag 'latest' -> %s" % context)
 
   kctl = Kubectl(context)

--- a/hokusai/commands/setup.py
+++ b/hokusai/commands/setup.py
@@ -10,7 +10,7 @@ from jinja2 import Environment, PackageLoader, FileSystemLoader
 from hokusai.lib.command import command
 from hokusai.lib.config import config
 from hokusai.services.ecr import ECR
-from hokusai.lib.common import print_green, YAML_HEADER
+from hokusai.lib.common import print_green, YAML_HEADER, clean_string
 from hokusai.lib.exceptions import HokusaiError
 
 @command
@@ -22,7 +22,7 @@ def setup(aws_account_id, project_type, project_name, aws_ecr_region, port, inte
 
   mkpath(os.path.join(os.getcwd(), 'hokusai'))
 
-  config.create(project_name.lower().replace('_', '-'), aws_account_id, aws_ecr_region)
+  config.create(clean_string(project_name), aws_account_id, aws_ecr_region)
 
   if project_type == 'ruby-rack':
     dockerfile = env.get_template("Dockerfile-ruby.j2")

--- a/hokusai/lib/common.py
+++ b/hokusai/lib/common.py
@@ -79,3 +79,6 @@ def k8s_uuid():
   for i in range(0,5):
     uuid.append(random.choice(string.lowercase))
   return ''.join(uuid)
+
+def clean_string(str):
+  return str.lower().replace('_', '-')

--- a/hokusai/lib/namespace.py
+++ b/hokusai/lib/namespace.py
@@ -1,0 +1,28 @@
+from collections import OrderedDict
+import yaml
+from hokusai.lib.exceptions import HokusaiError
+
+def create_new_app_yaml(source_file, app_name, destination_namespace):
+  with open(source_file, 'r') as stream:
+    try:
+      yaml_content = list(yaml.load_all(stream))
+      # update namespace to destination namespace
+      for c in yaml_content: update_namespace(c, destination_namespace)
+      new_namespace = OrderedDict([
+          ('apiVersion', 'v1'),
+          ('kind', 'Namespace'),
+          ('metadata', {
+            'name': destination_namespace
+          })
+        ])
+      yaml_content = [new_namespace] + yaml_content
+      with open("hokusai/%s.yml" % app_name, 'w') as output:
+        yaml.safe_dump_all(yaml_content, output, default_flow_style=False)
+    except yaml.YAMLError as exc:
+      raise HokusaiError("Cannot read source yaml.")
+
+def update_namespace(yaml_section, destination_namespace):
+  if 'namespace' in yaml_section: yaml_section['namespace'] = destination_namespace
+  for _k, v in yaml_section.iteritems():
+    if isinstance(v, dict):
+      update_namespace(v, destination_namespace)

--- a/hokusai/templates/production.yml.j2
+++ b/hokusai/templates/production.yml.j2
@@ -3,6 +3,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: {{ project_name }}-{{ component }}
+  namespace: default
 spec:
   replicas: 2
   strategy:
@@ -17,7 +18,6 @@ spec:
         component: {{ component }}
         layer: {{ layer }}
       name: {{ project_name }}-{{ component }}
-      namespace: default
     spec:
       containers:
       - name: {{ project_name }}-{{ component }}

--- a/hokusai/templates/staging.yml.j2
+++ b/hokusai/templates/staging.yml.j2
@@ -3,6 +3,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: {{ project_name }}-{{ component }}
+  namespace: default
 spec:
   replicas: 1
   strategy:
@@ -17,7 +18,6 @@ spec:
         component: {{ component }}
         layer: {{ layer }}
       name: {{ project_name }}-{{ component }}
-      namespace: default
     spec:
       containers:
       - name: {{ project_name }}-{{ component }}


### PR DESCRIPTION
# Problem
We want to be able to easily deploy different images of the same app on k8s.

# Possible Solution
Adding following command:
```
hokusai staging review_app create <name of the app>
```
What this command does is, it copies `staging.yaml`, adds a new `namespace` definition for this app instance and updates the `namespace` in yaml to point to newly created one and stores the result in `<app_name>.yaml`.
The idea is, we provide this `yaml` file and then we need to manually push the image with proper tag and create this deployment.