### PR TITLE
add alternate project types

### DIFF
--- a/docs/Getting_Started.md
+++ b/docs/Getting_Started.md
@@ -11,7 +11,7 @@ cd ./path/to/my/rails/project/git/repo
 hokusai setup --project-type ruby-rails
 ```
 
-(Other currently supported project types include `ruby-rack`, `nodejs`, `elixir` and `python-wsgi`.)
+(`hokusai setup --help` can report the list of all supported project types.)
 
 `hokusai setup` will create:
 - A `Dockerfile` in your project root

--- a/docs/Getting_Started.md
+++ b/docs/Getting_Started.md
@@ -11,6 +11,8 @@ cd ./path/to/my/rails/project/git/repo
 hokusai setup --project-type ruby-rails
 ```
 
+(Other currently supported project types include `ruby-rack`, `nodejs`, `elixir` and `python-wsgi`.)
+
 `hokusai setup` will create:
 - A `Dockerfile` in your project root
 - A configuration folder `./hokusai`.  This folder contains:


### PR DESCRIPTION
In starting a Hokusai project for Node, I was initially unsure how to apply the directions. I searched in the repo for `ruby-rails` to see if it was obvious what other keywords could be substituted. It was, indeed, obvious, but it seems potentially more obvious to list the project types. The tradeoff would be that this list has to manually be kept in sync. Maybe a more robust solution would be to make the project types list dynamic and inspectable via the CLI? 

Anyway, just thought I'd open a PR in case this seemed like a good idea.