### PR TITLE
Remove unneeded command for cleanup steps

### DIFF
--- a/docs/Review_Apps.md
+++ b/docs/Review_Apps.md
@@ -127,6 +127,5 @@ In order to start a review app you will need to follow these steps:
 15) Delete review app:
 
     ```shell
-    hokusai review_app env delete <name>
     hokusai review_app delete <name>
     ```


### PR DESCRIPTION
`hokusai review_app env delete <name>` does not appear to be a valid command. Also, my understanding is that `hokusai review_app delete <name>` will also take care of removing env variables.