### PR TITLE
Report error when kubectl unavailable during context check

### DIFF
--- a/hokusai/commands/check.py
+++ b/hokusai/commands/check.py
@@ -94,16 +94,20 @@ def check():
     return_code += 1
 
   for context in ['staging', 'production']:
-    if context in Kubectl('staging').contexts():
-      check_ok("kubectl context '%s'" % context)
-    else:
-      check_err("kubectl context '%s'" % context)
-      return_code += 1
+    try:
+      if context in Kubectl('staging').contexts():
+        check_ok("kubectl context '%s'" % context)
+      else:
+        check_err("kubectl context '%s'" % context)
+        return_code += 1
 
-    if os.path.isfile(os.path.join(os.getcwd(), "hokusai/%s.yml" % context)):
-      check_ok("./hokusai/%s.yml" % context)
-    else:
-      check_err("./hokusai/%s.yml" % context)
+      if os.path.isfile(os.path.join(os.getcwd(), "hokusai/%s.yml" % context)):
+        check_ok("./hokusai/%s.yml" % context)
+      else:
+        check_err("./hokusai/%s.yml" % context)
+        return_code += 1
+    except CalledProcessError:
+      check_err('%s context' % context)
       return_code += 1
 
   return return_code


### PR DESCRIPTION
During checks of production and staging Kubernetes contexts, report an error when the `kubectl` executable is unavailable.

These checks currently raise an exception when `kubectl` is unavailable:

```
ERROR: Command 'kubectl config view' returned non-zero exit status 127
```

We can instead display errors to the user:

```
staging context not found
production context not found
```