### PR TITLE
Version 0.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## v0.4.5
+
+* 1a9822a resolve this directory in hokusai.spec
+* 5746219 (origin/fea-push-git-tags, fea-push-git-tags) push tags to specified git remote if provided on deploy and promote
+* b6406df remove image digest from registry images output
+* 2561c03 remove history command
+* 3c43592 check project repo exists before updating deployment or running a command
+* 5738ff4 bugfix in hokusai/services/deployment.py
+* 93219ea include Pyinstaller spec
+* 10a7e12 updates to pyinstaller build steps
+* ec590d7 updates to distribute with PyInstaller
+* 8011f78 read VERSION from module
+* 96f8f52 fix Yarn failure in CI build
+
 ## v0.4.4
 
 * 3a45ed0 add interactive 'console' command with click-repl

--- a/docs/Command_Reference.md
+++ b/docs/Command_Reference.md
@@ -82,7 +82,6 @@ Note: `hokusai staging` `hokusai production` subcommands such as `create`, `upda
 * `hokusai [staging|production] status` - Print the Kubernetes resources status defined in the environment config.
 
 * `hokusai [staging|production] deploy` - Update the project's deployment(s) for a given environment to reference the given image tag and update the tag (staging/production) to reference the same image.
-* `hokusai [staging|production] history` - Print the project's deployment history in terms of revision number, creation time, container name and image tag for a given environment.
 * `hokusai [staging|production] [refresh|restart]` - Refresh the project's deployment(s) by recreating the currently running containers.
 
 * `hokusai [staging|production] env` - Interact with the runtime environment for the application

--- a/docs/Getting_Started.md
+++ b/docs/Getting_Started.md
@@ -84,7 +84,7 @@ See [Configuration Options](./Configuration_Options.md) if you want to modify yo
 
 `hokusai staging status` should eventually (once Kubernetes creates a load balancer for your project), output the ELB's DNS record.
 
-Get logs by running `hokusai staging logs` and see deployment history with `hokusai staging history`
+Get logs by running `hokusai staging logs`
 
 8) Create the Kubernetes production environment and environment configuration
 
@@ -101,7 +101,6 @@ See [Configuration Options](./Configuration_Options.md) if you want to modify yo
 hokusai production create
 hokusai production status
 hokusai production logs
-hokusai production history
 ```
 
 10) Deploy changes to the Kubernetes staging environment

--- a/hokusai.spec
+++ b/hokusai.spec
@@ -4,7 +4,7 @@ block_cipher = None
 
 
 a = Analysis(['bin/hokusai'],
-             pathex=['/Users/isacpetruzzi/Code/artsy/hokusai'],
+             pathex=['.'],
              binaries=[],
              datas=[],
              hiddenimports=['ConfigParser'],

--- a/hokusai/cli/production.py
+++ b/hokusai/cli/production.py
@@ -84,15 +84,6 @@ def deploy(tag, migration, constraint, verbose):
 
 @production.command(context_settings=CONTEXT_SETTINGS)
 @click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
-def history(verbose):
-  """Print the project's deployment history in terms of revision number,
-  creation time, container name and image tag"""
-  set_verbosity(verbose)
-  hokusai.history(KUBE_CONTEXT)
-
-
-@production.command(context_settings=CONTEXT_SETTINGS)
-@click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
 def refresh(verbose):
   """Refresh the project's deployment(s) by recreating the currently running containers"""
   set_verbosity(verbose)

--- a/hokusai/cli/staging.py
+++ b/hokusai/cli/staging.py
@@ -84,15 +84,6 @@ def deploy(tag, migration, constraint, verbose):
 
 @staging.command(context_settings=CONTEXT_SETTINGS)
 @click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
-def history(verbose):
-  """Print the project's deployment history in terms of revision number,
-  creation time, container name and image tag"""
-  set_verbosity(verbose)
-  hokusai.history(KUBE_CONTEXT)
-
-
-@staging.command(context_settings=CONTEXT_SETTINGS)
-@click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
 def refresh(verbose):
   """Refresh the project's deployment(s) by recreating the currently running containers"""
   set_verbosity(verbose)

--- a/hokusai/commands/__init__.py
+++ b/hokusai/commands/__init__.py
@@ -1,7 +1,7 @@
 from hokusai.commands.build import build
 from hokusai.commands.check import check
 from hokusai.commands.configure import configure
-from hokusai.commands.deployment import update, history, refresh, promote
+from hokusai.commands.deployment import update, refresh, promote
 from hokusai.commands.development import dev_start, dev_stop, dev_status, dev_logs, dev_run, dev_clean
 from hokusai.commands.gitdiff import gitdiff
 from hokusai.commands.gitlog import gitlog

--- a/hokusai/commands/deployment.py
+++ b/hokusai/commands/deployment.py
@@ -16,19 +16,6 @@ def update(context, tag, migration, constraint):
 
 
 @command
-def history(context):
-  deployment = Deployment(context)
-  for name in deployment.names:
-    print_green(name)
-    print("REVISION    CREATION TIMESTAMP            CONTAINER NAME - IMAGE TAG")
-    for replicaset in deployment.history(name):
-      revision = replicaset['metadata']['annotations']['deployment.kubernetes.io/revision']
-      created_at = replicaset['metadata']['creationTimestamp']
-      containers = ["%s - %s" % (container['name'], container['image'].rsplit(':', 1)[1]) for container in replicaset['spec']['template']['spec']['containers']]
-      print("%s           %s          %s" % (revision, created_at, ','.join(containers)))
-
-
-@command
 def refresh(context):
   deployment = Deployment(context)
   deployment.refresh()

--- a/hokusai/commands/images.py
+++ b/hokusai/commands/images.py
@@ -9,9 +9,9 @@ from hokusai.lib.common import print_green, shout
 def images():
   images = ECR().get_images()
   print('')
-  print_green('Image Pushed At           | Image Digest                                                     | Image Tags')
-  print_green('-------------------------------------------------------------------------------------------------------------------------------')
+  print_green('Image Pushed At            | Image Tags')
+  print_green('----------------------------------------------------------')
   for image in sorted(images, key=itemgetter('imagePushedAt'), reverse=True):
     if 'imageTags' not in image.keys():
       continue
-    print("%s | %s | %s" % (image['imagePushedAt'], image['imageDigest'][7:], ', '.join(image['imageTags'])))
+    print("%s | %s" % (image['imagePushedAt'], ', '.join(image['imageTags'])))

--- a/hokusai/services/command_runner.py
+++ b/hokusai/services/command_runner.py
@@ -14,6 +14,9 @@ class CommandRunner(object):
     self.ecr = ECR()
 
   def run(self, image_tag, cmd, tty=False, env=(), constraint=()):
+    if not self.ecr.project_repo_exists():
+      raise HokusaiError("Project repo does not exist.  Aborting.")
+
     if os.environ.get('USER') is not None:
       uuid = "%s-%s" % (os.environ.get('USER'), k8s_uuid())
     else:

--- a/hokusai/services/deployment.py
+++ b/hokusai/services/deployment.py
@@ -106,11 +106,11 @@ class Deployment(object):
       container_images = [container['image'] for container in containers]
 
       if not all(x == container_images[0] for x in container_images):
-        raise HokusaiError("Deployment's containers do not reference the same image tag", return_code=return_code)
+        raise HokusaiError("Deployment's containers do not reference the same image tag.  Aborting.")
 
       images.append(containers[0]['image'])
 
     if not all(y == images[0] for y in images):
-      raise HokusaiError("Deployments do not reference the same image tag", return_code=return_code)
+      raise HokusaiError("Deployments do not reference the same image tag. Aborting.")
 
     return images[0].rsplit(':', 1)[1]

--- a/hokusai/services/deployment.py
+++ b/hokusai/services/deployment.py
@@ -90,10 +90,6 @@ class Deployment(object):
     if return_code:
       raise HokusaiError("Refresh failed!", return_code=return_code)
 
-  def history(self, deployment_name):
-    replicasets = self.kctl.get_object('replicaset', selector="app=%s,layer=application" % config.project_name)
-    replicasets = filter(lambda rs: rs['metadata']['ownerReferences'][0]['name'] == deployment_name, replicasets)
-    return sorted(replicasets, key=lambda rs: int(rs['metadata']['annotations']['deployment.kubernetes.io/revision']))
 
   @property
   def names(self):

--- a/hokusai/services/deployment.py
+++ b/hokusai/services/deployment.py
@@ -16,6 +16,9 @@ class Deployment(object):
     self.cache = self.kctl.get_object('deployment', selector="app=%s,layer=application" % config.project_name)
 
   def update(self, tag, constraint):
+    if not self.ecr.project_repo_exists():
+      raise HokusaiError("Project repo does not exist.  Aborting.")
+
     print_green("Deploying %s to %s..." % (tag, self.context))
 
     if self.context != tag:

--- a/hokusai/version.py
+++ b/hokusai/version.py
@@ -1,1 +1,1 @@
-VERSION = '0.4.4'
+VERSION = '0.4.5'


### PR DESCRIPTION
Notable changes:
- PyInstaller OSX build
- Push git tags to remote on deploy / promote for CI workflow
- Remove history command as it fell out of sync with multiple deployment and printed misleading information (will readdress when implementing deployment manifests in https://github.com/artsy/hokusai/issues/61)
- `registry images` command no longer prints noisy image digest

Changelog for v0.4.5:

* 1a9822a resolve this directory in hokusai.spec
* 5746219 (origin/fea-push-git-tags, fea-push-git-tags) push tags to specified git remote if provided on deploy and promote
* b6406df remove image digest from registry images output
* 2561c03 remove history command
* 3c43592 check project repo exists before updating deployment or running a command
* 5738ff4 bugfix in hokusai/services/deployment.py
* 93219ea include Pyinstaller spec
* 10a7e12 updates to pyinstaller build steps
* ec590d7 updates to distribute with PyInstaller
* 8011f78 read VERSION from module
* 96f8f52 fix Yarn failure in CI build