### PR TITLE
fix Yarn failure in CI build

### DIFF
--- a/hokusai/templates/Dockerfile-node.j2
+++ b/hokusai/templates/Dockerfile-node.j2
@@ -23,6 +23,7 @@ RUN npm install -g yarn
 WORKDIR /tmp
 ADD package.json package.json
 ADD yarn.lock yarn.lock
+RUN chmod u+x /usr/local/bin/yarn
 RUN yarn install
 RUN mv /tmp/node_modules /app/
 


### PR DESCRIPTION
I've experience transient issues with `yarn` failing to run due to permission issues when the Dockerfile runs on CircleCI. I feel like this might be a bit of a hack to solve the issue, but it seems to have done the trick.

[Example failied build](https://circleci.com/gh/artsy/volley/12)