### PR TITLE
Install `curl` during release_dockerhub job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
       - checkout
       - setup_remote_docker
       - run: echo "$DOCKERHUB_PASSWORD" | docker login --username "$DOCKERHUB_USERNAME" --password-stdin
-      - run: apk add make
+      - run: apk add curl make
       - run: make image
       - run: make publish-dockerhub
 


### PR DESCRIPTION
`curl` is used to check if a docker image has already been pushed to Docker Hub with the provided version number. If so, it will halt the process.

It's worth noting that I also had to add the Docker Hub user configured for use in Circle CI builds as a collaborator with write access to the artsy/hokusai Docker Hub repository.