### PR TITLE
Update hokusai check command to find executables via which

### DIFF
--- a/hokusai/commands/check.py
+++ b/hokusai/commands/check.py
@@ -26,28 +26,28 @@ def check():
     check_err('Config project-name')
 
   try:
-    shout('docker --version')
+    shout('which docker')
     check_ok('docker')
   except CalledProcessError:
     check_err('docker')
     return_code += 1
 
   try:
-    shout('docker-compose --version')
+    shout('which docker-compose')
     check_ok('docker-compose')
   except CalledProcessError:
     check_err('docker-compose')
     return_code += 1
 
   try:
-    shout('kubectl version')
+    shout('which kubectl')
     check_ok('kubectl')
   except CalledProcessError:
     check_err('kubectl')
     return_code += 1
 
   try:
-    shout('git version')
+    shout('which git')
     check_ok('git')
   except CalledProcessError:
     check_err('git')


### PR DESCRIPTION
For the `hokusai check` command, we want to verify that required executables are available on the system. We currently call an executable's version subcommand, but the invocation varies and it's possible that an implementation may exit nonzero even if the program is available.

Instead of relying on the behavior of various `version` subcommands, simply check that the executable exists in the system `PATH`.

Addresses https://github.com/artsy/hokusai/issues/82