### PR TITLE
Release version/latest binaries for release branch CI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,8 +67,14 @@ workflows:
   version: 2
   build_deploy:
     jobs:
-      - test_linux
-      - test_macos
+      - test_linux:
+          filters:
+            branches:
+              ignore: release
+      - test_macos:
+          filters:
+            branches:
+              ignore: release
       - release_head_linux:
           requires:
             - test_linux
@@ -88,16 +94,12 @@ workflows:
             - test_linux
             - test_macos
           filters:
-            tags:
-              only: /^v.*/
             branches:
-              ignore: /.*/
+              only: release
       - release_version_macos:
           requires:
             - test_linux
             - test_macos
           filters:
-            tags:
-              only: /^v.*/
             branches:
-              ignore: /.*/
+              only: release


### PR DESCRIPTION
We use this release strategy for many other projects at Artsy and I think it makes sense to use here as well.

Feature development continues to be merged into the `master` branch triggering releases of `hokusai-head-${platform}-${arch}` binaries.

To release a new version, bump the version in `hokusai/VERSION` and open up a PR against the `release` branch.

Once merged, CI will build version/latest binaries and push them to S3.