### PR TITLE
push tags to specified git remote if provided on deploy and promote

### DIFF
--- a/hokusai/cli/pipeline.py
+++ b/hokusai/cli/pipeline.py
@@ -32,10 +32,11 @@ def gitlog(verbose):
 @pipeline.command(context_settings=CONTEXT_SETTINGS)
 @click.option('--migration', type=click.STRING, help='Run a migration before deploying')
 @click.option('--constraint', type=click.STRING, multiple=True, help='Constrain migration and deploy hooks to run on nodes matching labels in the form of "key=value"')
+@click.option('--git-remote', type=click.STRING, help='Push deployment tags to git remote')
 @click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
-def promote(migration, constraint, verbose):
+def promote(migration, constraint, git_remote, verbose):
   """Update the project's deployment(s) on production with the image tag
   currently deployed on staging and update the production tag
   to reference the same image"""
   set_verbosity(verbose)
-  hokusai.promote(migration, constraint)
+  hokusai.promote(migration, constraint, git_remote)

--- a/hokusai/cli/production.py
+++ b/hokusai/cli/production.py
@@ -73,13 +73,14 @@ def logs(timestamps, follow, tail, verbose):
 @click.argument('tag', type=click.STRING)
 @click.option('--migration', type=click.STRING, help='Run a migration before deploying')
 @click.option('--constraint', type=click.STRING, multiple=True, help='Constrain migration and deploy hooks to run on nodes matching labels in the form of "key=value"')
+@click.option('--git-remote', type=click.STRING, help='Push deployment tags to git remote')
 @click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
-def deploy(tag, migration, constraint, verbose):
+def deploy(tag, migration, constraint, git_remote, verbose):
   """Update the project's deployment(s) to reference
   the given image tag and update the tag production
   to reference the same image"""
   set_verbosity(verbose)
-  hokusai.update(KUBE_CONTEXT, tag, migration, constraint)
+  hokusai.update(KUBE_CONTEXT, tag, migration, constraint, git_remote)
 
 
 @production.command(context_settings=CONTEXT_SETTINGS)

--- a/hokusai/cli/staging.py
+++ b/hokusai/cli/staging.py
@@ -73,13 +73,14 @@ def logs(timestamps, follow, tail, verbose):
 @click.argument('tag', type=click.STRING)
 @click.option('--migration', type=click.STRING, help='Run a migration before deploying')
 @click.option('--constraint', type=click.STRING, multiple=True, help='Constrain migration and deploy hooks to run on nodes matching labels in the form of "key=value"')
+@click.option('--git-remote', type=click.STRING, help='Push deployment tags to git remote')
 @click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
-def deploy(tag, migration, constraint, verbose):
+def deploy(tag, migration, constraint, git_remote, verbose):
   """Update the project's deployment(s) to reference
   the given image tag and update the tag staging
   to reference the same image"""
   set_verbosity(verbose)
-  hokusai.update(KUBE_CONTEXT, tag, migration, constraint)
+  hokusai.update(KUBE_CONTEXT, tag, migration, constraint, git_remote)
 
 
 @staging.command(context_settings=CONTEXT_SETTINGS)

--- a/hokusai/commands/deployment.py
+++ b/hokusai/commands/deployment.py
@@ -5,13 +5,13 @@ from hokusai.services.command_runner import CommandRunner
 from hokusai.lib.exceptions import HokusaiError
 
 @command
-def update(context, tag, migration, constraint):
+def update(context, tag, migration, constraint, git_remote):
   if migration is not None:
     print_green("Running migration '%s' on %s..." % (migration, context))
     return_code = CommandRunner(context).run(tag, migration, constraint=constraint)
     if return_code:
       raise HokusaiError("Migration failed with return code %s" % return_code, return_code=return_code)
-  Deployment(context).update(tag, constraint)
+  Deployment(context).update(tag, constraint, git_remote)
   print_green("Deployment updated to %s" % tag)
 
 
@@ -35,7 +35,7 @@ def refresh(context):
 
 
 @command
-def promote(migration, constraint):
+def promote(migration, constraint, git_remote):
   deploy_from = Deployment('staging')
   tag = deploy_from.current_tag
   if tag is None:
@@ -46,5 +46,5 @@ def promote(migration, constraint):
     return_code = CommandRunner('production').run(tag, migration, constraint=constraint)
     if return_code:
       raise HokusaiError("Migration failed with return code %s" % return_code, return_code=return_code)
-  deploy_to = Deployment('production').update(tag, constraint)
+  deploy_to = Deployment('production').update(tag, constraint, git_remote)
   print_green("Promoted staging to production at %s" % tag)


### PR DESCRIPTION
Add the flag `--git-remote` to `hokusai [staging|production] deploy` and `hokusai pipeline promote` - if provided, push deployment tags to the specified remote.
