### PR TITLE
refactor deployment update behavior to account for canary and review apps

### DIFF
--- a/hokusai/commands/deployment.py
+++ b/hokusai/commands/deployment.py
@@ -15,7 +15,7 @@ def update(context, tag, migration, constraint, git_remote, timeout,
       raise HokusaiError("Migration failed with return code %s" % return_code, return_code=return_code)
   Deployment(context, namespace=namespace).update(tag, constraint, git_remote, timeout,
                                                   update_config=update_config, filename=filename)
-  print_green("Deployment updated to %s" % tag)
+  print_green("Deployment(s) updated to %s" % tag)
 
 
 @command()


### PR DESCRIPTION
Refactor deployment behavior (see comments)

This logic should be refactored, but essentially if namespace and filename are provided, the caller is a review app, while if namespace is None it is either staging or production.  If filename is unset for staging or production it is targeting the 'canonical' app, i.e. staging.yml or production.yml while if it is set it is targeting a 'canary' app.

- For the canonical app, run deploy hooks and post-depoy steps creating deployment tags
- For a canary app, skip deploy hooks and post-deploy steps
- For review apps, run deploy hooks but skip post-deploy steps

For all deployment rollouts, if update_config or filename targets a yml file, bust the deployment cache using k8s field selectors and get deployments to watch the rollout from the yml file spec.