### PR TITLE
Style: Fix formatting of example repo link in docs

### DIFF
--- a/docs/Configuration_Options.md
+++ b/docs/Configuration_Options.md
@@ -23,7 +23,7 @@ When running `hokusai setup` the following files are created:
     - `project-name`: <string> (required) - The project name
     - `pre-deploy`: <string> (optional) - A pre-deploy hook - useful to enforce migrations
     - `post-deploy`: <string> (optional) - A post-deploy hook
-    - `git-remote`: <string> (optional) - Push deployment tags to git remote when invoking the `hoksuai [staging|production] deploy` or the `hoksuai pipeline promote` commands.  Can either be a local alias like 'origin' or a URI like 'git@github.com:artsy/hokusai.git'.  Bound to the `--git-remote` option for these commands.
+    - `git-remote`: <string> (optional) - Push deployment tags to git remote when invoking the `hoksuai [staging|production] deploy` or the `hoksuai pipeline promote` commands.  Can either be a local alias like 'origin' or a URI like `git@github.com:artsy/hokusai.git`.  Bound to the `--git-remote` option for these commands.
     - `run-tty`: <boolean> (optional) - Attach the terminal to your shell session when invoking `hokusai [staging|production] run`.  Bound to the `--tty` option for this command, overridden by the `HOKUSAI_RUN_TTY` env var.
 
 * `./hokusai/build.yml` is the base docker-compose Yaml file referenced when running `hokusai local` commands. It should contain a single service for the project, `build` referencing the root project directory, and any build args (i.e.) host environment variables to inject into the Dockerfile.


### PR DESCRIPTION
[skip ci]

Before this change, Github was rendering a mailto link, which was unintended.