### PR TITLE
add --tag-exists option to registry images command

### DIFF
--- a/hokusai/cli/registry.py
+++ b/hokusai/cli/registry.py
@@ -37,12 +37,13 @@ def pull(tag, local_tag, verbose):
 
 
 @registry.command(context_settings=CONTEXT_SETTINGS)
+@click.option('-e', '--tag-exists', type=click.STRING, help='Exit 0 if the given image tag is found and 1 if not')
 @click.option('-r', '--reverse-sort', type=click.BOOL, is_flag=True, help='Sort oldest to latest')
 @click.option('-l', '--limit', type=click.INT, default=20, help="Limit output to N images")
 @click.option('-f', '--filter-tags', type=click.STRING, help='Filter images that have at least one tag matching the provided string')
 @click.option('-d', '--digests', type=click.BOOL, is_flag=True, help='Print image digests')
 @click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
-def images(reverse_sort, limit, filter_tags, digests, verbose):
+def images(tag_exists, reverse_sort, limit, filter_tags, digests, verbose):
   """Print images and tags in the project's registry"""
   set_verbosity(verbose)
-  hokusai.images(reverse_sort, limit, filter_tags, digests)
+  hokusai.images(tag_exists, reverse_sort, limit, filter_tags, digests)

--- a/hokusai/commands/images.py
+++ b/hokusai/commands/images.py
@@ -3,15 +3,17 @@ from operator import itemgetter
 from hokusai.lib.command import command
 from hokusai.services.ecr import ECR
 from hokusai.lib.config import config
-from hokusai.lib.common import print_green, print_yellow, print_smart, shout
+from hokusai.lib.common import print_green, print_yellow, print_red, print_smart, shout, pick_yes, pick_no
 
 @command()
 def images(tag_exists, reverse_sort, limit, filter_tags, digests):
   ecr = ECR()
   if tag_exists:
     if ecr.get_image_by_tag(tag_exists):
+      print_green(pick_yes())
       return
     else:
+      print_red(pick_no())
       return 1
 
   images = ecr.images

--- a/hokusai/commands/images.py
+++ b/hokusai/commands/images.py
@@ -6,8 +6,15 @@ from hokusai.lib.config import config
 from hokusai.lib.common import print_green, print_yellow, print_smart, shout
 
 @command()
-def images(reverse_sort, limit, filter_tags, digests):
-  images = ECR().images
+def images(tag_exists, reverse_sort, limit, filter_tags, digests):
+  ecr = ECR()
+  if tag_exists:
+    if ecr.get_image_by_tag(tag_exists):
+      return
+    else:
+      return 1
+
+  images = ecr.images
   sorted_images = sorted(images, key=itemgetter('imagePushedAt'), reverse=not reverse_sort)
   filtered_images = filter(lambda image: 'imageTags' in image.keys(), sorted_images)
   if filter_tags:

--- a/hokusai/lib/common.py
+++ b/hokusai/lib/common.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import os
 import sys
 import signal
@@ -111,3 +113,9 @@ def get_region_name():
   if os.environ.get('AWS_REGION'):
     return os.environ.get('AWS_REGION')
   return AWS_DEFAULT_REGION
+
+def pick_yes():
+  return random.choice(["Yep", "Si", "Da", "Ja", "Hai", "Jā", "Oui", "Shì", "Sim"])
+
+def pick_no():
+  return random.choice(["Nope", "No", "Nein", "Nay", "Nē", "Non", "Iya", "Méiyǒu", "Não"])

--- a/hokusai/lib/common.py
+++ b/hokusai/lib/common.py
@@ -115,7 +115,7 @@ def get_region_name():
   return AWS_DEFAULT_REGION
 
 def pick_yes():
-  return random.choice(["Yep", "Si", "Da", "Ja", "Hai", "Jā", "Oui", "Shì", "Sim"])
+  return random.choice(["Yep", "Si", "да", "Da", "Aane", "हाँ", "Ja", "はい", "Jā", "так", "بله", "Tak", "Wi", "Oui", "יאָ", "예", "是", "Sim"])
 
 def pick_no():
-  return random.choice(["Nope", "No", "Nein", "Nay", "Nē", "Non", "Iya", "Méiyǒu", "Não"])
+  return random.choice(["Nope", "No", "нет", "Ne", "नहीं", "Daabi", "Nein", "Nay", "Nē", "ні", "خیر", "Nie", "Non", "ניט", "не", "아니", "いや", "没有", "Não"])


### PR DESCRIPTION
To support CI builds that need to determine if an image with a given tag exists