### PR TITLE
Introduce Git remote guards 

### DIFF
--- a/hokusai/cli/production.py
+++ b/hokusai/cli/production.py
@@ -31,11 +31,14 @@ def delete(verbose):
 
 
 @production.command(context_settings=CONTEXT_SETTINGS)
+@click.option('--check-branch', type=click.STRING, default="master", help='Check branch before updating (default: master)')
+@click.option('--check-remote', type=click.STRING, help='Check remotes before updating (otherwise check all remotes)')
+@click.option('--skip-checks', type=click.BOOL, is_flag=True, help='Skip all checks and update configuration recklessly')
 @click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
-def update(verbose):
+def update(check_branch, check_remote, skip_checks, verbose):
   """Update the Kubernetes resources defined in ./hokusai/production.yml"""
   set_verbosity(verbose)
-  hokusai.k8s_update(KUBE_CONTEXT)
+  hokusai.k8s_update(KUBE_CONTEXT, check_branch=check_branch, check_remote=check_remote, skip_checks=skip_checks)
 
 
 @production.command(context_settings=CONTEXT_SETTINGS)

--- a/hokusai/cli/review_app.py
+++ b/hokusai/cli/review_app.py
@@ -45,7 +45,7 @@ def delete(app_name, verbose):
 def update(app_name, verbose):
   """Updates the Kubernetes based resources defined in ./hokusai/{APP_NAME}.yml"""
   set_verbosity(verbose)
-  hokusai.k8s_update(KUBE_CONTEXT, namespace=clean_string(app_name), yaml_file_name=app_name)
+  hokusai.k8s_update(KUBE_CONTEXT, namespace=clean_string(app_name), yaml_file_name=app_name, skip_checks=True)
 
 
 @review_app.command(context_settings=CONTEXT_SETTINGS)

--- a/hokusai/cli/staging.py
+++ b/hokusai/cli/staging.py
@@ -31,11 +31,14 @@ def delete(verbose):
 
 
 @staging.command(context_settings=CONTEXT_SETTINGS)
+@click.option('--check-branch', type=click.STRING, default="master", help='Check branch before updating (default: master)')
+@click.option('--check-remote', type=click.STRING, help='Check remotes before updating (otherwise check all remotes)')
+@click.option('--skip-checks', type=click.BOOL, is_flag=True, help='Skip all checks and update configuration recklessly')
 @click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
-def update(verbose):
+def update(check_branch, check_remote, skip_checks, verbose):
   """Update the Kubernetes resources defined in ./hokusai/staging.yml"""
   set_verbosity(verbose)
-  hokusai.k8s_update(KUBE_CONTEXT)
+  hokusai.k8s_update(KUBE_CONTEXT, check_branch=check_branch, check_remote=check_remote, skip_checks=skip_checks)
 
 
 @staging.command(context_settings=CONTEXT_SETTINGS)

--- a/hokusai/commands/gitdiff.py
+++ b/hokusai/commands/gitdiff.py
@@ -25,4 +25,6 @@ def gitdiff():
     raise HokusaiError("Could not find a git SHA1 for tag %s.  Aborting." % production_tag)
 
   print_green("Comparing %s to %s" % (production_tag, staging_tag))
+  for remote in shout('git remote').splitlines():
+    shout("git fetch %s" % remote)
   shout("git diff %s %s" % (production_tag, staging_tag), print_output=True)

--- a/hokusai/commands/gitlog.py
+++ b/hokusai/commands/gitlog.py
@@ -24,4 +24,6 @@ def gitlog():
     raise HokusaiError("Could not find a git SHA1 for tag %s.  Aborting." % production_tag)
 
   print_green("Comparing %s to %s" % (production_tag, staging_tag))
+  for remote in shout('git remote').splitlines():
+    shout("git fetch %s" % remote)
   shout("git log --right-only %s..%s" % (production_tag, staging_tag), print_output=True)

--- a/hokusai/lib/config.py
+++ b/hokusai/lib/config.py
@@ -82,15 +82,18 @@ class HokusaiConfig(object):
       raise HokusaiError("Environment variable %s could not be cast to %s" % (env_var, _type))
 
   def _config_value_for(self, key, _type):
-    with open(HOKUSAI_CONFIG_FILE, 'r') as config_file:
-      config_struct = yaml.safe_load(config_file.read())
-      try:
-        val = config_struct[key]
-      except KeyError:
-        return None
-      if not isinstance(val, _type):
-        raise HokusaiError("Config key %s is not of %s" % (key, _type))
-      return val
+    try:
+      with open(HOKUSAI_CONFIG_FILE, 'r') as config_file:
+        config_struct = yaml.safe_load(config_file.read())
+        try:
+          val = config_struct[key]
+        except KeyError:
+          return None
+        if not isinstance(val, _type):
+          raise HokusaiError("Config key %s is not of %s" % (key, _type))
+        return val
+    except IOError:
+      return None
 
 
   @property

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -5,12 +5,11 @@ import boto3
 from hokusai import CWD
 from hokusai.lib import config
 
+TEST_KUBE_CONTEXT = os.environ.get('HOKUSAI_TEST_KUBE_CTX', 'minikube')
+
 for varname, varval in os.environ.items():
   if 'HOKUSAI_' in varname:
     del os.environ[varname]
-
-
-TEST_KUBE_CONTEXT = os.environ.get('HOKUSAI_TEST_KUBE_CTX', 'minikube')
 
 config.HOKUSAI_CONFIG_FILE = os.path.join(CWD, 'test/fixtures/project/hokusai/', 'config.yml')
 

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -5,6 +5,11 @@ import boto3
 from hokusai import CWD
 from hokusai.lib import config
 
+for varname, varval in os.environ.items():
+  if 'HOKUSAI_' in varname:
+    del os.environ[varname]
+
+
 TEST_KUBE_CONTEXT = os.environ.get('HOKUSAI_TEST_KUBE_CTX', 'minikube')
 
 config.HOKUSAI_CONFIG_FILE = os.path.join(CWD, 'test/fixtures/project/hokusai/', 'config.yml')

--- a/test/integration/test_kubernetes.py
+++ b/test/integration/test_kubernetes.py
@@ -38,7 +38,7 @@ class TestKubernetes(HokusaiIntegrationTestCase):
     @patch('hokusai.lib.command.sys.exit')
     def test_01_k8s_update(self, mocked_sys_exit):
         with captured_output() as (out, err):
-            kubernetes.k8s_update(TEST_KUBE_CONTEXT, yaml_file_name='minikube')
+            kubernetes.k8s_update(TEST_KUBE_CONTEXT, yaml_file_name='minikube', skip_checks=True)
             mocked_sys_exit.assert_called_once_with(0)
             # self.assertIn('deployment.apps "hello-web" unchanged', out.getvalue().strip())
             # self.assertIn('service "hello-web" unchanged', out.getvalue().strip())


### PR DESCRIPTION
Fetch from git remotes before running `hokusai [staging|production] update` which will enforce a local checkout of master up to date with _all_ remotes unless overridden.

Also perform a `git fetch` for all remotes during `hokusai pipeline git[diff|log]` commands.

Small fixes to integration tests and an error checking for verbose config when running `hokusai setup` before a configfile exists

Fixes https://github.com/artsy/hokusai/issues/41 and https://github.com/artsy/hokusai/issues/81