### PR TITLE
Add mask argument to shout_concurrent function

### DIFF
--- a/hokusai/lib/common.py
+++ b/hokusai/lib/common.py
@@ -77,7 +77,7 @@ def shout(command, print_output=False, mask=()):
   else:
     return check_output(verbose(command, mask=mask), stderr=STDOUT, shell=True)
 
-def shout_concurrent(commands, print_output=False):
+def shout_concurrent(commands, print_output=False, mask=()):
   if print_output:
     processes = [Popen(verbose(command, mask=mask), shell=True) for command in commands]
   else:


### PR DESCRIPTION
Follow up to https://github.com/artsy/hokusai/pull/153

Addresses the following error when promoting Metaphysics via Hokusai:

```
$ hokusai pipeline promote --git-remote upstream
Deploying 91f2817e92802c0750234604ffa43d1c160c2d98 to production...

Patching deployment metaphysics-web...

Waiting for deployment rollouts to complete...
ERROR: global name 'mask' is not defined
```