### PR TITLE
[deploy] Skip git push hooks when pushing tags.

### DIFF
--- a/hokusai/services/deployment.py
+++ b/hokusai/services/deployment.py
@@ -46,7 +46,7 @@ class Deployment(object):
         print_green("Pushing deployment tags to %s..." % remote)
         shout("git tag -f %s" % self.context, print_output=True)
         shout("git tag %s" % deployment_tag, print_output=True)
-        shout("git push --force %s --tags" % remote, print_output=True)
+        shout("git push --force %s --tags --no-verify" % remote, print_output=True)
 
     if config.pre_deploy is not None:
       print_green("Running pre-deploy hook '%s'..." % config.pre_deploy)


### PR DESCRIPTION
⚠️ I made this edit from the GH UI as I didn’t find any tests for this, but please let me know if you want me to test things otherwise.


This was failing deploys for me on a checkout of a repo where I had changes that led to the push hook failing.

I don’t think we ever need to care about push hooks when pushing tags, especially not those for commits that already exist on the remote.