### PR TITLE
Add registry pull and override Yaml files option

### DIFF
--- a/hokusai/cli/base.py
+++ b/hokusai/cli/base.py
@@ -47,23 +47,25 @@ def setup(project_name, template_remote, template_dir, var, allow_missing_vars, 
 
 
 @base.command(context_settings=CONTEXT_SETTINGS)
+@click.option('--yaml-file-name', type=click.STRING, help='Use the docker-compose Yaml filename in the ./hokusai directory (default: build.yml)')
 @click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
-def build(verbose):
+def build(yaml_file_name, verbose):
   """Build the Docker image defined in ./hokusai/build.yml"""
   set_verbosity(verbose)
-  hokusai.build()
+  hokusai.build(yaml_file_name)
 
 
 @base.command(context_settings=CONTEXT_SETTINGS)
 @click.option('--build/--no-build', default=True, help='Force a build of the :latest image before running the test suite (default: true)')
 @click.option('--cleanup/--no-cleanup', default=False, help='Remove containers on exit / error (default: False)')
+@click.option('--yaml-file-name', type=click.STRING, help='Use the docker-compose Yaml filename in the ./hokusai directory (default: test.yml)')
 @click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
-def test(build, cleanup, verbose):
+def test(build, cleanup, yaml_file_name, verbose):
   """Boot the docker-compose test environment defined by `./hokusai/test.yml` and run the test suite
 
   Return the exit code of the container with the name 'project-name' in `hokusai/config.yml`"""
   set_verbosity(verbose)
-  hokusai.test(build, cleanup)
+  hokusai.test(build, cleanup, yaml_file_name)
 
 
 @base.command(context_settings=CONTEXT_SETTINGS)

--- a/hokusai/cli/dev.py
+++ b/hokusai/cli/dev.py
@@ -16,11 +16,12 @@ def dev(context_settings=CONTEXT_SETTINGS):
 @dev.command(context_settings=CONTEXT_SETTINGS)
 @click.option('--build/--no-build', default=True, help='Force a build of the :latest image before starting (default: true)')
 @click.option('-d', '--detach', type=click.BOOL, is_flag=True, help="Run containers in the background")
+@click.option('--yaml-file-name', type=click.STRING, help='Use the docker-compose Yaml file name in the ./hokusai directory (default development.yml)')
 @click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
-def start(build, detach, verbose):
+def start(build, detach, yaml_file_name, verbose):
   """Start the development environment defined in ./hokusai/development.yml"""
   set_verbosity(verbose)
-  hokusai.dev_start(build, detach)
+  hokusai.dev_start(build, detach, yaml_file_name)
 
 
 @dev.command(context_settings=CONTEXT_SETTINGS)

--- a/hokusai/cli/production.py
+++ b/hokusai/cli/production.py
@@ -15,30 +15,34 @@ def production(context_settings=CONTEXT_SETTINGS):
   pass
 
 @production.command(context_settings=CONTEXT_SETTINGS)
+@click.option('--yaml-file-name', type=click.STRING, help='Kubernetes Yaml filename in the ./hokusai directory (default production.yml)')
 @click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
-def create(verbose):
+def create(yaml_file_name, verbose):
   """Create the Kubernetes resources defined in ./hokusai/production.yml"""
   set_verbosity(verbose)
-  hokusai.k8s_create(KUBE_CONTEXT)
+  hokusai.k8s_create(KUBE_CONTEXT, yaml_file_name=yaml_file_name)
 
 
 @production.command(context_settings=CONTEXT_SETTINGS)
+@click.option('--yaml-file-name', type=click.STRING, help='Kubernetes Yaml filename in the ./hokusai directory (default production.yml)')
 @click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
-def delete(verbose):
+def delete(yaml_file_name, verbose):
   """Delete the Kubernetes resources defined in ./hokusai/production.yml"""
   set_verbosity(verbose)
-  hokusai.k8s_delete(KUBE_CONTEXT)
+  hokusai.k8s_delete(KUBE_CONTEXT, yaml_file_name=yaml_file_name)
 
 
 @production.command(context_settings=CONTEXT_SETTINGS)
 @click.option('--check-branch', type=click.STRING, default="master", help='Check branch before updating (default: master)')
 @click.option('--check-remote', type=click.STRING, help='Check remotes before updating (otherwise check all remotes)')
 @click.option('--skip-checks', type=click.BOOL, is_flag=True, help='Skip all checks and update configuration recklessly')
+@click.option('--yaml-file-name', type=click.STRING, help='Kubernetes Yaml filename in the ./hokusai directory (default production.yml)')
 @click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
-def update(check_branch, check_remote, skip_checks, verbose):
+def update(check_branch, check_remote, skip_checks, yaml_file_name, verbose):
   """Update the Kubernetes resources defined in ./hokusai/production.yml"""
   set_verbosity(verbose)
-  hokusai.k8s_update(KUBE_CONTEXT, check_branch=check_branch, check_remote=check_remote, skip_checks=skip_checks)
+  hokusai.k8s_update(KUBE_CONTEXT, check_branch=check_branch,
+                      check_remote=check_remote, skip_checks=skip_checks, yaml_file_name=yaml_file_name)
 
 
 @production.command(context_settings=CONTEXT_SETTINGS)
@@ -46,11 +50,12 @@ def update(check_branch, check_remote, skip_checks, verbose):
 @click.option('--pods/--no-pods', default=True, help='Print pods (default: true)')
 @click.option('--describe', type=click.BOOL, is_flag=True, help="Print 'kubectl describe' output for resources and pods")
 @click.option('--top', type=click.BOOL, is_flag=True, help='Print top pods')
+@click.option('--yaml-file-name', type=click.STRING, help='Kubernetes Yaml filename in the ./hokusai directory (default production.yml)')
 @click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
-def status(resources, pods, describe, top, verbose):
+def status(resources, pods, describe, top, yaml_file_name, verbose):
   """Print Kubernetes resources in the production context"""
   set_verbosity(verbose)
-  hokusai.k8s_status(KUBE_CONTEXT, resources, pods, describe, top)
+  hokusai.k8s_status(KUBE_CONTEXT, resources, pods, describe, top, yaml_file_name=yaml_file_name)
 
 
 @production.command(context_settings=CONTEXT_SETTINGS)

--- a/hokusai/cli/registry.py
+++ b/hokusai/cli/registry.py
@@ -12,16 +12,27 @@ def registry(context_settings=CONTEXT_SETTINGS):
 
 
 @registry.command(context_settings=CONTEXT_SETTINGS)
-@click.option('--tag', type=click.STRING, help='The tag to push (default: the value of `git rev-parse HEAD`)')
+@click.option('--tag', type=click.STRING, help='The remote tag to push to (default: the value of `git rev-parse HEAD`)')
+@click.option('--local-tag', type=click.STRING, default='latest', help='The local tag to push (default: latest)')
 @click.option('--build/--no-build', default=True, help='Force a build of the :latest image before pushing (default: true)')
 @click.option('--force', type=click.BOOL, is_flag=True, help='Push even if working directory is not clean')
 @click.option('--overwrite', type=click.BOOL, is_flag=True, help='Push even if the tag already exists')
 @click.option('--skip-latest', type=click.BOOL, is_flag=True, help="Don't update the 'latest' tag" )
 @click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
-def push(tag, build, force, overwrite, skip_latest, verbose):
+def push(tag, local_tag, build, force, overwrite, skip_latest, verbose):
   """Build and push an image to the project's registry tagged as the git SHA1 of HEAD"""
   set_verbosity(verbose)
-  hokusai.push(tag, build, force, overwrite, skip_latest)
+  hokusai.push(tag, local_tag, build, force, overwrite, skip_latest)
+
+
+@registry.command(context_settings=CONTEXT_SETTINGS)
+@click.option('--tag', type=click.STRING, default='latest', help='The remote tag to pull  (default: latest)')
+@click.option('--local-tag', type=click.STRING, default='latest', help='The local tag to pull to (default: latest)')
+@click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
+def pull(tag, local_tag, verbose):
+  """Pull the image tag --tag from the project's registry and tag as --local-tag"""
+  set_verbosity(verbose)
+  hokusai.pull(tag, local_tag)
 
 
 @registry.command(context_settings=CONTEXT_SETTINGS)

--- a/hokusai/cli/registry.py
+++ b/hokusai/cli/registry.py
@@ -15,14 +15,15 @@ def registry(context_settings=CONTEXT_SETTINGS):
 @click.option('--tag', type=click.STRING, help='The remote tag to push to (default: the value of `git rev-parse HEAD`)')
 @click.option('--local-tag', type=click.STRING, default='latest', help='The local tag to push (default: latest)')
 @click.option('--build/--no-build', default=True, help='Force a build of the :latest image before pushing (default: true)')
+@click.option('--yaml-file-name', type=click.STRING, help='Use the docker-compose Yaml filename in the ./hokusai directory (default: build.yml)')
 @click.option('--force', type=click.BOOL, is_flag=True, help='Push even if working directory is not clean')
 @click.option('--overwrite', type=click.BOOL, is_flag=True, help='Push even if the tag already exists')
 @click.option('--skip-latest', type=click.BOOL, is_flag=True, help="Don't update the 'latest' tag" )
 @click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
-def push(tag, local_tag, build, force, overwrite, skip_latest, verbose):
+def push(tag, local_tag, build, yaml_file_name, force, overwrite, skip_latest, verbose):
   """Build and push an image to the project's registry tagged as the git SHA1 of HEAD"""
   set_verbosity(verbose)
-  hokusai.push(tag, local_tag, build, force, overwrite, skip_latest)
+  hokusai.push(tag, local_tag, build, yaml_file_name, force, overwrite, skip_latest)
 
 
 @registry.command(context_settings=CONTEXT_SETTINGS)

--- a/hokusai/cli/staging.py
+++ b/hokusai/cli/staging.py
@@ -15,30 +15,34 @@ def staging(context_settings=CONTEXT_SETTINGS):
   pass
 
 @staging.command(context_settings=CONTEXT_SETTINGS)
+@click.option('--yaml-file-name', type=click.STRING, help='Kubernetes Yaml filename in the ./hokusai directory (default staging.yml)')
 @click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
 def create(verbose):
   """Create the Kubernetes resources defined in ./hokusai/staging.yml"""
-  set_verbosity(verbose)
-  hokusai.k8s_create(KUBE_CONTEXT)
+  set_verbosity(yaml_file_name, verbose)
+  hokusai.k8s_create(KUBE_CONTEXT, yaml_file_name=yaml_file_name)
 
 
 @staging.command(context_settings=CONTEXT_SETTINGS)
+@click.option('--yaml-file-name', type=click.STRING, help='Kubernetes Yaml filename in the ./hokusai directory (default staging.yml)')
 @click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
 def delete(verbose):
   """Delete the Kubernetes resources defined in ./hokusai/staging.yml"""
   set_verbosity(verbose)
-  hokusai.k8s_delete(KUBE_CONTEXT)
+  hokusai.k8s_delete(KUBE_CONTEXT, yaml_file_name=yaml_file_name)
 
 
 @staging.command(context_settings=CONTEXT_SETTINGS)
 @click.option('--check-branch', type=click.STRING, default="master", help='Check branch before updating (default: master)')
 @click.option('--check-remote', type=click.STRING, help='Check remotes before updating (otherwise check all remotes)')
 @click.option('--skip-checks', type=click.BOOL, is_flag=True, help='Skip all checks and update configuration recklessly')
+@click.option('--yaml-file-name', type=click.STRING, help='Kubernetes Yaml filename in the ./hokusai directory (default staging.yml)')
 @click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
-def update(check_branch, check_remote, skip_checks, verbose):
+def update(check_branch, check_remote, skip_checks, yaml_file_name, verbose):
   """Update the Kubernetes resources defined in ./hokusai/staging.yml"""
   set_verbosity(verbose)
-  hokusai.k8s_update(KUBE_CONTEXT, check_branch=check_branch, check_remote=check_remote, skip_checks=skip_checks)
+  hokusai.k8s_update(KUBE_CONTEXT, check_branch=check_branch,
+                      check_remote=check_remote, skip_checks=skip_checks, yaml_file_name=yaml_file_name)
 
 
 @staging.command(context_settings=CONTEXT_SETTINGS)
@@ -46,11 +50,12 @@ def update(check_branch, check_remote, skip_checks, verbose):
 @click.option('--pods/--no-pods', default=True, help='Print pods (default: true)')
 @click.option('--describe', type=click.BOOL, is_flag=True, help="Print 'kubectl describe' output for resources and pods")
 @click.option('--top', type=click.BOOL, is_flag=True, help='Print top pods')
+@click.option('--yaml-file-name', type=click.STRING, help='Kubernetes Yaml filename in the ./hokusai directory (default staging.yml)')
 @click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
-def status(resources, pods, describe, top, verbose):
+def status(resources, pods, describe, top, yaml_file_name, verbose):
   """Print Kubernetes resources in the staging context"""
   set_verbosity(verbose)
-  hokusai.k8s_status(KUBE_CONTEXT, resources, pods, describe, top)
+  hokusai.k8s_status(KUBE_CONTEXT, resources, pods, describe, top, yaml_file_name=yaml_file_name)
 
 
 @staging.command(context_settings=CONTEXT_SETTINGS)

--- a/hokusai/commands/__init__.py
+++ b/hokusai/commands/__init__.py
@@ -10,6 +10,7 @@ from hokusai.commands.env import create_env, delete_env, get_env, set_env, unset
 from hokusai.commands.images import images
 from hokusai.commands.logs import logs
 from hokusai.commands.push import push
+from hokusai.commands.pull import pull
 from hokusai.commands.run import run
 from hokusai.commands.setup import setup
 from hokusai.commands.kubernetes import k8s_create, k8s_update, k8s_delete, k8s_status, k8s_copy_config

--- a/hokusai/commands/build.py
+++ b/hokusai/commands/build.py
@@ -4,5 +4,5 @@ from hokusai.lib.command import command
 from hokusai.services.docker import Docker
 
 @command()
-def build():
-  Docker().build()
+def build(yaml_file_name):
+  Docker().build(yaml_file_name)

--- a/hokusai/commands/development.py
+++ b/hokusai/commands/development.py
@@ -9,8 +9,12 @@ from hokusai.lib.exceptions import HokusaiError
 from hokusai.services.docker import Docker
 
 @command()
-def dev_start(build, detach):
-  docker_compose_yml = os.path.join(CWD, HOKUSAI_CONFIG_DIR, DEVELOPMENT_YML_FILE)
+def dev_start(build, detach, yaml_file_name):
+  if yaml_file_name is None:
+    docker_compose_yml = os.path.join(CWD, HOKUSAI_CONFIG_DIR, DEVELOPMENT_YML_FILE)
+  else:
+    docker_compose_yml = os.path.join(CWD, HOKUSAI_CONFIG_DIR, yaml_file_name)
+
   if not os.path.isfile(docker_compose_yml):
     raise HokusaiError("Yaml file %s does not exist." % docker_compose_yml)
 
@@ -21,7 +25,7 @@ def dev_start(build, detach):
 
   opts = ''
   if build:
-    Docker().build()
+    Docker().build(yaml_file_name)
   if detach:
     opts += ' -d'
 

--- a/hokusai/commands/pull.py
+++ b/hokusai/commands/pull.py
@@ -1,0 +1,21 @@
+import os
+
+from hokusai.lib.command import command
+from hokusai.lib.config import config
+from hokusai.services.ecr import ECR
+from hokusai.lib.common import print_green, shout
+from hokusai.lib.exceptions import HokusaiError
+
+@command()
+def pull(tag, local_tag):
+  ecr = ECR()
+  if not ecr.project_repo_exists():
+    raise HokusaiError("ECR repo %s does not exist... did you run `hokusai setup` for this project?" % config.project_name)
+
+  shout(ecr.get_login(), mask=(r'^(docker login -u) .+ (-p) .+ (.+)$', r'\1 ****** \2 ***** \3'))
+
+  shout("docker pull %s:%s" % (ecr.project_repo, tag))
+
+  shout("docker tag %s:%s hokusai_%s:%s" % (ecr.project_repo, tag, config.project_name, 'latest'))
+  
+  print_green("Pulled %s:%s to hokusai_%s:%s" % (ecr.project_repo, tag, config.project_name, 'latest'), newline_after=True)

--- a/hokusai/commands/push.py
+++ b/hokusai/commands/push.py
@@ -8,7 +8,7 @@ from hokusai.lib.exceptions import HokusaiError
 from hokusai.services.docker import Docker
 
 @command()
-def push(tag, local_tag, build, force, overwrite, skip_latest=False):
+def push(tag, local_tag, build, yaml_file_name, force, overwrite, skip_latest=False):
   if force is None and shout('git status --porcelain'):
     raise HokusaiError("Working directory is not clean.  Aborting.")
 
@@ -27,7 +27,7 @@ def push(tag, local_tag, build, force, overwrite, skip_latest=False):
     raise HokusaiError("Tag %s already exists in registry.  Aborting." % tag)
 
   if build:
-    Docker().build()
+    Docker().build(yaml_file_name)
 
   build_tag = "hokusai_%s:%s" % (config.project_name, local_tag)
 

--- a/hokusai/commands/push.py
+++ b/hokusai/commands/push.py
@@ -8,7 +8,7 @@ from hokusai.lib.exceptions import HokusaiError
 from hokusai.services.docker import Docker
 
 @command()
-def push(tag, build, force, overwrite, skip_latest=False):
+def push(tag, local_tag, build, force, overwrite, skip_latest=False):
   if force is None and shout('git status --porcelain'):
     raise HokusaiError("Working directory is not clean.  Aborting.")
 
@@ -29,7 +29,7 @@ def push(tag, build, force, overwrite, skip_latest=False):
   if build:
     Docker().build()
 
-  build_tag = "hokusai_%s:latest" % config.project_name
+  build_tag = "hokusai_%s:%s" % (config.project_name, local_tag)
 
   shout("docker tag %s %s:%s" % (build_tag, ecr.project_repo, tag))
   shout("docker push %s:%s" % (ecr.project_repo, tag), print_output=True)

--- a/hokusai/commands/test.py
+++ b/hokusai/commands/test.py
@@ -9,8 +9,12 @@ from hokusai.lib.exceptions import CalledProcessError, HokusaiError
 from hokusai.services.docker import Docker
 
 @command()
-def test(build, cleanup):
-  docker_compose_yml = os.path.join(CWD, HOKUSAI_CONFIG_DIR, TEST_YML_FILE)
+def test(build, cleanup, yaml_file_name):
+  if yaml_file_name is None:
+    docker_compose_yml = os.path.join(CWD, HOKUSAI_CONFIG_DIR, TEST_YML_FILE)
+  else:
+    docker_compose_yml = os.path.join(CWD, HOKUSAI_CONFIG_DIR, yaml_file_name)
+
   if not os.path.isfile(docker_compose_yml):
     raise HokusaiError("Yaml file %s does not exist." % docker_compose_yml)
 
@@ -24,7 +28,7 @@ def test(build, cleanup):
 
   opts = ' --abort-on-container-exit'
   if build:
-    Docker().build()
+    Docker().build(yaml_file_name)
 
   print_green("Starting test environment... Press Ctrl+C to stop.", newline_after=True)
   try:

--- a/hokusai/services/docker.py
+++ b/hokusai/services/docker.py
@@ -6,17 +6,20 @@ from hokusai.lib.common import shout
 from hokusai.lib.exceptions import HokusaiError
 
 class Docker(object):
-  def build(self):
-    docker_compose_yml = os.path.join(CWD, HOKUSAI_CONFIG_DIR, BUILD_YAML_FILE)
-    legacy_docker_compose_yml = os.path.join(CWD, HOKUSAI_CONFIG_DIR, LEGACY_BUILD_YAML_FILE)
+  def build(self, yaml_file_name):
+    if yaml_file_name is None:
+      docker_compose_yml = os.path.join(CWD, HOKUSAI_CONFIG_DIR, BUILD_YAML_FILE)
+      legacy_docker_compose_yml = os.path.join(CWD, HOKUSAI_CONFIG_DIR, LEGACY_BUILD_YAML_FILE)
 
-    if not os.path.isfile(docker_compose_yml) and not os.path.isfile(legacy_docker_compose_yml):
-      raise HokusaiError("Yaml files %s / %s do not exist." % (docker_compose_yml, legacy_docker_compose_yml))
+      if not os.path.isfile(docker_compose_yml) and not os.path.isfile(legacy_docker_compose_yml):
+        raise HokusaiError("Yaml files %s / %s do not exist." % (docker_compose_yml, legacy_docker_compose_yml))
 
-    if os.path.isfile(docker_compose_yml):
-      build_command = "docker-compose -f %s -p hokusai build" % docker_compose_yml
-    if os.path.isfile(legacy_docker_compose_yml):
-      build_command = "docker-compose -f %s -p hokusai build" % legacy_docker_compose_yml
+      if os.path.isfile(docker_compose_yml):
+        build_command = "docker-compose -f %s -p hokusai build" % docker_compose_yml
+      if os.path.isfile(legacy_docker_compose_yml):
+        build_command = "docker-compose -f %s -p hokusai build" % legacy_docker_compose_yml
+    else:
+      build_command = "docker-compose -f %s -p hokusai build" % yaml_file_name
 
     if config.pre_build:
       build_command = "%s && %s" % (config.pre_build, build_command)


### PR DESCRIPTION
@dblandin the registry pull command relates to the work we did last week with Volt and @starsirius 

@ansor4 I hope the addition of the override option `--yaml-file-name` to commands like build, test and push will allow for supporting multiple build targets in a single project...