### PR TITLE
Install bash in hokusai image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,10 @@ RUN pip install docker-compose==1.22.0
 # Install the AWS CLI
 RUN pip install awscli --upgrade
 
-# Install Git and Ssh
-RUN apk add git openssh
+# Install Git, Ssh, and bash
+RUN apk add git openssh bash
 
 # Install the AWS IAM Authenticator
-
 RUN curl -L https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.4.0/aws-iam-authenticator_0.4.0_linux_amd64 -o /usr/local/bin/aws-iam-authenticator && chmod a+x /usr/local/bin/aws-iam-authenticator
 
 ADD . /src


### PR DESCRIPTION
A few teams are trying out [Slack Orb](https://github.com/CircleCI-Public/slack-orb) for Slack notifications for CircleCI builds. However, it [requires bash](https://github.com/CircleCI-Public/slack-orb/tree/69d380089dfbb3e81e26d38fb982716e840521ee#bash-shell). 😞 

We can probably install it downstream in each app, but maybe we can just included in the hokusai image. Looks like `bash` is [1.25MB](https://pkgs.alpinelinux.org/package/edge/main/x86/bash) and hope it's not that much overhead.