### PR TITLE
@ashkan18 => [GitCompare] Import HokusaiError

### DIFF
--- a/hokusai/commands/gitcompare.py
+++ b/hokusai/commands/gitcompare.py
@@ -3,6 +3,7 @@ from hokusai.lib.common import print_red, print_green, shout
 from hokusai.lib.config import config
 from hokusai.services.deployment import Deployment
 from hokusai.services.ecr import ECR
+from hokusai.lib.exceptions import HokusaiError
 
 @command()
 def gitcompare(org_name, git_compare_link):


### PR DESCRIPTION
Small one, h/t @joeyAghion .

This command errors if you are missing a `staging` or `production` tag, but the import was missing.