### PR TITLE
lock docker-compose version to 1.22.0 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM python:2-alpine
 RUN apk add docker
 
 # Install Docker Compose
-RUN pip install docker-compose
+RUN pip install docker-compose==1.22.0
 
 # Install Git
 RUN apk add git


### PR DESCRIPTION
Found out that docker-compose version 1.23.0 [introduces](https://docs.docker.com/release-notes/docker-compose/) a randomly-generated hex string appended to all container names, which breaks `hokusai test` as it calls `docker wait {name of the container}` where it assumes the name of the test container to be `hokusai_{project_name}_1` - this pattern always felt shaky and indeed it's not going to work going forward.  But until we can figure out how to reliably resolve the "primary" container in test mode, pin docker-compose to version 1.22.0 so we don't break CI builds as happened [here](https://circleci.com/gh/artsy/osmosis/227).

I already ran `make image` and `make publish-dockerhub` locally so as to unblock CI builds that pull the latest Hokusai image.