### PR TITLE
Deployment timeout options, registry images output options, addition logs options and prettier printing

### DIFF
--- a/docs/Command_Reference.md
+++ b/docs/Command_Reference.md
@@ -115,7 +115,7 @@ When running `hoksuai [staging|production] deploy` or `hokusai pipeline promote`
 2) Attempts to run a `--migration` command, if specified.  If this command fails, Hokusai exits with the return code of this command.
 3) Attempts to run a `pre-deploy` hook, if specified.  If this command fails, Hokusai exits with the return code of this command.
 4) Patches the deployment's containers that run the application image (those that contain the project's repository in their `image` field) with the new deeployment tag.
-5) Waits for the deployment to roll out.  If the deployment does not specify a `progressDeadlineSeconds` it could hang indefinitely.  If the deployment fails to rollout, Hokusai runs a `kubectl rollout undo` to roll all deployments back automatically, then exits with `1`.
+5) Waits for the deployment to roll out.  If the deployment fails to rollout withing the provided `--timeout` (default 10 minutes), Hokusai runs a `kubectl rollout undo` to roll all deployments back automatically, then exits with `1`.
 6) Attempts to run a `post-deploy` hook, if defined.  If it fails, Hokusai prints a warning and continues.
 7) Attempts to push deployment tags to the project registry.  If it fails, Hokusai prints a warning and continues.
 8) Attempts to push deployment tags to Git if `git-remote` is defined in the project's config.  If it fails, Hokusai prints a warning and continues.

--- a/hokusai/cli/pipeline.py
+++ b/hokusai/cli/pipeline.py
@@ -43,10 +43,11 @@ def gitcompare(org_name, git_compare_link, verbose):
 @click.option('--migration', type=click.STRING, help='Run a migration before deploying')
 @click.option('--constraint', type=click.STRING, multiple=True, help='Constrain migration and deploy hooks to run on nodes matching labels in the form of "key=value"')
 @click.option('--git-remote', type=click.STRING, help='Push deployment tags to git remote')
+@click.option('-t', '--timeout', type=click.INT, default=600, help="Timeout deployment rollout after N seconds (default 600)")
 @click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
-def promote(migration, constraint, git_remote, verbose):
+def promote(migration, constraint, git_remote, timeout, verbose):
   """Update the project's deployment(s) on production with the image tag
   currently deployed on staging and update the production tag
   to reference the same image"""
   set_verbosity(verbose)
-  hokusai.promote(migration, constraint, git_remote)
+  hokusai.promote(migration, constraint, git_remote, timeout)

--- a/hokusai/cli/production.py
+++ b/hokusai/cli/production.py
@@ -78,13 +78,14 @@ def logs(timestamps, follow, tail, verbose):
 @click.option('--migration', type=click.STRING, help='Run a migration before deploying')
 @click.option('--constraint', type=click.STRING, multiple=True, help='Constrain migration and deploy hooks to run on nodes matching labels in the form of "key=value"')
 @click.option('--git-remote', type=click.STRING, help='Push deployment tags to git remote')
+@click.option('-t', '--timeout', type=click.INT, default=600, help="Timeout deployment rollout after N seconds (default 600)")
 @click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
-def deploy(tag, migration, constraint, git_remote, verbose):
+def deploy(tag, migration, constraint, git_remote, timeout, verbose):
   """Update the project's deployment(s) to reference
   the given image tag and update the tag production
   to reference the same image"""
   set_verbosity(verbose)
-  hokusai.update(KUBE_CONTEXT, tag, migration, constraint, git_remote)
+  hokusai.update(KUBE_CONTEXT, tag, migration, constraint, git_remote, timeout)
 
 
 @production.command(context_settings=CONTEXT_SETTINGS)

--- a/hokusai/cli/production.py
+++ b/hokusai/cli/production.py
@@ -68,11 +68,12 @@ def run(command, tty, tag, env, constraint, verbose):
 @click.option('-f', '--follow', type=click.BOOL, is_flag=True, help='Follow logs')
 @click.option('-t', '--tail', type=click.INT, help="Number of lines of recent logs to display")
 @click.option('-p', '--previous', type=click.BOOL, is_flag=True, help='Get from the previous run of the Pod container(s)')
+@click.option('-l', '--label', type=click.STRING, multiple=True, help='Filter pods by additional label selectors in the form of "key=value"')
 @click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
-def logs(timestamps, follow, tail, previous, verbose):
+def logs(timestamps, follow, tail, previous, label, verbose):
   """Get container logs"""
   set_verbosity(verbose)
-  hokusai.logs(KUBE_CONTEXT, timestamps, follow, tail, previous)
+  hokusai.logs(KUBE_CONTEXT, timestamps, follow, tail, previous, label)
 
 @production.command(context_settings=CONTEXT_SETTINGS)
 @click.argument('tag', type=click.STRING)

--- a/hokusai/cli/production.py
+++ b/hokusai/cli/production.py
@@ -67,11 +67,12 @@ def run(command, tty, tag, env, constraint, verbose):
 @click.option('-s', '--timestamps', type=click.BOOL, is_flag=True, help='Include timestamps')
 @click.option('-f', '--follow', type=click.BOOL, is_flag=True, help='Follow logs')
 @click.option('-t', '--tail', type=click.INT, help="Number of lines of recent logs to display")
+@click.option('-p', '--previous', type=click.BOOL, is_flag=True, help='Get from the previous run of the Pod container(s)')
 @click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
-def logs(timestamps, follow, tail, verbose):
+def logs(timestamps, follow, tail, previous, verbose):
   """Get container logs"""
   set_verbosity(verbose)
-  hokusai.logs(KUBE_CONTEXT, timestamps, follow, tail)
+  hokusai.logs(KUBE_CONTEXT, timestamps, follow, tail, previous)
 
 @production.command(context_settings=CONTEXT_SETTINGS)
 @click.argument('tag', type=click.STRING)

--- a/hokusai/cli/registry.py
+++ b/hokusai/cli/registry.py
@@ -25,8 +25,11 @@ def push(tag, build, force, overwrite, skip_latest, verbose):
 
 
 @registry.command(context_settings=CONTEXT_SETTINGS)
+@click.option('-r', '--reverse-sort', type=click.BOOL, is_flag=True, help='Sort oldest to latest')
+@click.option('-l', '--limit', type=click.INT, default=20, help="Limit output to N images")
+@click.option('-f', '--filter-tags', type=click.STRING, help='Filter images that have at least one tag matching the provided string')
 @click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
-def images(verbose):
+def images(reverse_sort, limit, filter_tags, verbose):
   """Print images and tags in the project's registry"""
   set_verbosity(verbose)
-  hokusai.images()
+  hokusai.images(reverse_sort, limit, filter_tags)

--- a/hokusai/cli/review_app.py
+++ b/hokusai/cli/review_app.py
@@ -95,11 +95,13 @@ def logs(app_name, timestamps, follow, tail, verbose):
 @click.option('--migration', type=click.STRING, help='Run a migration before deploying')
 @click.option('--constraint', type=click.STRING, multiple=True, help='Constrain migration and deploy hooks to run on nodes matching labels in the form of "key=value"')
 @click.option('--git-remote', type=click.STRING, help='Push deployment tags to git remote')
+@click.option('-t', '--timeout', type=click.INT, default=600, help="Timeout deployment rollout after N seconds (default 600)")
 @click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
-def deploy(app_name, tag, migration, constraint, git_remote, verbose):
+def deploy(app_name, tag, migration, constraint, git_remote, timeout, verbose):
   """Update the project's deployment(s) to reference the given image tag"""
   set_verbosity(verbose)
-  hokusai.update(KUBE_CONTEXT, tag, migration, constraint, git_remote, namespace=clean_string(app_name), resolve_tag_sha1=False)
+  hokusai.update(KUBE_CONTEXT, tag, migration, constraint, git_remote, timeout,
+                  namespace=clean_string(app_name), resolve_tag_sha1=False)
 
 
 @review_app.command(context_settings=CONTEXT_SETTINGS)

--- a/hokusai/cli/review_app.py
+++ b/hokusai/cli/review_app.py
@@ -83,11 +83,12 @@ def run(app_name, command, tty, tag, env, constraint, verbose):
 @click.option('-f', '--follow', type=click.BOOL, is_flag=True, help='Follow logs')
 @click.option('-t', '--tail', type=click.INT, help="Number of lines of recent logs to display")
 @click.option('-p', '--previous', type=click.BOOL, is_flag=True, help='Get from the previous run of the Pod container(s)')
+@click.option('-l', '--label', type=click.STRING, multiple=True, help='Filter pods by additional label selectors in the form of "key=value"')
 @click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
-def logs(app_name, timestamps, follow, tail, previous, verbose):
+def logs(app_name, timestamps, follow, tail, previous, label, verbose):
   """Get container logs"""
   set_verbosity(verbose)
-  hokusai.logs(KUBE_CONTEXT, timestamps, follow, tail, previous, namespace=clean_string(app_name))
+  hokusai.logs(KUBE_CONTEXT, timestamps, follow, tail, previous, label, namespace=clean_string(app_name))
 
 
 @review_app.command(context_settings=CONTEXT_SETTINGS)

--- a/hokusai/cli/review_app.py
+++ b/hokusai/cli/review_app.py
@@ -82,11 +82,12 @@ def run(app_name, command, tty, tag, env, constraint, verbose):
 @click.option('-s', '--timestamps', type=click.BOOL, is_flag=True, help='Include timestamps')
 @click.option('-f', '--follow', type=click.BOOL, is_flag=True, help='Follow logs')
 @click.option('-t', '--tail', type=click.INT, help="Number of lines of recent logs to display")
+@click.option('-p', '--previous', type=click.BOOL, is_flag=True, help='Get from the previous run of the Pod container(s)')
 @click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
-def logs(app_name, timestamps, follow, tail, verbose):
+def logs(app_name, timestamps, follow, tail, previous, verbose):
   """Get container logs"""
   set_verbosity(verbose)
-  hokusai.logs(KUBE_CONTEXT, timestamps, follow, tail, namespace=clean_string(app_name))
+  hokusai.logs(KUBE_CONTEXT, timestamps, follow, tail, previous, namespace=clean_string(app_name))
 
 
 @review_app.command(context_settings=CONTEXT_SETTINGS)

--- a/hokusai/cli/staging.py
+++ b/hokusai/cli/staging.py
@@ -68,11 +68,12 @@ def run(command, tty, tag, env, constraint, verbose):
 @click.option('-f', '--follow', type=click.BOOL, is_flag=True, help='Follow logs')
 @click.option('-t', '--tail', type=click.INT, help="Number of lines of recent logs to display")
 @click.option('-p', '--previous', type=click.BOOL, is_flag=True, help='Get from the previous run of the Pod container(s)')
+@click.option('-l', '--label', type=click.STRING, multiple=True, help='Filter pods by additional label selectors in the form of "key=value"')
 @click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
-def logs(timestamps, follow, tail, previous, verbose):
+def logs(timestamps, follow, tail, previous, label, verbose):
   """Get container logs"""
   set_verbosity(verbose)
-  hokusai.logs(KUBE_CONTEXT, timestamps, follow, tail, previous)
+  hokusai.logs(KUBE_CONTEXT, timestamps, follow, tail, previous, label)
 
 @staging.command(context_settings=CONTEXT_SETTINGS)
 @click.argument('tag', type=click.STRING)

--- a/hokusai/cli/staging.py
+++ b/hokusai/cli/staging.py
@@ -78,13 +78,14 @@ def logs(timestamps, follow, tail, verbose):
 @click.option('--migration', type=click.STRING, help='Run a migration before deploying')
 @click.option('--constraint', type=click.STRING, multiple=True, help='Constrain migration and deploy hooks to run on nodes matching labels in the form of "key=value"')
 @click.option('--git-remote', type=click.STRING, help='Push deployment tags to git remote')
+@click.option('-t', '--timeout', type=click.INT, default=600, help="Timeout deployment rollout after N seconds (default 600)")
 @click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
-def deploy(tag, migration, constraint, git_remote, verbose):
+def deploy(tag, migration, constraint, git_remote, timeout, verbose):
   """Update the project's deployment(s) to reference
   the given image tag and update the tag staging
   to reference the same image"""
   set_verbosity(verbose)
-  hokusai.update(KUBE_CONTEXT, tag, migration, constraint, git_remote)
+  hokusai.update(KUBE_CONTEXT, tag, migration, constraint, git_remote, timeout)
 
 
 @staging.command(context_settings=CONTEXT_SETTINGS)

--- a/hokusai/cli/staging.py
+++ b/hokusai/cli/staging.py
@@ -67,11 +67,12 @@ def run(command, tty, tag, env, constraint, verbose):
 @click.option('-s', '--timestamps', type=click.BOOL, is_flag=True, help='Include timestamps')
 @click.option('-f', '--follow', type=click.BOOL, is_flag=True, help='Follow logs')
 @click.option('-t', '--tail', type=click.INT, help="Number of lines of recent logs to display")
+@click.option('-p', '--previous', type=click.BOOL, is_flag=True, help='Get from the previous run of the Pod container(s)')
 @click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
-def logs(timestamps, follow, tail, verbose):
+def logs(timestamps, follow, tail, previous, verbose):
   """Get container logs"""
   set_verbosity(verbose)
-  hokusai.logs(KUBE_CONTEXT, timestamps, follow, tail)
+  hokusai.logs(KUBE_CONTEXT, timestamps, follow, tail, previous)
 
 @staging.command(context_settings=CONTEXT_SETTINGS)
 @click.argument('tag', type=click.STRING)

--- a/hokusai/commands/configure.py
+++ b/hokusai/commands/configure.py
@@ -15,12 +15,12 @@ def configure(kubectl_version, bucket_name, key_name, config_file, platform, ins
   if not ((bucket_name and key_name) or config_file):
     raise HokusaiError("Must define bucket_name and key_name or config_file")
 
-  print_green("Downloading and installing kubectl...")
+  print_green("Downloading and installing kubectl...", newline_before=True, newline_after=True)
   urllib.urlretrieve("https://storage.googleapis.com/kubernetes-release/release/v%s/bin/%s/amd64/kubectl" % (kubectl_version, platform), os.path.join('/tmp', 'kubectl'))
   os.chmod(os.path.join('/tmp', 'kubectl'), 0755)
   shutil.move(os.path.join('/tmp', 'kubectl'), os.path.join(install_to, 'kubectl'))
 
-  print_green("Configuring kubectl...")
+  print_green("Configuring kubectl...", newline_after=True)
   if not os.path.isdir(install_config_to):
     mkpath(install_config_to)
 

--- a/hokusai/commands/configure.py
+++ b/hokusai/commands/configure.py
@@ -1,6 +1,7 @@
 import os
 import urllib
 import shutil
+import tempfile
 
 from distutils.dir_util import mkpath
 
@@ -16,9 +17,11 @@ def configure(kubectl_version, bucket_name, key_name, config_file, platform, ins
     raise HokusaiError("Must define bucket_name and key_name or config_file")
 
   print_green("Downloading and installing kubectl...", newline_before=True, newline_after=True)
-  urllib.urlretrieve("https://storage.googleapis.com/kubernetes-release/release/v%s/bin/%s/amd64/kubectl" % (kubectl_version, platform), os.path.join('/tmp', 'kubectl'))
-  os.chmod(os.path.join('/tmp', 'kubectl'), 0755)
-  shutil.move(os.path.join('/tmp', 'kubectl'), os.path.join(install_to, 'kubectl'))
+  tmpdir = tempfile.mkdtemp()
+  urllib.urlretrieve("https://storage.googleapis.com/kubernetes-release/release/v%s/bin/%s/amd64/kubectl" % (kubectl_version, platform), os.path.join(tmpdir, 'kubectl'))
+  os.chmod(os.path.join(tmpdir, 'kubectl'), 0755)
+  shutil.move(os.path.join(tmpdir, 'kubectl'), os.path.join(install_to, 'kubectl'))
+  shutil.rmtree(tmpdir)
 
   print_green("Configuring kubectl...", newline_after=True)
   if not os.path.isdir(install_config_to):

--- a/hokusai/commands/deployment.py
+++ b/hokusai/commands/deployment.py
@@ -6,13 +6,13 @@ from hokusai.services.ecr import ECR
 from hokusai.lib.exceptions import HokusaiError
 
 @command()
-def update(context, tag, migration, constraint, git_remote, namespace=None, resolve_tag_sha1=True):
+def update(context, tag, migration, constraint, git_remote, timeout, namespace=None, resolve_tag_sha1=True):
   if migration is not None:
     print_green("Running migration '%s' on %s..." % (migration, context))
     return_code = CommandRunner(context, namespace=namespace).run(tag, migration, constraint=constraint, tty=False)
     if return_code:
       raise HokusaiError("Migration failed with return code %s" % return_code, return_code=return_code)
-  Deployment(context, namespace=namespace).update(tag, constraint, git_remote, resolve_tag_sha1=resolve_tag_sha1)
+  Deployment(context, namespace=namespace).update(tag, constraint, git_remote, timeout, resolve_tag_sha1=resolve_tag_sha1)
   print_green("Deployment updated to %s" % tag)
 
 
@@ -23,7 +23,7 @@ def refresh(context, deployment_name, namespace=None):
 
 
 @command()
-def promote(migration, constraint, git_remote):
+def promote(migration, constraint, git_remote, timeout):
   ecr = ECR()
 
   deploy_from = Deployment('staging')
@@ -40,5 +40,6 @@ def promote(migration, constraint, git_remote):
     return_code = CommandRunner('production').run(tag, migration, constraint=constraint, tty=False)
     if return_code:
       raise HokusaiError("Migration failed with return code %s" % return_code, return_code=return_code)
-  deploy_to = Deployment('production').update(tag, constraint, git_remote)
+
+  deploy_to = Deployment('production').update(tag, constraint, git_remote, timeout)
   print_green("Promoted staging to production at %s" % tag)

--- a/hokusai/commands/deployment.py
+++ b/hokusai/commands/deployment.py
@@ -8,7 +8,7 @@ from hokusai.lib.exceptions import HokusaiError
 @command()
 def update(context, tag, migration, constraint, git_remote, timeout, namespace=None, resolve_tag_sha1=True):
   if migration is not None:
-    print_green("Running migration '%s' on %s..." % (migration, context))
+    print_green("Running migration '%s' on %s..." % (migration, context), newline_after=True)
     return_code = CommandRunner(context, namespace=namespace).run(tag, migration, constraint=constraint, tty=False)
     if return_code:
       raise HokusaiError("Migration failed with return code %s" % return_code, return_code=return_code)
@@ -36,7 +36,7 @@ def promote(migration, constraint, git_remote, timeout):
     return 1
 
   if migration is not None:
-    print_green("Running migration '%s' on production..." % migration)
+    print_green("Running migration '%s' on production..." % migration, newline_after=True)
     return_code = CommandRunner('production').run(tag, migration, constraint=constraint, tty=False)
     if return_code:
       raise HokusaiError("Migration failed with return code %s" % return_code, return_code=return_code)

--- a/hokusai/commands/env.py
+++ b/hokusai/commands/env.py
@@ -1,7 +1,7 @@
 from hokusai.lib.config import config
 from hokusai.lib.command import command
 from hokusai.services.configmap import ConfigMap
-from hokusai.lib.common import print_green
+from hokusai.lib.common import print_green, print_smart
 from hokusai.lib.exceptions import HokusaiError
 
 @command()
@@ -25,10 +25,10 @@ def get_env(context, environment, namespace=None):
   if environment:
     for k, v in configmap.all():
       if k in environment:
-        print("%s=%s" % (k, v))
+        print_smart("%s=%s" % (k, v))
   else:
     for k, v in configmap.all():
-      print("%s=%s" % (k, v))
+      print_smart("%s=%s" % (k, v))
 
 
 @command()

--- a/hokusai/commands/images.py
+++ b/hokusai/commands/images.py
@@ -3,7 +3,7 @@ from operator import itemgetter
 from hokusai.lib.command import command
 from hokusai.services.ecr import ECR
 from hokusai.lib.config import config
-from hokusai.lib.common import print_green, print_yellow, shout
+from hokusai.lib.common import print_green, print_yellow, print_smart, shout
 
 @command()
 def images(reverse_sort, limit, filter_tags):
@@ -13,8 +13,7 @@ def images(reverse_sort, limit, filter_tags):
   if filter_tags:
     filtered_images = filter(lambda image: filter_tags in ', '.join(image['imageTags']), filtered_images)
 
-  print('')
-  print_green('Image Pushed At           | Image Tags')
+  print_green('Image Pushed At           | Image Tags', newline_before=True)
   print_green('----------------------------------------------------------')
 
   for image in filtered_images[:limit]:
@@ -25,8 +24,8 @@ def images(reverse_sort, limit, filter_tags):
     elif 'staging' in image['imageTags']:
       print_yellow(line)
     else:
-      print(line)
+      print_smart(line)
 
-  print('')
-  print_yellow("%d more images available" % (len(filtered_images) - len(filtered_images[:limit])))
+  print_yellow("%d more images available" % (len(filtered_images) - len(filtered_images[:limit])),
+                newline_before=True, newline_after=True)
 

--- a/hokusai/commands/images.py
+++ b/hokusai/commands/images.py
@@ -3,15 +3,30 @@ from operator import itemgetter
 from hokusai.lib.command import command
 from hokusai.services.ecr import ECR
 from hokusai.lib.config import config
-from hokusai.lib.common import print_green, shout
+from hokusai.lib.common import print_green, print_yellow, shout
 
 @command()
-def images():
+def images(reverse_sort, limit, filter_tags):
   images = ECR().get_images()
+  sorted_images = sorted(images, key=itemgetter('imagePushedAt'), reverse=not reverse_sort)
+  filtered_images = filter(lambda image: 'imageTags' in image.keys(), sorted_images)
+  if filter_tags:
+    filtered_images = filter(lambda image: filter_tags in ', '.join(image['imageTags']), filtered_images)
+
   print('')
   print_green('Image Pushed At           | Image Tags')
   print_green('----------------------------------------------------------')
-  for image in sorted(images, key=itemgetter('imagePushedAt'), reverse=True):
-    if 'imageTags' not in image.keys():
-      continue
-    print("%s | %s" % (image['imagePushedAt'], ', '.join(image['imageTags'])))
+
+  for image in filtered_images[:limit]:
+    image_tags = ', '.join(image['imageTags'])
+    line = "%s | %s" % (image['imagePushedAt'], image_tags)
+    if 'production' in image['imageTags']:
+      print_green(line)
+    elif 'staging' in image['imageTags']:
+      print_yellow(line)
+    else:
+      print(line)
+
+  print('')
+  print_yellow("%d more images available" % (len(filtered_images) - len(filtered_images[:limit])))
+

--- a/hokusai/commands/kubernetes.py
+++ b/hokusai/commands/kubernetes.py
@@ -73,18 +73,15 @@ def k8s_status(context, resources, pods, describe, top, namespace=None, yaml_fil
     kctl_cmd = "get"
     output = " -o wide"
   if resources:
-    print('')
-    print_green("Resources")
+    print_green("Resources", newline_before=True)
     print_green("===========")
     shout(kctl.command("%s -f %s%s" % (kctl_cmd, kubernetes_yml, output)), print_output=True)
   if pods:
-    print('')
-    print_green("Pods")
+    print_green("Pods", newline_before=True)
     print_green("===========")
     shout(kctl.command("%s pods --selector app=%s,layer=application%s" % (kctl_cmd, config.project_name, output)), print_output=True)
   if top:
-    print('')
-    print_green("Top Pods")
+    print_green("Top Pods", newline_before=True)
     print_green("===========")
     shout(kctl.command("top pods --selector app=%s,layer=application" % config.project_name), print_output=True)
 

--- a/hokusai/commands/logs.py
+++ b/hokusai/commands/logs.py
@@ -4,12 +4,14 @@ from hokusai.lib.common import shout, shout_concurrent
 from hokusai.services.kubectl import Kubectl
 
 @command()
-def logs(context, timestamps, follow, tail, namespace=None):
+def logs(context, timestamps, follow, tail, previous, namespace=None):
   kctl = Kubectl(context, namespace=namespace)
 
   opts = ''
   if timestamps:
     opts += ' --timestamps'
+  if previous:
+    opts += ' --previous'
   if follow or config.follow_logs:
     opts += ' --follow'
   if tail or config.tail_logs:

--- a/hokusai/commands/push.py
+++ b/hokusai/commands/push.py
@@ -33,10 +33,10 @@ def push(tag, build, force, overwrite, skip_latest=False):
 
   shout("docker tag %s %s:%s" % (build_tag, ecr.project_repo, tag))
   shout("docker push %s:%s" % (ecr.project_repo, tag), print_output=True)
-  print_green("Pushed %s to %s:%s" % (build_tag, ecr.project_repo, tag))
+  print_green("Pushed %s to %s:%s" % (build_tag, ecr.project_repo, tag), newline_after=True)
 
   if skip_latest: return
 
   shout("docker tag %s %s:%s" % (build_tag, ecr.project_repo, 'latest'))
   shout("docker push %s:%s" % (ecr.project_repo, 'latest'), print_output=True)
-  print_green("Pushed %s to %s:%s" % (build_tag, ecr.project_repo, 'latest'))
+  print_green("Pushed %s to %s:%s" % (build_tag, ecr.project_repo, 'latest'), newline_after=True)

--- a/hokusai/commands/test.py
+++ b/hokusai/commands/test.py
@@ -26,7 +26,7 @@ def test(build, cleanup):
   if build:
     Docker().build()
 
-  print_green("Starting test environment... Press Ctrl+C to stop.")
+  print_green("Starting test environment... Press Ctrl+C to stop.", newline_after=True)
   try:
     shout("docker-compose -f %s -p hokusai up%s" % (docker_compose_yml, opts), print_output=True)
     return_code = int(shout("docker wait hokusai_%s_1" % config.project_name))

--- a/hokusai/lib/common.py
+++ b/hokusai/lib/common.py
@@ -28,21 +28,28 @@ VERBOSE = False
 
 AWS_DEFAULT_REGION = 'us-east-1'
 
-def smart_str(s):
+def smart_str(s, newline_before=False, newline_after=False):
+  if newline_before:
+    s = '\n' + s
+  if newline_after:
+    s = s + '\n'
   if isinstance(s, unicode):
       return unicode(s).encode("utf-8")
   elif isinstance(s, int) or isinstance(s, float):
       return str(s)
   return s
 
-def print_green(msg):
-  cprint(smart_str(msg), 'green')
+def print_smart(msg, newline_before=False, newline_after=False):
+  print(smart_str(msg, newline_before, newline_after))
 
-def print_red(msg):
-  cprint(smart_str(msg), 'red')
+def print_green(msg, newline_before=False, newline_after=False):
+  cprint(smart_str(msg, newline_before, newline_after), 'green')
 
-def print_yellow(msg):
-  cprint(smart_str(msg), 'yellow')
+def print_red(msg, newline_before=False, newline_after=False):
+  cprint(smart_str(msg, newline_before, newline_after), 'red')
+
+def print_yellow(msg, newline_before=False, newline_after=False):
+  cprint(smart_str(msg, newline_before, newline_after), 'yellow')
 
 def set_verbosity(v):
   global VERBOSE
@@ -53,7 +60,7 @@ def get_verbosity():
   return VERBOSE
 
 def verbose(msg):
-  if VERBOSE: cprint("==> hokusai exec `%s`" % smart_str(msg), 'yellow')
+  if VERBOSE: print_yellow("==> hokusai exec `%s`" % msg, newline_before=True, newline_after=True)
   return msg
 
 

--- a/hokusai/lib/common.py
+++ b/hokusai/lib/common.py
@@ -60,7 +60,7 @@ def get_verbosity():
   return VERBOSE
 
 def verbose(msg):
-  if VERBOSE: print_yellow("==> hokusai exec `%s`" % msg, newline_before=True, newline_after=True)
+  if VERBOSE: print_yellow("==> hokusai exec `%s`" % msg, newline_after=True)
   return msg
 
 

--- a/hokusai/services/deployment.py
+++ b/hokusai/services/deployment.py
@@ -29,12 +29,12 @@ class Deployment(object):
         raise HokusaiError("Could not find a git SHA1 for tag %s.  Aborting." % tag)
 
     if self.namespace is None:
-      print_green("Deploying %s to %s..." % (tag, self.context))
+      print_green("Deploying %s to %s..." % (tag, self.context), newline_after=True)
     else:
-      print_green("Deploying %s to %s/%s..." % (tag, self.context, self.namespace))
+      print_green("Deploying %s to %s/%s..." % (tag, self.context, self.namespace), newline_after=True)
 
     if config.pre_deploy is not None:
-      print_green("Running pre-deploy hook '%s'..." % config.pre_deploy)
+      print_green("Running pre-deploy hook '%s'..." % config.pre_deploy, newline_after=True)
       return_code = CommandRunner(self.context, namespace=self.namespace).run(tag, config.pre_deploy, constraint=constraint, tty=False)
       if return_code:
         raise HokusaiError("Pre-deploy hook failed with return code %s" % return_code, return_code=return_code)
@@ -57,7 +57,7 @@ class Deployment(object):
         }
       }
 
-      print_green("Patching deployment %s..." % deployment['metadata']['name'])
+      print_green("Patching deployment %s..." % deployment['metadata']['name'], newline_after=True)
       shout(self.kctl.command("patch deployment %s -p '%s'" % (deployment['metadata']['name'], json.dumps(patch))))
 
     print_green("Waiting for deployment rollouts to complete...")
@@ -65,7 +65,7 @@ class Deployment(object):
     rollout_commands = [self.kctl.command("rollout status deployment/%s" % deployment['metadata']['name']) for deployment in self.cache]
     return_codes = shout_concurrent(rollout_commands, print_output=True)
     if any(return_codes):
-      print_red("One or more deployment rollouts timed out!  Rolling back...")
+      print_red("One or more deployment rollouts timed out!  Rolling back...", newline_before=True, newline_after=True)
       rollback_commands = [self.kctl.command("rollout undo deployment/%s" % deployment['metadata']['name']) for deployment in self.cache]
       shout_concurrent(rollback_commands, print_output=True)
       raise HokusaiError("Deployment failed!")
@@ -73,30 +73,30 @@ class Deployment(object):
     post_deploy_success = True
 
     if config.post_deploy is not None:
-      print_green("Running post-deploy hook '%s'..." % config.post_deploy)
+      print_green("Running post-deploy hook '%s'..." % config.post_deploy, newline_after=True)
       return_code = CommandRunner(self.context, namespace=self.namespace).run(tag, config.post_deploy, constraint=constraint, tty=False)
       if return_code:
-        print_yellow("WARNING: Running the post-deploy hook failed with return code %s" % return_code)
-        print_yellow("The tag %s has been rolled out.  However, you should run the post-deploy hook '%s' manually, or re-run this deployment." % (tag, config.post_deploy))
+        print_yellow("WARNING: Running the post-deploy hook failed with return code %s" % return_code, newline_before=True, newline_after=True)
+        print_yellow("The tag %s has been rolled out.  However, you should run the post-deploy hook '%s' manually, or re-run this deployment." % (tag, config.post_deploy), newline_after=True)
         post_deploy_success = False
 
     if self.namespace is None:
       deployment_tag = "%s--%s" % (self.context, datetime.datetime.utcnow().strftime("%Y-%m-%d--%H-%M-%S"))
-      print_green("Updating ECR deployment tags in %s..." % self.ecr.project_repo)
+      print_green("Updating ECR deployment tags in %s..." % self.ecr.project_repo, newline_after=True)
       try:
         self.ecr.retag(tag, self.context)
         print_green("Updated ECR tag %s -> %s" % (tag, self.context))
 
         self.ecr.retag(tag, deployment_tag)
-        print_green("Updated ECR tag %s -> %s" % (tag, deployment_tag))
+        print_green("Updated ECR tag %s -> %s" % (tag, deployment_tag), newline_after=True)
       except (ValueError, ClientError) as e:
-        print_yellow("WARNING: Updating ECR deployment tags failed due to the error: '%s'" % str(e))
-        print_yellow("The tag %s has been rolled out.  However, you should create the ECR tags '%s' and '%s' manually, or re-run this deployment." % (tag, deployment_tag, self.context))
+        print_yellow("WARNING: Updating ECR deployment tags failed due to the error: '%s'" % str(e), newline_before=True, newline_after=True)
+        print_yellow("The tag %s has been rolled out.  However, you should create the ECR tags '%s' and '%s' manually, or re-run this deployment." % (tag, deployment_tag, self.context), newline_after=True)
         post_deploy_success = False
 
       remote = git_remote or config.git_remote
       if remote is not None:
-        print_green("Pushing Git deployment tags to %s..." % remote)
+        print_green("Pushing Git deployment tags to %s..." % remote, newline_after=True)
         try:
           shout("git fetch %s" % remote)
           shout("git tag -f %s %s" % (self.context, tag), print_output=True)
@@ -104,10 +104,10 @@ class Deployment(object):
           shout("git push -f --no-verify %s refs/tags/%s" % (remote, self.context), print_output=True)
           print_green("Updated Git tag %s -> %s" % (tag, self.context))
           shout("git push -f --no-verify %s refs/tags/%s" % (remote, deployment_tag), print_output=True)
-          print_green("Updated Git tag %s -> %s" % (tag, deployment_tag))
+          print_green("Updated Git tag %s -> %s" % (tag, deployment_tag), newline_after=True)
         except CalledProcessError as e:
-          print_yellow("WARNING: Creating Git deployment tags failed due to the error: '%s'" % str(e))
-          print_yellow("The tag %s has been rolled out.  However, you should create the Git tags '%s' and '%s' manually, or re-run this deployment." % (tag, deployment_tag, self.context))
+          print_yellow("WARNING: Creating Git deployment tags failed due to the error: '%s'" % str(e), newline_before=True, newline_after=True)
+          print_yellow("The tag %s has been rolled out.  However, you should create the Git tags '%s' and '%s' manually, or re-run this deployment." % (tag, deployment_tag, self.context), newline_after=True)
           post_deploy_success = False
 
     if post_deploy_success:
@@ -127,7 +127,7 @@ class Deployment(object):
           }
         }
       }
-      print_green("Refreshing %s..." % deployment['metadata']['name'])
+      print_green("Refreshing %s..." % deployment['metadata']['name'], newline_after=True)
       shout(self.kctl.command("patch deployment %s -p '%s'" % (deployment['metadata']['name'], json.dumps(patch))))
 
     print_green("Waiting for refresh to complete...")

--- a/hokusai/services/deployment.py
+++ b/hokusai/services/deployment.py
@@ -19,7 +19,7 @@ class Deployment(object):
     else:
       self.cache = self.kctl.get_objects('deployment', selector="app=%s,layer=application" % config.project_name)
 
-  def update(self, tag, constraint, git_remote, resolve_tag_sha1=True):
+  def update(self, tag, constraint, git_remote, timeout, resolve_tag_sha1=True):
     if not self.ecr.project_repo_exists():
       raise HokusaiError("Project repo does not exist.  Aborting.")
 
@@ -52,9 +52,11 @@ class Deployment(object):
             "spec": {
               "containers": deployment_targets
             }
-          }
+          },
+          "progressDeadlineSeconds": timeout
         }
       }
+
       print_green("Patching deployment %s..." % deployment['metadata']['name'])
       shout(self.kctl.command("patch deployment %s -p '%s'" % (deployment['metadata']['name'], json.dumps(patch))))
 

--- a/hokusai/services/ecr.py
+++ b/hokusai/services/ecr.py
@@ -6,6 +6,7 @@ from botocore.exceptions import BotoCoreError, ClientError
 
 from hokusai.lib.config import config
 from hokusai.lib.common import get_region_name
+from hokusai.lib.exceptions import HokusaiError
 
 SHA1_REGEX = re.compile(r"\b[0-9a-f]{40}\b")
 
@@ -30,8 +31,7 @@ class ECR(object):
       try:
         repos += res['repositories']
       except KeyError, err:
-        print(res)
-        raise
+        raise HokusaiError("Fetching ECR registry failed with error %s" % str(err))
       while 'nextToken' in res:
         res = self.client.describe_repositories(registryId=self.aws_account_id,
                                                   nextToken=res['nextToken'])

--- a/test/unit/test_common.py
+++ b/test/unit/test_common.py
@@ -35,7 +35,7 @@ class TestCommon(HokusaiUnitTestCase):
     with mock_verbosity(True):
       with captured_output() as (out, err):
         verbose(TEST_MESSAGE)
-        self.assertEqual(out.getvalue().strip(), "\x1b[33m\n==> hokusai exec `%s`\n\x1b[0m" % TEST_MESSAGE)
+        self.assertEqual(out.getvalue().strip(), "\x1b[33m==> hokusai exec `%s`\n\x1b[0m" % TEST_MESSAGE)
 
   def test_non_verbose_output(self):
     with mock_verbosity(False):

--- a/test/unit/test_common.py
+++ b/test/unit/test_common.py
@@ -35,7 +35,7 @@ class TestCommon(HokusaiUnitTestCase):
     with mock_verbosity(True):
       with captured_output() as (out, err):
         verbose(TEST_MESSAGE)
-        self.assertEqual(out.getvalue().strip(), "\x1b[33m==> hokusai exec `%s`\x1b[0m" % TEST_MESSAGE)
+        self.assertEqual(out.getvalue().strip(), "\x1b[33m\n==> hokusai exec `%s`\n\x1b[0m" % TEST_MESSAGE)
 
   def test_non_verbose_output(self):
     with mock_verbosity(False):


### PR DESCRIPTION
* 987a77d (HEAD -> master) add --label option to logs to filter by additional label selectors
* a10105f print newline only after verbose log line
* 1cdb7b9 add the --previous option to logs commands
* 395d57d use a unique tmp dir to download and configure kubectl
* 36316e7 refactor printing always via smart_str and add some spacing
* 538f5d5 add --timeout flag to deploy and promote and patch deployments with `progressDeadlineSeconds` when rolling out
* 8cf1ce4 add flags --reverse-sort, --limit and --filter-tags to hokusai registry images

This PR adds a default timeout of `600` seconds to all deployment rollouts by patching `deployment.spec.progressDeadlineSeconds` when rolling out new deployments.  It can be overridden by the `--timeout` flag on `hokusai [staging|production|review_app] deploy` and `hokusai pipeline promote` commands.  This will prevent deployments from blocking indefinitely if new replicas fail to start or become ready.

Also includes a few extra options for the `hokusai registry images` command... `--reverse-sort` displays images oldest to newest, `--limit` truncates the output of images (default 20) and `--filter-tags` selects only images matching the provided string (so for instance you can use `--filter-tags staging` to select all `staging` `staging-{deployment_timestamp}` tags or even `--filter-tags 2019` to match on tags created this year.  It also colorizes "production" images green and "staging" images yellow for better readability.

Also also includes a few extra options to `hokusai [staging|production] logs` commands... `--previous` retrieves logs from the previous run of a restarted container, so if you see any Pod restarts, get logs right before the container's crash with the `--previous` flag.  You can also pass additional [label selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) to the logs command with the `--label` option ( in the form of `key=value,key=value`) to further filter the Pods from which you are getting logs... so in the case of Gravity, one use the option `--label component=sidekiq` to get only sidekiq pod's logs.

Finally includes a refactor of `print()` statements lying around to use `common.print_smart` which passes through `common.smart_str` and adds some spacing to output.
