### PR TITLE
Fix using context on k8s_update and not use yaml_file_name

### DIFF
--- a/hokusai/commands/kubernetes.py
+++ b/hokusai/commands/kubernetes.py
@@ -36,7 +36,7 @@ def k8s_create(context, tag='latest', yaml_file_name=None):
 @command
 def k8s_update(context, yaml_file_name=None):
   if yaml_file_name is None: yaml_file_name = context
-  kubernetes_yml = os.path.join(os.getcwd(), "hokusai/%s.yml" % context)
+  kubernetes_yml = os.path.join(os.getcwd(), "hokusai/%s.yml" % yaml_file_name)
   if not os.path.isfile(kubernetes_yml):
     raise HokusaiError("Yaml file %s does not exist." % kubernetes_yml)
 


### PR DESCRIPTION
# Problem
When doing `hokusai review_app update <app name>` we noticed it uses `staging.yml` instead of the review app file yaml.

# Cause
We were setting yaml file based on app name but we were using context (staging for review apps)

# Solution
use `yaml_file_name` instead of context for applying deployment.