### PR TITLE
Fix Configmap serialization and other minor issues

### DIFF
--- a/hokusai/commands/gitcompare.py
+++ b/hokusai/commands/gitcompare.py
@@ -3,6 +3,7 @@ from hokusai.lib.common import print_red, print_green, shout
 from hokusai.lib.config import config
 from hokusai.services.deployment import Deployment
 from hokusai.services.ecr import ECR
+from hokusai.lib.exceptions import HokusaiError
 
 @command()
 def gitcompare(org_name, git_compare_link):

--- a/hokusai/commands/gitlog.py
+++ b/hokusai/commands/gitlog.py
@@ -2,6 +2,7 @@ from hokusai.lib.command import command
 from hokusai.lib.common import print_red, print_green, shout
 from hokusai.services.deployment import Deployment
 from hokusai.services.ecr import ECR
+from hokusai.lib.exceptions import HokusaiError
 
 @command()
 def gitlog():

--- a/hokusai/services/configmap.py
+++ b/hokusai/services/configmap.py
@@ -1,10 +1,9 @@
 import os
 import sys
 
-from collections import OrderedDict
 from tempfile import NamedTemporaryFile
 
-import yaml
+import json
 
 from hokusai.lib.config import config
 from hokusai.lib.common import print_green, shout
@@ -22,16 +21,16 @@ class ConfigMap(object):
     }
     if name is None:
       self.metadata['labels'] = { 'app': config.project_name }
-    self.struct = OrderedDict([
-      ('apiVersion', 'v1'),
-      ('kind', 'ConfigMap'),
-      ('metadata', self.metadata),
-      ('data', {})
-    ])
+    self.struct = {
+      'apiVersion': 'v1',
+      'kind': 'ConfigMap',
+      'metadata': self.metadata,
+      'data': {}
+    }
 
   def _to_file(self):
     f = NamedTemporaryFile(delete=False)
-    f.write(yaml.safe_dump(self.struct, default_flow_style=False))
+    f.write(json.dumps(self.struct))
     f.close()
     return f
 
@@ -46,8 +45,8 @@ class ConfigMap(object):
     shout(self.kctl.command("delete configmap %s" % self.name))
 
   def load(self):
-    payload = shout(self.kctl.command("get configmap %s -o yaml" % self.name))
-    struct = yaml.load(payload)
+    payload = shout(self.kctl.command("get configmap %s -o json" % self.name))
+    struct = json.loads(payload)
     if 'data' in struct:
       self.struct['data'] = struct['data']
     else:

--- a/hokusai/services/deployment.py
+++ b/hokusai/services/deployment.py
@@ -162,7 +162,7 @@ class Deployment(object):
       if remote:
         print_green("Pushing Git deployment tags to %s..." % remote, newline_after=True)
         try:
-          shout("git fetch %s" % remote)
+          shout("git fetch %s --tags" % remote)
           shout("git tag -f %s %s" % (self.context, tag), print_output=True)
           shout("git tag -f %s %s" % (deployment_tag, tag), print_output=True)
           shout("git push -f --no-verify %s refs/tags/%s" % (remote, self.context), print_output=True)


### PR DESCRIPTION
Addresses https://github.com/artsy/hokusai/issues/174 by serializing / deserializing ConfigMaps to JSON

@starsirius this should cast all new env vars to strings, as they are passed in to the CLI as such

Also few minor fixes relating to Git tags: fix missing HokusaiError imports in `gitcompare.py` and `gitlog.py` and fetch all git tags in `services/deployment.py`