### PR TITLE
Add Circle CI 2.0 configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,20 +8,24 @@ jobs:
 
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "requirements.txt" }}
-          - v1-dependencies-
+          - v1-pip-cache-{{ checksum "requirements.txt" }}
+          - v1-pip-cache-
 
       - run:
           name: Install dependencies
           command: |
-            sudo pip install -r requirements.txt
+            mkdir -p ./venv
+            virtualenv ./venv
+            . venv/bin/activate
+            pip install -r requirements.txt
 
       - save_cache:
           paths:
             - ./venv
-          key: v1-dependencies-{{ checksum "requirements.txt" }}
+          key: v1-pip-cache-{{ checksum "requirements.txt" }}
 
       - run:
           name: Run tests
           command: |
+            . venv/bin/activate
             python -m unittest discover test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,27 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/python:2
+    steps:
+      - checkout
+
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "requirements.txt" }}
+          - v1-dependencies-
+
+      - run:
+          name: Install dependencies
+          command: |
+            sudo pip install -r requirements.txt
+
+      - save_cache:
+          paths:
+            - ./venv
+          key: v1-dependencies-{{ checksum "requirements.txt" }}
+
+      - run:
+          name: Run tests
+          command: |
+            python -m unittest discover test


### PR DESCRIPTION
This commit sets up a base Circle CI 2.0 configuration that installs
Python dependencies via Pip and runs the test suite.

It uses the docker executor with the `circleci/python:2` docker image.

Addresses https://github.com/artsy/hokusai/issues/96
Depends on https://github.com/artsy/hokusai/pull/97