### PR TITLE
Stub AWS session in test

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,13 +1,15 @@
 import os
 import unittest
+import boto3
 
 from hokusai.lib.common import shout
 from hokusai.lib import config
 
 config.HOKUSAI_CONFIG_FILE = os.path.join(os.getcwd(), 'test', 'fixtures', 'config.yml')
 
+boto3.setup_default_session(aws_access_key_id='foo', aws_secret_access_key='bar')
+
 if os.environ.get('DEBUG') is '1':
-  import boto3
   boto3.set_stream_logger(name='botocore')
 
 class HokusaiTestCase(unittest.TestCase):


### PR DESCRIPTION
Problem:

Before this change, boto was looking for AWS creds specified via ENV
variables or a valid ~/.aws/credentials file. This was undocumented and
complexity to setting up a clean developer / CI environment.

Solution:

Directly set the `boto3.setup_default_session` in test/__init__.py,
ensuring that any downstream boto calls would use this session.