### PR TITLE
Don't require `test_*` workflow jobs during release build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,23 +119,14 @@ workflows:
             branches:
               only: master
       - release_version_linux:
-          requires:
-            - test_linux
-            - test_macos
           filters:
             branches:
               only: release
       - release_version_macos:
-          requires:
-            - test_linux
-            - test_macos
           filters:
             branches:
               only: release
       - release_pip:
-          requires:
-            - test_linux
-            - test_macos
           filters:
             branches:
               only: release


### PR DESCRIPTION
This fixes a Circle CI workflow dependency issue in which release jobs depended on test jobs which are configured to ignore `release` branch commits. This prevented the workflow from running at all for any `release` branch commit.