### PR TITLE
Update README to reference up-to-date docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ curl https://artsy-provisioning-public.s3.amazonaws.com/hokusai -o /usr/local/bi
 
 2) Set the environment variables `$AWS_ACCESS_KEY_ID` and `$AWS_SECRET_ACCESS_KEY` in your shell / `~/.bash_profile`.
 
-3) Run `hokusai configure --kubectl-version <kubectl version> --s3-bucket <bucket name> --s3-key <file key>`.  You'll need to provide the kubectl version matching your Kubernetes deployments, as well as the S3 bucket name and key of your org's kubectl config file. (System administrators, see [Administering Hokusai](./docs/Administering_Hokusai.md) for instructions on preparing AWS, Kubernetes, and publishing a kubectl config file. Artsy devs, see [here](https://github.com/artsy/potential/blob/master/platform/Kubernetes.md#configuring-hokusai).)
+3) Run `hokusai configure --kubectl-version <kubectl version> --s3-bucket <bucket name> --s3-key <file key>`.  You'll need to provide the kubectl version matching your Kubernetes deployments, as well as the S3 bucket name and key of your org's kubectl config file. System administrators: see [Administering Hokusai](./docs/Administering_Hokusai.md) for instructions on preparing AWS, Kubernetes, and publishing a kubectl config file. Artsy devs: see [these artsy/README docs](https://github.com/artsy/README/blob/master/playbooks/hokusai.md) for the current way to install and configure hokusai.
 
 To enable bash autocompletion: `eval "$(_HOKUSAI_COMPLETE=source hokusai)"`
 


### PR DESCRIPTION
Previously this README referenced artsy/potential docs that pointed to a artsy/README link that 404'ed. After this change, this README references a now up-to-date Hokusai artsy/README playbook (see https://github.com/artsy/README/pull/80)