### PR TITLE
remove requires_* steps from release_dockerhub in circleci workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,9 +131,6 @@ workflows:
             branches:
               only: release
       - release_dockerhub:
-          requires:
-            - test_linux
-            - test_macos
           filters:
             branches:
               only: release


### PR DESCRIPTION
Rebased from `upstream/master` - drop requires as they were removed in 1829ca73bb0c7f343dd9312c1236cd64a4fdc4fa
