### PR TITLE
add openssh client to Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ RUN apk add docker
 # Install Docker Compose
 RUN pip install docker-compose==1.22.0
 
-# Install Git
-RUN apk add git
+# Install Git and Ssh
+RUN apk add git openssh
 
 ADD . /src
 WORKDIR /src


### PR DESCRIPTION
Another missing dependency in Alpine... we need the openssh client so git can push with it to remotes

Already hot-pushed new tags