### PR TITLE
Update review_app docs

### DIFF
--- a/docs/Command_Reference.md
+++ b/docs/Command_Reference.md
@@ -128,14 +128,27 @@ In order to start a review app you will need to follow these steps:
     hokusai review_app env_copy <name>
     ```
 
-6) Update review app:
+6) Find and visit your staging app:
+    - In the Kubernetes UI, find the "Namespace" dropdown in the main nav and select your chosen `<name>` from that menu
+    - Go to Replica Sets > _replica set name_ (there is probably only one)
+    - Browse to the "Services" section
+    - Look in the "External endpoints" column
+    - These endpoints are your publicly accessible URLs
+
+7) If you need to update environment variables:
+    - Until this feature is added to Hokusai, you can update environment variables as usual from the Config Maps section of the Kubernetes UI
+
+8) If you need to refresh  your app, (e.g. after updating environment variables)
+    - Until this feature is added to Hokusai, you can restart apps as usual by terminating pods from the Pods section of the Kubernetes UI
+
+9) Update review app:
 
     If you have made changes to your review app's yaml file, you need to update deployment for that do:
     ```shell
     hokusai review_app update <name>
     ```
 
-7) Delete review app:
+10) Delete review app:
     ```shell
     hokusai review_app delete <name>
     ```

--- a/docs/Command_Reference.md
+++ b/docs/Command_Reference.md
@@ -101,39 +101,44 @@ Note: `hokusai staging` `hokusai production` subcommands such as `create`, `upda
 Hokusai provides a command for managing review apps. Review apps are useful for testing feature branches that are not yet ready to be deployed to staging but we do want to test them on a staging-like environment.
 In order to start a review app you will need to follow these steps:
 1) Create new review app
-```shell
-hokusai review_app setup <name> # we recommend using branch name or pr number as name
-```
-This command will create a new `<name>.yaml` under `hokusai/` folder.
+    ```shell
+    hokusai review_app setup <name> # we recommend using branch name or pr number as name
+    ```
+    This command will create a new `<name>.yaml` under `hokusai/` folder.
 
 2) Check newly created `<name>.yaml` file and make sure everything looks good. Note that we use Kubernetes [`namespace`](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/) for review apps. Basically each review app will end up being in its own namespace to not collide with staging.
 
 3) Push an image with this review app tag:
-```shell
-hokusai registry push --tag <name>
-```
+    ```shell
+    hokusai registry push --tag <name>
+    ```
+
+    If you have git-ignored files in your working directory (likely) you will have to force push with:
+    ```shell
+    hokusai registry push --force --tag <name>
+    ```
 
 4) Create new deployment on k8s:
-```shell
-hokusai review_app create <name>
-```
+    ```shell
+    hokusai review_app create <name>
+    ```
 
 5) Copy staging `configMap` to new namespace:
-```shell
-hokusai review_app copy_env <name>
-```
+    ```shell
+    hokusai review_app env_copy <name>
+    ```
 
 6) Update review app:
-If you have made changes to your review app's yaml file, you need to update deployment for that do:
-```shell
-hokusai review_app update <name>
-```
+
+    If you have made changes to your review app's yaml file, you need to update deployment for that do:
+    ```shell
+    hokusai review_app update <name>
+    ```
 
 7) Delete review app:
-To delete the review app:
-```shell
-hokusai review_app delete <name>
-```
+    ```shell
+    hokusai review_app delete <name>
+    ```
 
 ### Working with the Staging -> Production pipeline
 


### PR DESCRIPTION
I just had my first adventure with review apps, here are some notes to add to the docs:

- `copy_env` is actually `env_copy`

- `hokusai registry push --force --tag <name>` is probably what you'll need to do

- how to find your public urls

- interim methods for updating env vars and refreshing (issues added for adding subcommands for these: #74, #75)

- some whitespace tweaks.

