### PR TITLE
Fix deployment targets and introduce build hooks - update gitcompare

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ VERSION ?= $(shell cat hokusai/VERSION)
 
 dependencies:
 	pip install --requirement requirements.txt --quiet
-	pip install --quiet pyinstaller
+	pip install --quiet pyinstaller==3.3.1
 
 test:
 	python -m unittest discover test

--- a/docs/Configuration_Options.md
+++ b/docs/Configuration_Options.md
@@ -22,8 +22,10 @@ When running `hokusai setup` the following files are created:
 
     - `project-name`: <string> (required) - The project name
     - `hokusai-required-version`: <string> (optional) - A [PEP-440 version specifier string](https://www.python.org/dev/peps/pep-0440/#version-specifiers).  Hokusai will raise an error when running commands if its current version does not satisfy these version specifications.  For example: `~=0.5`, `==0.5.1`, `>=0.4.0,<0.4.6`, `!=0.1.*` are all valid version specifier strings
+    - `pre-build`: <string> (optional) - A pre-build hook - useful to inject dynamic environment variables into the build, for example: `export COMMIT_HASH=$(git rev-parse HEAD)`
+    - `post-build`: <string> (optional) - A post-build hook - useful for image post-processing
     - `pre-deploy`: <string> (optional) - A pre-deploy hook - useful to enforce migrations
-    - `post-deploy`: <string> (optional) - A post-deploy hook
+    - `post-deploy`: <string> (optional) - A post-deploy hook - useful for deploy notifications
     - `git-remote`: <string> (optional) - Push deployment tags to git remote when invoking the `hokusai [staging|production] deploy` or the `hokusai pipeline promote` commands.  Can either be a local alias like 'origin' or a URI like `git@github.com:artsy/hokusai.git`.  Bound to the `--git-remote` option for these commands.
     - `run-tty`: <boolean> (optional) - Attach the terminal to your shell session when invoking `hokusai [staging|production] run`.  Bound to the `--tty` option for this command, overridden by the `HOKUSAI_RUN_TTY` env var.
 

--- a/hokusai/cli/pipeline.py
+++ b/hokusai/cli/pipeline.py
@@ -29,14 +29,14 @@ def gitlog(verbose):
   hokusai.gitlog()
 
 @pipeline.command(context_settings=CONTEXT_SETTINGS)
+@click.option('--org-name', type=click.STRING, required=True, help='Name of the (github) organization')
 @click.option('--git-compare-link', type=click.STRING, help='Python formatted string input that gets org name, project name and 2 diff sha1s, example: https://github.com/%s/%s/compare/%s...%s', default="https://github.com/%s/%s/compare/%s...%s")
-@click.option('--org-name', type=click.STRING, help='Run a migration before deploying')
 @click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
-def gitcompare(git_compare_link, org_name, verbose):
+def gitcompare(org_name, git_compare_link, verbose):
   """Prints a git compare link between the tag currently deployed on production
   and the tag currently deployed on staging"""
   set_verbosity(verbose)
-  hokusai.gitcompare(git_compare_link, org_name)
+  hokusai.gitcompare(org_name, git_compare_link)
 
 
 @pipeline.command(context_settings=CONTEXT_SETTINGS)

--- a/hokusai/commands/build.py
+++ b/hokusai/commands/build.py
@@ -1,18 +1,8 @@
 import os
 
 from hokusai.lib.command import command
-from hokusai.lib.config import config
-from hokusai.lib.common import shout
-from hokusai.lib.exceptions import HokusaiError
+from hokusai.services.docker import Docker
 
 @command()
 def build():
-  docker_compose_yml = os.path.join(os.getcwd(), 'hokusai/build.yml')
-  legacy_docker_compose_yml = os.path.join(os.getcwd(), 'hokusai/common.yml')
-  if not os.path.isfile(docker_compose_yml) and not os.path.isfile(legacy_docker_compose_yml):
-    raise HokusaiError("Yaml files %s / %s do not exist." % (docker_compose_yml, legacy_docker_compose_yml))
-
-  if os.path.isfile(docker_compose_yml):
-    shout("docker-compose -f %s -p hokusai build" % docker_compose_yml, print_output=True)
-  if os.path.isfile(legacy_docker_compose_yml):
-    shout("docker-compose -f %s -p hokusai build" % legacy_docker_compose_yml, print_output=True)
+  Docker().build()

--- a/hokusai/commands/gitcompare.py
+++ b/hokusai/commands/gitcompare.py
@@ -5,7 +5,7 @@ from hokusai.services.deployment import Deployment
 from hokusai.services.ecr import ECR
 
 @command()
-def gitcompare(git_compare_link, org_name):
+def gitcompare(org_name, git_compare_link):
   ecr = ECR()
 
   staging_deployment = Deployment('staging')

--- a/hokusai/commands/push.py
+++ b/hokusai/commands/push.py
@@ -5,6 +5,7 @@ from hokusai.lib.config import config
 from hokusai.services.ecr import ECR
 from hokusai.lib.common import print_green, shout
 from hokusai.lib.exceptions import HokusaiError
+from hokusai.services.docker import Docker
 
 @command()
 def push(tag, build, force, overwrite, skip_latest=False):
@@ -26,14 +27,7 @@ def push(tag, build, force, overwrite, skip_latest=False):
     raise HokusaiError("Tag %s already exists in registry.  Aborting." % tag)
 
   if build:
-    docker_compose_yml = os.path.join(os.getcwd(), 'hokusai/build.yml')
-    legacy_docker_compose_yml = os.path.join(os.getcwd(), 'hokusai/common.yml')
-    if not os.path.isfile(docker_compose_yml) and not os.path.isfile(legacy_docker_compose_yml):
-      raise HokusaiError("Yaml files %s / %s do not exist." % (docker_compose_yml, legacy_docker_compose_yml))
-    if os.path.isfile(docker_compose_yml):
-      shout("docker-compose -f %s -p hokusai build" % docker_compose_yml, print_output=True)
-    if os.path.isfile(legacy_docker_compose_yml):
-      shout("docker-compose -f %s -p hokusai build" % legacy_docker_compose_yml, print_output=True)
+    Docker().build()
 
   build_tag = "hokusai_%s:latest" % config.project_name
 

--- a/hokusai/lib/config.py
+++ b/hokusai/lib/config.py
@@ -106,6 +106,14 @@ class HokusaiConfig(object):
     return self.get('git-remote')
 
   @property
+  def pre_build(self):
+    return self.get('pre-build')
+
+  @property
+  def post_build(self):
+    return self.get('post-build')
+
+  @property
   def run_tty(self):
     return self.get('run-tty', default=False, use_env=True, _type=bool)
 

--- a/hokusai/services/deployment.py
+++ b/hokusai/services/deployment.py
@@ -56,9 +56,8 @@ class Deployment(object):
 
     deployment_timestamp = datetime.datetime.utcnow().strftime("%s%f")
     for deployment in self.cache:
-      containers = deployment['spec']['template']['spec']['containers']
-      container_names = [container['name'] for container in containers]
-      deployment_targets = [{"name": name, "image": "%s:%s" % (self.ecr.project_repo, tag)} for name in container_names]
+      containers = [(container['name'], container['image']) for container in deployment['spec']['template']['spec']['containers']]
+      deployment_targets = [{"name": name, "image": "%s:%s" % (self.ecr.project_repo, tag)} for name, image in containers if self.ecr.project_repo in image]
       patch = {
         "spec": {
           "template": {

--- a/hokusai/services/docker.py
+++ b/hokusai/services/docker.py
@@ -1,0 +1,25 @@
+import os
+
+from hokusai.lib.config import config
+from hokusai.lib.common import shout
+from hokusai.lib.exceptions import HokusaiError
+
+class Docker(object):
+  def build(self):
+    docker_compose_yml = os.path.join(os.getcwd(), 'hokusai/build.yml')
+    legacy_docker_compose_yml = os.path.join(os.getcwd(), 'hokusai/common.yml')
+    if not os.path.isfile(docker_compose_yml) and not os.path.isfile(legacy_docker_compose_yml):
+      raise HokusaiError("Yaml files %s / %s do not exist." % (docker_compose_yml, legacy_docker_compose_yml))
+
+    if os.path.isfile(docker_compose_yml):
+      build_command = "docker-compose -f %s -p hokusai build" % docker_compose_yml
+    if os.path.isfile(legacy_docker_compose_yml):
+      build_command = "docker-compose -f %s -p hokusai build" % legacy_docker_compose_yml
+
+    if config.pre_build:
+      build_command = "%s && %s" % (config.pre_build, build_command)
+
+    if config.post_build:
+      build_command = "%s && %s" % (build_command, config.post_build)
+
+    shout(build_command, print_output=True)

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -1,7 +1,5 @@
 import os
 
-from mock import patch
-
 from hokusai.lib import config
 from hokusai.lib.exceptions import HokusaiError
 


### PR DESCRIPTION
- Fix overwriting a deployment's target if the repo is not the project's (so we can run Nginx or other sidecar containers and Hokusai won't overwrite these deployment images)
- Introduces pre-build and post-build hooks for injecting, say the commit hash like we do in Force and Positron, and doing any Docker image postprocessing (have played around with [squashing images](https://github.com/jwilder/docker-squash))
- Fixes documentation and and refactor a bit the `pipeline gitcompare` command 