### PR TITLE
mask verbose output - add a mask when shelling out to docker login

### DIFF
--- a/hokusai/commands/push.py
+++ b/hokusai/commands/push.py
@@ -19,7 +19,7 @@ def push(tag, build, force, overwrite, skip_latest=False):
   if not ecr.project_repo_exists():
     raise HokusaiError("ECR repo %s does not exist... did you run `hokusai setup` for this project?" % config.project_name)
 
-  shout(ecr.get_login())
+  shout(ecr.get_login(), mask=(r'^(docker login -u) .+ (-p) .+ (.+)$', r'\1 ****** \2 ***** \3'))
   if tag is None:
     tag = shout('git rev-parse HEAD').strip()
 

--- a/hokusai/lib/common.py
+++ b/hokusai/lib/common.py
@@ -4,6 +4,7 @@ import signal
 import string
 import random
 import json
+import re
 
 from subprocess import call, check_call, check_output, Popen, STDOUT
 
@@ -59,25 +60,28 @@ def get_verbosity():
   global VERBOSE
   return VERBOSE
 
-def verbose(msg):
-  if VERBOSE: print_yellow("==> hokusai exec `%s`" % msg, newline_after=True)
+def verbose(msg, mask=()):
+  if VERBOSE:
+    if mask:
+      print_yellow("==> hokusai exec `%s`" % re.sub(mask[0], mask[1], msg), newline_after=True)
+    else:
+      print_yellow("==> hokusai exec `%s`" % msg, newline_after=True)
   return msg
 
+def returncode(command, mask=()):
+  return call(verbose(command, mask=mask), stderr=STDOUT, shell=True)
 
-def returncode(command):
-  return call(verbose(command), stderr=STDOUT, shell=True)
-
-def shout(command, print_output=False):
+def shout(command, print_output=False, mask=()):
   if print_output:
-    return check_call(verbose(command), stderr=STDOUT, shell=True)
+    return check_call(verbose(command, mask=mask), stderr=STDOUT, shell=True)
   else:
-    return check_output(verbose(command), stderr=STDOUT, shell=True)
+    return check_output(verbose(command, mask=mask), stderr=STDOUT, shell=True)
 
 def shout_concurrent(commands, print_output=False):
   if print_output:
-    processes = [Popen(verbose(command), shell=True) for command in commands]
+    processes = [Popen(verbose(command, mask=mask), shell=True) for command in commands]
   else:
-    processes = [Popen(verbose(command), shell=True, stdout=open(os.devnull, 'w'), stderr=STDOUT) for command in commands]
+    processes = [Popen(verbose(command, mask=mask), shell=True, stdout=open(os.devnull, 'w'), stderr=STDOUT) for command in commands]
 
   return_codes = []
   try:

--- a/test/unit/test_common.py
+++ b/test/unit/test_common.py
@@ -37,6 +37,12 @@ class TestCommon(HokusaiUnitTestCase):
         verbose(TEST_MESSAGE)
         self.assertEqual(out.getvalue().strip(), "\x1b[33m==> hokusai exec `%s`\n\x1b[0m" % TEST_MESSAGE)
 
+  def test_masked_verbose_output(self):
+    with mock_verbosity(True):
+      with captured_output() as (out, err):
+        verbose(TEST_MESSAGE, mask=(r'^(\w*).*$', r'\1 ***'))
+        self.assertEqual(out.getvalue().strip(), "\x1b[33m==> hokusai exec `%s`\n\x1b[0m" % 'Ohai ***')
+
   def test_non_verbose_output(self):
     with mock_verbosity(False):
       with captured_output() as (out, err):


### PR DESCRIPTION
Add a keyword argument `mask`, accepting a tuple of 2 regexes to `common.verbose`.  If it is supplied, it unpacks the tuple and passes items as arguments to `re.sub` and only prints the resulting output verbosely.

Also pass the `mask` kwarg through to `verbose` from `returncode`, `shout`, and `shout_concurrent` functions.

When calling `shout(ecr.get_login())` in `hokusai registry push`, mask the username and password.

Fixes https://github.com/artsy/hokusai/issues/152