### PR TITLE
Add `hokusai pipeline gitcompare`

### DIFF
--- a/docs/Command_Reference.md
+++ b/docs/Command_Reference.md
@@ -105,6 +105,7 @@ See full details in the [Review App reference](Review_Apps.md).
 * `hokusai pipeline` - Interact with the project's' staging -> production pipeline
   - `hokusai pipeline gitdiff` - Print a git diff between the tags deployed on production vs staging.
   - `hokusai pipeline gitlog`  - Print a git log comparing the tags deployed on production vs staging, can be used to see what commits are going to be promoted.
+  - `hokusai pipeline gitcompare --org-name <your org name in githug>` - Print a git compare url for comparing whats on staging with production.
   - `hokusai pipeline promote` - Update the project's deployment(s) on production with the image tag currently deployed on staging and update the production tag to reference the same image.
 
 ### How to do a rollback

--- a/hokusai/cli/pipeline.py
+++ b/hokusai/cli/pipeline.py
@@ -29,7 +29,7 @@ def gitlog(verbose):
   hokusai.gitlog()
 
 @pipeline.command(context_settings=CONTEXT_SETTINGS)
-@click.option('--git-compare-link', type=click.STRING, help='Python formatted string input that gets org name, appName and 2 diff sha1s, example: https://github.com/%s/%s/compare/%s...%s', default="https://github.com/%s/%s/compare/%s...%s")
+@click.option('--git-compare-link', type=click.STRING, help='Python formatted string input that gets org name, project name and 2 diff sha1s, example: https://github.com/%s/%s/compare/%s...%s', default="https://github.com/%s/%s/compare/%s...%s")
 @click.option('--org-name', type=click.STRING, help='Run a migration before deploying')
 @click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
 def gitcompare(git_compare_link, org_name, verbose):

--- a/hokusai/cli/pipeline.py
+++ b/hokusai/cli/pipeline.py
@@ -29,13 +29,14 @@ def gitlog(verbose):
   hokusai.gitlog()
 
 @pipeline.command(context_settings=CONTEXT_SETTINGS)
-@click.option('--git-compare-link', type=click.STRING, help='Run a migration before deploying', default="https://github.com/%s/compare/%s...%s")
+@click.option('--git-compare-link', type=click.STRING, help='Python formatted string input that gets org name, appName and 2 diff sha1s, example: https://github.com/%s/%s/compare/%s...%s', default="https://github.com/%s/%s/compare/%s...%s")
+@click.option('--org-name', type=click.STRING, help='Run a migration before deploying')
 @click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
-def gitlog(git_compare_link, verbose):
+def gitcompare(git_compare_link, org_name, verbose):
   """Prints a git compare link between the tag currently deployed on production
   and the tag currently deployed on staging"""
   set_verbosity(verbose)
-  hokusai.gitcopmare(git_compare_link)
+  hokusai.gitcompare(git_compare_link, org_name)
 
 
 @pipeline.command(context_settings=CONTEXT_SETTINGS)

--- a/hokusai/cli/pipeline.py
+++ b/hokusai/cli/pipeline.py
@@ -28,6 +28,15 @@ def gitlog(verbose):
   set_verbosity(verbose)
   hokusai.gitlog()
 
+@pipeline.command(context_settings=CONTEXT_SETTINGS)
+@click.option('--git-compare-link', type=click.STRING, help='Run a migration before deploying', default="https://github.com/%s/compare/%s...%s")
+@click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
+def gitlog(git_compare_link, verbose):
+  """Prints a git compare link between the tag currently deployed on production
+  and the tag currently deployed on staging"""
+  set_verbosity(verbose)
+  hokusai.gitcopmare(git_compare_link)
+
 
 @pipeline.command(context_settings=CONTEXT_SETTINGS)
 @click.option('--migration', type=click.STRING, help='Run a migration before deploying')

--- a/hokusai/commands/__init__.py
+++ b/hokusai/commands/__init__.py
@@ -5,6 +5,7 @@ from hokusai.commands.deployment import update, refresh, promote
 from hokusai.commands.development import dev_start, dev_stop, dev_status, dev_logs, dev_run, dev_clean
 from hokusai.commands.gitdiff import gitdiff
 from hokusai.commands.gitlog import gitlog
+from hokusai.commands.gitcompare import gitcompare
 from hokusai.commands.env import create_env, delete_env, get_env, set_env, unset_env
 from hokusai.commands.images import images
 from hokusai.commands.logs import logs

--- a/hokusai/commands/gitcompare.py
+++ b/hokusai/commands/gitcompare.py
@@ -1,0 +1,28 @@
+from hokusai.lib.command import command
+from hokusai.lib.common import print_red, print_green, shout
+from hokusai.lib.config import config
+from hokusai.services.deployment import Deployment
+from hokusai.services.ecr import ECR
+
+@command
+def gitcompare(git_compare_link):
+  ecr = ECR()
+
+  staging_deployment = Deployment('staging')
+  staging_tag = staging_deployment.current_tag
+  if staging_tag is None:
+    raise HokusaiError("Could not find a tag for staging.  Aborting.")
+  staging_tag = ecr.find_git_sha1_image_tag(staging_tag)
+  if staging_tag is None:
+    raise HokusaiError("Could not find a git SHA1 tag for tag %s.  Aborting." % staging_tag)
+
+  production_deployment = Deployment('production')
+  production_tag = production_deployment.current_tag
+  if production_tag is None:
+    raise HokusaiError("Could not find a tag for production.  Aborting.")
+  production_tag = ecr.find_git_sha1_image_tag(production_tag)
+  if production_tag is None:
+    raise HokusaiError("Could not find a git SHA1 for tag %s.  Aborting." % production_tag)
+
+  print_green("Comparing %s to %s" % (production_tag, staging_tag))
+  shout(git_compare_link % (config.project_name, production_tag, staging_tag), print_output=True)

--- a/hokusai/commands/gitcompare.py
+++ b/hokusai/commands/gitcompare.py
@@ -5,7 +5,7 @@ from hokusai.services.deployment import Deployment
 from hokusai.services.ecr import ECR
 
 @command
-def gitcompare(git_compare_link):
+def gitcompare(git_compare_link, org_name):
   ecr = ECR()
 
   staging_deployment = Deployment('staging')
@@ -24,5 +24,4 @@ def gitcompare(git_compare_link):
   if production_tag is None:
     raise HokusaiError("Could not find a git SHA1 for tag %s.  Aborting." % production_tag)
 
-  print_green("Comparing %s to %s" % (production_tag, staging_tag))
-  shout(git_compare_link % (config.project_name, production_tag, staging_tag), print_output=True)
+  print_green(git_compare_link % (org_name, config.project_name, production_tag, staging_tag))


### PR DESCRIPTION
# Problem
Often times we want to be able to get compare link on github so we can post it on our channels let people know what commits are going to be deployed.

# Solution
add `hokusai pipeline gitcompare` which by default uses github as git provider but can get a format string as input for supporting other providers (possibly)