### PR TITLE
Adds --no-verify to tag push

### DIFF
--- a/hokusai/services/deployment.py
+++ b/hokusai/services/deployment.py
@@ -44,7 +44,8 @@ class Deployment(object):
       remote = git_remote or config.git_remote
       if remote is not None:
         print_green("Pushing deployment tags to %s..." % remote)
-        shout("git tag -f %s" % self.context, print_output=True)
+        shout("git push -f --no-verify %s refs/tags/%s" % (remote, self.context), print_output=True)
+        shout("git push --no-verify %s refs/tags/%s" % (remote, deployment_tag), print_output=True)
         shout("git tag %s" % deployment_tag, print_output=True)
         shout("git push --force %s --tags --no-verify" % remote, print_output=True)
 

--- a/hokusai/services/deployment.py
+++ b/hokusai/services/deployment.py
@@ -46,7 +46,7 @@ class Deployment(object):
         print_green("Pushing deployment tags to %s..." % remote)
         shout("git tag -f %s" % self.context, print_output=True)
         shout("git tag %s" % deployment_tag, print_output=True)
-        shout("git push --force %s --tags" % remote, print_output=True)
+        shout("git push --force %s --tags --no-verify" % remote, print_output=True)
 
     if config.pre_deploy is not None:
       print_green("Running pre-deploy hook '%s'..." % config.pre_deploy)


### PR DESCRIPTION
I ran into this when trying to promote metaphysics (the pre-commit hook failed because my `node_modules` were out of date). I'd have thought that `--force` would bypass that, but I guess not!