### PR TITLE
Find all Yaml j2 templates including docker-compose files

### DIFF
--- a/hokusai/commands/development.py
+++ b/hokusai/commands/development.py
@@ -8,7 +8,7 @@ from hokusai.lib.common import print_green, shout, EXIT_SIGNALS
 from hokusai.lib.exceptions import HokusaiError
 from hokusai.services.docker import Docker
 from hokusai.lib.template_selector import TemplateSelector
-from hokusai.services.kubernetes_spec import KubernetesSpec
+from hokusai.services.yaml_spec import YamlSpec
 
 @command()
 def dev_start(build, detach, filename):
@@ -17,7 +17,7 @@ def dev_start(build, detach, filename):
   else:
     yaml_template = TemplateSelector().get(filename)
 
-  docker_compose_yml = KubernetesSpec(yaml_template).to_file()
+  docker_compose_yml = YamlSpec(yaml_template).to_file()
 
   def cleanup(*args):
     shout("docker-compose -f %s -p hokusai stop" % docker_compose_yml, print_output=True)
@@ -45,7 +45,7 @@ def dev_stop(filename):
   else:
     yaml_template = TemplateSelector().get(filename)
 
-  docker_compose_yml = KubernetesSpec(yaml_template).to_file()
+  docker_compose_yml = YamlSpec(yaml_template).to_file()
 
   shout("docker-compose -f %s -p hokusai stop" % docker_compose_yml, print_output=True)
 
@@ -56,7 +56,7 @@ def dev_status(filename):
   else:
     yaml_template = TemplateSelector().get(filename)
 
-  docker_compose_yml = KubernetesSpec(yaml_template).to_file()
+  docker_compose_yml = YamlSpec(yaml_template).to_file()
 
   shout("docker-compose -f %s -p hokusai ps" % docker_compose_yml, print_output=True)
 
@@ -67,7 +67,7 @@ def dev_logs(follow, tail, filename):
   else:
     yaml_template = TemplateSelector().get(filename)
 
-  docker_compose_yml = KubernetesSpec(yaml_template).to_file()
+  docker_compose_yml = YamlSpec(yaml_template).to_file()
 
   opts = ''
   if follow:
@@ -84,7 +84,7 @@ def dev_run(command, service_name, stop, filename):
   else:
     yaml_template = TemplateSelector().get(filename)
 
-  docker_compose_yml = KubernetesSpec(yaml_template).to_file()
+  docker_compose_yml = YamlSpec(yaml_template).to_file()
 
   if service_name is None:
     service_name = config.project_name
@@ -101,7 +101,7 @@ def dev_clean(filename):
   else:
     yaml_template = TemplateSelector().get(filename)
 
-  docker_compose_yml = KubernetesSpec(yaml_template).to_file()
+  docker_compose_yml = YamlSpec(yaml_template).to_file()
 
   shout("docker-compose -f %s -p hokusai stop" % docker_compose_yml, print_output=True)
   shout("docker-compose -f %s -p hokusai rm --force" % docker_compose_yml, print_output=True)

--- a/hokusai/commands/development.py
+++ b/hokusai/commands/development.py
@@ -7,16 +7,17 @@ from hokusai.lib.config import HOKUSAI_CONFIG_DIR, DEVELOPMENT_YML_FILE, config
 from hokusai.lib.common import print_green, shout, EXIT_SIGNALS
 from hokusai.lib.exceptions import HokusaiError
 from hokusai.services.docker import Docker
+from hokusai.lib.template_selector import TemplateSelector
+from hokusai.services.kubernetes_spec import KubernetesSpec
 
 @command()
 def dev_start(build, detach, filename):
   if filename is None:
-    docker_compose_yml = os.path.join(CWD, HOKUSAI_CONFIG_DIR, DEVELOPMENT_YML_FILE)
+    yaml_template = TemplateSelector().get(os.path.join(CWD, HOKUSAI_CONFIG_DIR, DEVELOPMENT_YML_FILE))
   else:
-    docker_compose_yml = filename
+    yaml_template = TemplateSelector().get(filename)
 
-  if not os.path.isfile(docker_compose_yml):
-    raise HokusaiError("Yaml file %s does not exist." % docker_compose_yml)
+  docker_compose_yml = KubernetesSpec(yaml_template).to_file()
 
   def cleanup(*args):
     shout("docker-compose -f %s -p hokusai stop" % docker_compose_yml, print_output=True)
@@ -40,36 +41,33 @@ def dev_start(build, detach, filename):
 @command()
 def dev_stop(filename):
   if filename is None:
-    docker_compose_yml = os.path.join(CWD, HOKUSAI_CONFIG_DIR, DEVELOPMENT_YML_FILE)
+    yaml_template = TemplateSelector().get(os.path.join(CWD, HOKUSAI_CONFIG_DIR, DEVELOPMENT_YML_FILE))
   else:
-    docker_compose_yml = filename
+    yaml_template = TemplateSelector().get(filename)
 
-  if not os.path.isfile(docker_compose_yml):
-    raise HokusaiError("Yaml file %s does not exist." % docker_compose_yml)
+  docker_compose_yml = KubernetesSpec(yaml_template).to_file()
 
   shout("docker-compose -f %s -p hokusai stop" % docker_compose_yml, print_output=True)
 
 @command()
 def dev_status(filename):
   if filename is None:
-    docker_compose_yml = os.path.join(CWD, HOKUSAI_CONFIG_DIR, DEVELOPMENT_YML_FILE)
+    yaml_template = TemplateSelector().get(os.path.join(CWD, HOKUSAI_CONFIG_DIR, DEVELOPMENT_YML_FILE))
   else:
-    docker_compose_yml = filename
+    yaml_template = TemplateSelector().get(filename)
 
-  if not os.path.isfile(docker_compose_yml):
-    raise HokusaiError("Yaml file %s does not exist." % docker_compose_yml)
+  docker_compose_yml = KubernetesSpec(yaml_template).to_file()
 
   shout("docker-compose -f %s -p hokusai ps" % docker_compose_yml, print_output=True)
 
 @command()
 def dev_logs(follow, tail, filename):
   if filename is None:
-    docker_compose_yml = os.path.join(CWD, HOKUSAI_CONFIG_DIR, DEVELOPMENT_YML_FILE)
+    yaml_template = TemplateSelector().get(os.path.join(CWD, HOKUSAI_CONFIG_DIR, DEVELOPMENT_YML_FILE))
   else:
-    docker_compose_yml = filename
+    yaml_template = TemplateSelector().get(filename)
 
-  if not os.path.isfile(docker_compose_yml):
-    raise HokusaiError("Yaml file %s does not exist." % docker_compose_yml)
+  docker_compose_yml = KubernetesSpec(yaml_template).to_file()
 
   opts = ''
   if follow:
@@ -82,12 +80,11 @@ def dev_logs(follow, tail, filename):
 @command()
 def dev_run(command, service_name, stop, filename):
   if filename is None:
-    docker_compose_yml = os.path.join(CWD, HOKUSAI_CONFIG_DIR, DEVELOPMENT_YML_FILE)
+    yaml_template = TemplateSelector().get(os.path.join(CWD, HOKUSAI_CONFIG_DIR, DEVELOPMENT_YML_FILE))
   else:
-    docker_compose_yml = filename
+    yaml_template = TemplateSelector().get(filename)
 
-  if not os.path.isfile(docker_compose_yml):
-    raise HokusaiError("Yaml file %s does not exist." % docker_compose_yml)
+  docker_compose_yml = KubernetesSpec(yaml_template).to_file()
 
   if service_name is None:
     service_name = config.project_name
@@ -100,12 +97,11 @@ def dev_run(command, service_name, stop, filename):
 @command()
 def dev_clean(filename):
   if filename is None:
-    docker_compose_yml = os.path.join(CWD, HOKUSAI_CONFIG_DIR, DEVELOPMENT_YML_FILE)
+    yaml_template = TemplateSelector().get(os.path.join(CWD, HOKUSAI_CONFIG_DIR, DEVELOPMENT_YML_FILE))
   else:
-    docker_compose_yml = filename
+    yaml_template = TemplateSelector().get(filename)
 
-  if not os.path.isfile(docker_compose_yml):
-    raise HokusaiError("Yaml file %s does not exist." % docker_compose_yml)
+  docker_compose_yml = KubernetesSpec(yaml_template).to_file()
 
   shout("docker-compose -f %s -p hokusai stop" % docker_compose_yml, print_output=True)
   shout("docker-compose -f %s -p hokusai rm --force" % docker_compose_yml, print_output=True)

--- a/hokusai/commands/kubernetes.py
+++ b/hokusai/commands/kubernetes.py
@@ -4,6 +4,7 @@ from hokusai import CWD
 from hokusai.lib.command import command
 from hokusai.lib.config import HOKUSAI_CONFIG_DIR, config
 from hokusai.lib.common import print_green, shout, returncode
+from hokusai.lib.template_selector import TemplateSelector
 from hokusai.services.ecr import ECR
 from hokusai.services.kubectl import Kubectl
 from hokusai.services.configmap import ConfigMap
@@ -13,12 +14,9 @@ from hokusai.lib.exceptions import HokusaiError
 @command()
 def k8s_create(context, tag='latest', namespace=None, filename=None, environment=()):
   if filename is None:
-    kubernetes_yml = os.path.join(CWD, HOKUSAI_CONFIG_DIR, "%s.yml" % context)
+    yaml_template = TemplateSelector().get(os.path.join(CWD, HOKUSAI_CONFIG_DIR, context))
   else:
-    kubernetes_yml = filename
-
-  if not os.path.isfile(kubernetes_yml):
-    raise HokusaiError("Yaml file %s does not exist." % kubernetes_yml)
+    yaml_template = TemplateSelector().get(filename)
 
   ecr = ECR()
   if not ecr.project_repo_exists():
@@ -52,12 +50,9 @@ def k8s_create(context, tag='latest', namespace=None, filename=None, environment
 def k8s_update(context, namespace=None, filename=None, check_branch="master",
                 check_remote=None, skip_checks=False, dry_run=False):
   if filename is None:
-    kubernetes_yml = os.path.join(CWD, HOKUSAI_CONFIG_DIR, "%s.yml" % context)
+    yaml_template = TemplateSelector().get(os.path.join(CWD, HOKUSAI_CONFIG_DIR, context))
   else:
-    kubernetes_yml = filename
-
-  if not os.path.isfile(kubernetes_yml):
-    raise HokusaiError("Yaml file %s does not exist." % kubernetes_yml)
+    yaml_template = TemplateSelector().get(filename)
 
   if not skip_checks:
     current_branch = None
@@ -91,12 +86,9 @@ def k8s_update(context, namespace=None, filename=None, check_branch="master",
 @command()
 def k8s_delete(context, namespace=None, filename=None):
   if filename is None:
-    kubernetes_yml = os.path.join(CWD, HOKUSAI_CONFIG_DIR, "%s.yml" % context)
+    yaml_template = TemplateSelector().get(os.path.join(CWD, HOKUSAI_CONFIG_DIR, context))
   else:
-    kubernetes_yml = filename
-
-  if not os.path.isfile(kubernetes_yml):
-    raise HokusaiError("Yaml file %s does not exist." % kubernetes_yml)
+    yaml_template = TemplateSelector().get(filename)
 
   if filename is None:
     configmap = ConfigMap(context, namespace=namespace)
@@ -113,12 +105,9 @@ def k8s_delete(context, namespace=None, filename=None):
 @command()
 def k8s_status(context, resources, pods, describe, top, namespace=None, filename=None):
   if filename is None:
-    kubernetes_yml = os.path.join(CWD, HOKUSAI_CONFIG_DIR, "%s.yml" % context)
+    yaml_template = TemplateSelector().get(os.path.join(CWD, HOKUSAI_CONFIG_DIR, context))
   else:
-    kubernetes_yml = filename
-
-  if not os.path.isfile(kubernetes_yml):
-    raise HokusaiError("Yaml file %s does not exist." % kubernetes_yml)
+    yaml_template = TemplateSelector().get(filename)
 
   kctl = Kubectl(context, namespace=namespace)
   kubernetes_spec = KubernetesSpec(yaml_template).to_file()

--- a/hokusai/commands/kubernetes.py
+++ b/hokusai/commands/kubernetes.py
@@ -42,12 +42,10 @@ def k8s_create(context, tag='latest', namespace=None, filename=None, environment
     print_green("Created configmap %s-environment" % config.project_name)
 
   kctl = Kubectl(context, namespace=namespace)
-  kubernetes_spec = KubernetesSpec(kubernetes_yml).to_file()
-  try:
-    shout(kctl.command("create --save-config -f %s" % kubernetes_spec), print_output=True)
-    print_green("Created Kubernetes environment %s" % kubernetes_yml)
-  finally:
-    os.unlink(kubernetes_spec)
+  kubernetes_spec = KubernetesSpec(yaml_template).to_file()
+
+  shout(kctl.command("create --save-config -f %s" % kubernetes_spec), print_output=True)
+  print_green("Created Kubernetes environment %s" % yaml_template)
 
 
 @command()
@@ -80,16 +78,14 @@ def k8s_update(context, namespace=None, filename=None, check_branch="master",
         raise HokusaiError("Local branch %s is divergent from %s/%s.  Aborting." % (current_branch, remote, current_branch))
 
   kctl = Kubectl(context, namespace=namespace)
-  kubernetes_spec = KubernetesSpec(kubernetes_yml).to_file()
-  try:
-    if dry_run:
-      shout(kctl.command("apply -f %s --dry-run" % kubernetes_spec), print_output=True)
-      print_green("Updated Kubernetes environment %s (dry run)" % kubernetes_yml)
-    else:
-      shout(kctl.command("apply -f %s" % kubernetes_spec), print_output=True)
-      print_green("Updated Kubernetes environment %s" % kubernetes_yml)
-  finally:
-    os.unlink(kubernetes_spec)
+  kubernetes_spec = KubernetesSpec(yaml_template).to_file()
+
+  if dry_run:
+    shout(kctl.command("apply -f %s --dry-run" % kubernetes_spec), print_output=True)
+    print_green("Updated Kubernetes environment %s (dry run)" % yaml_template)
+  else:
+    shout(kctl.command("apply -f %s" % kubernetes_spec), print_output=True)
+    print_green("Updated Kubernetes environment %s" % yaml_template)
 
 
 @command()
@@ -108,12 +104,11 @@ def k8s_delete(context, namespace=None, filename=None):
     print_green("Deleted configmap %s-environment" % config.project_name)
 
   kctl = Kubectl(context, namespace=namespace)
-  kubernetes_spec = KubernetesSpec(kubernetes_yml).to_file()
-  try:
-    shout(kctl.command("delete -f %s" % kubernetes_spec), print_output=True)
-    print_green("Deleted Kubernetes environment %s" % kubernetes_yml)
-  finally:
-    os.unlink(kubernetes_spec)
+  kubernetes_spec = KubernetesSpec(yaml_template).to_file()
+
+  shout(kctl.command("delete -f %s" % kubernetes_spec), print_output=True)
+  print_green("Deleted Kubernetes environment %s" % yaml_template)
+
 
 @command()
 def k8s_status(context, resources, pods, describe, top, namespace=None, filename=None):
@@ -126,28 +121,27 @@ def k8s_status(context, resources, pods, describe, top, namespace=None, filename
     raise HokusaiError("Yaml file %s does not exist." % kubernetes_yml)
 
   kctl = Kubectl(context, namespace=namespace)
-  kubernetes_spec = KubernetesSpec(kubernetes_yml).to_file()
-  try:
-    if describe:
-      kctl_cmd = "describe"
-      output = ""
-    else:
-      kctl_cmd = "get"
-      output = " -o wide"
-    if resources:
-      print_green("Resources", newline_before=True)
-      print_green("===========")
-      shout(kctl.command("%s -f %s%s" % (kctl_cmd, kubernetes_spec, output)), print_output=True)
-    if pods:
-      print_green("Pods", newline_before=True)
-      print_green("===========")
-      shout(kctl.command("%s pods --selector app=%s,layer=application%s" % (kctl_cmd, config.project_name, output)), print_output=True)
-    if top:
-      print_green("Top Pods", newline_before=True)
-      print_green("===========")
-      shout(kctl.command("top pods --selector app=%s,layer=application" % config.project_name), print_output=True)
-  finally:
-    os.unlink(kubernetes_spec)
+  kubernetes_spec = KubernetesSpec(yaml_template).to_file()
+
+  if describe:
+    kctl_cmd = "describe"
+    output = ""
+  else:
+    kctl_cmd = "get"
+    output = " -o wide"
+  if resources:
+    print_green("Resources", newline_before=True)
+    print_green("===========")
+    shout(kctl.command("%s -f %s%s" % (kctl_cmd, kubernetes_spec, output)), print_output=True)
+  if pods:
+    print_green("Pods", newline_before=True)
+    print_green("===========")
+    shout(kctl.command("%s pods --selector app=%s,layer=application%s" % (kctl_cmd, config.project_name, output)), print_output=True)
+  if top:
+    print_green("Top Pods", newline_before=True)
+    print_green("===========")
+    shout(kctl.command("top pods --selector app=%s,layer=application" % config.project_name), print_output=True)
+
 
 
 @command()

--- a/hokusai/commands/kubernetes.py
+++ b/hokusai/commands/kubernetes.py
@@ -8,7 +8,7 @@ from hokusai.lib.template_selector import TemplateSelector
 from hokusai.services.ecr import ECR
 from hokusai.services.kubectl import Kubectl
 from hokusai.services.configmap import ConfigMap
-from hokusai.services.kubernetes_spec import KubernetesSpec
+from hokusai.services.yaml_spec import YamlSpec
 from hokusai.lib.exceptions import HokusaiError
 
 @command()
@@ -40,9 +40,9 @@ def k8s_create(context, tag='latest', namespace=None, filename=None, environment
     print_green("Created configmap %s-environment" % config.project_name)
 
   kctl = Kubectl(context, namespace=namespace)
-  kubernetes_spec = KubernetesSpec(yaml_template).to_file()
+  yaml_spec = YamlSpec(yaml_template).to_file()
 
-  shout(kctl.command("create --save-config -f %s" % kubernetes_spec), print_output=True)
+  shout(kctl.command("create --save-config -f %s" % yaml_spec), print_output=True)
   print_green("Created Kubernetes environment %s" % yaml_template)
 
 
@@ -73,13 +73,13 @@ def k8s_update(context, namespace=None, filename=None, check_branch="master",
         raise HokusaiError("Local branch %s is divergent from %s/%s.  Aborting." % (current_branch, remote, current_branch))
 
   kctl = Kubectl(context, namespace=namespace)
-  kubernetes_spec = KubernetesSpec(yaml_template).to_file()
+  yaml_spec = YamlSpec(yaml_template).to_file()
 
   if dry_run:
-    shout(kctl.command("apply -f %s --dry-run" % kubernetes_spec), print_output=True)
+    shout(kctl.command("apply -f %s --dry-run" % yaml_spec), print_output=True)
     print_green("Updated Kubernetes environment %s (dry run)" % yaml_template)
   else:
-    shout(kctl.command("apply -f %s" % kubernetes_spec), print_output=True)
+    shout(kctl.command("apply -f %s" % yaml_spec), print_output=True)
     print_green("Updated Kubernetes environment %s" % yaml_template)
 
 
@@ -96,9 +96,9 @@ def k8s_delete(context, namespace=None, filename=None):
     print_green("Deleted configmap %s-environment" % config.project_name)
 
   kctl = Kubectl(context, namespace=namespace)
-  kubernetes_spec = KubernetesSpec(yaml_template).to_file()
+  yaml_spec = YamlSpec(yaml_template).to_file()
 
-  shout(kctl.command("delete -f %s" % kubernetes_spec), print_output=True)
+  shout(kctl.command("delete -f %s" % yaml_spec), print_output=True)
   print_green("Deleted Kubernetes environment %s" % yaml_template)
 
 
@@ -110,7 +110,7 @@ def k8s_status(context, resources, pods, describe, top, namespace=None, filename
     yaml_template = TemplateSelector().get(filename)
 
   kctl = Kubectl(context, namespace=namespace)
-  kubernetes_spec = KubernetesSpec(yaml_template).to_file()
+  yaml_spec = YamlSpec(yaml_template).to_file()
 
   if describe:
     kctl_cmd = "describe"
@@ -121,7 +121,7 @@ def k8s_status(context, resources, pods, describe, top, namespace=None, filename
   if resources:
     print_green("Resources", newline_before=True)
     print_green("===========")
-    shout(kctl.command("%s -f %s%s" % (kctl_cmd, kubernetes_spec, output)), print_output=True)
+    shout(kctl.command("%s -f %s%s" % (kctl_cmd, yaml_spec, output)), print_output=True)
   if pods:
     print_green("Pods", newline_before=True)
     print_green("===========")

--- a/hokusai/commands/namespace.py
+++ b/hokusai/commands/namespace.py
@@ -8,12 +8,12 @@ from hokusai.lib.exceptions import HokusaiError
 from hokusai.lib.common import print_green, clean_string
 from hokusai.lib.constants import YAML_HEADER
 from hokusai.lib.config import HOKUSAI_CONFIG_DIR
-from hokusai.services.kubernetes_spec import KubernetesSpec
+from hokusai.services.yaml_spec import YamlSpec
 
 @command()
 def create_new_app_yaml(source_file, app_name):
-  kubernetes_spec = KubernetesSpec(source_file).to_file()
-  with open(kubernetes_spec, 'r') as stream:
+  yaml_spec = YamlSpec(source_file).to_file()
+  with open(yaml_spec, 'r') as stream:
     try:
       yaml_content = list(yaml.load_all(stream))
     except yaml.YAMLError as exc:

--- a/hokusai/commands/namespace.py
+++ b/hokusai/commands/namespace.py
@@ -8,14 +8,19 @@ from hokusai.lib.exceptions import HokusaiError
 from hokusai.lib.common import print_green, clean_string
 from hokusai.lib.constants import YAML_HEADER
 from hokusai.lib.config import HOKUSAI_CONFIG_DIR
+from hokusai.services.kubernetes_spec import KubernetesSpec
 
 @command()
 def create_new_app_yaml(source_file, app_name):
-  with open(source_file, 'r') as stream:
-    try:
-      yaml_content = list(yaml.load_all(stream))
-    except yaml.YAMLError as exc:
-      raise HokusaiError("Cannot read source yaml file %s." % source_file)
+  kubernetes_spec = KubernetesSpec(source_file).to_file()
+  try:
+    with open(kubernetes_spec, 'r') as stream:
+      try:
+        yaml_content = list(yaml.load_all(stream))
+      except yaml.YAMLError as exc:
+        raise HokusaiError("Cannot read source yaml file %s." % source_file)
+  finally:
+    os.unlink(kubernetes_spec)
 
   for c in yaml_content: update_namespace(c, clean_string(app_name))
 

--- a/hokusai/commands/namespace.py
+++ b/hokusai/commands/namespace.py
@@ -13,14 +13,11 @@ from hokusai.services.kubernetes_spec import KubernetesSpec
 @command()
 def create_new_app_yaml(source_file, app_name):
   kubernetes_spec = KubernetesSpec(source_file).to_file()
-  try:
-    with open(kubernetes_spec, 'r') as stream:
-      try:
-        yaml_content = list(yaml.load_all(stream))
-      except yaml.YAMLError as exc:
-        raise HokusaiError("Cannot read source yaml file %s." % source_file)
-  finally:
-    os.unlink(kubernetes_spec)
+  with open(kubernetes_spec, 'r') as stream:
+    try:
+      yaml_content = list(yaml.load_all(stream))
+    except yaml.YAMLError as exc:
+      raise HokusaiError("Cannot read source yaml file %s." % source_file)
 
   for c in yaml_content: update_namespace(c, clean_string(app_name))
 

--- a/hokusai/commands/test.py
+++ b/hokusai/commands/test.py
@@ -7,16 +7,17 @@ from hokusai.lib.config import HOKUSAI_CONFIG_DIR, TEST_YML_FILE, config
 from hokusai.lib.common import print_green, shout, EXIT_SIGNALS
 from hokusai.lib.exceptions import CalledProcessError, HokusaiError
 from hokusai.services.docker import Docker
+from hokusai.lib.template_selector import TemplateSelector
+from hokusai.services.kubernetes_spec import KubernetesSpec
 
 @command()
 def test(build, cleanup, filename, service_name):
   if filename is None:
-    docker_compose_yml = os.path.join(CWD, HOKUSAI_CONFIG_DIR, TEST_YML_FILE)
+    yaml_template = TemplateSelector().get(os.path.join(CWD, HOKUSAI_CONFIG_DIR, TEST_YML_FILE))
   else:
-    docker_compose_yml = filename
+    yaml_template = TemplateSelector().get(filename)
 
-  if not os.path.isfile(docker_compose_yml):
-    raise HokusaiError("Yaml file %s does not exist." % docker_compose_yml)
+  docker_compose_yml = KubernetesSpec(yaml_template).to_file()
 
   def on_cleanup(*args):
     shout("docker-compose -f %s -p hokusai stop" % docker_compose_yml)

--- a/hokusai/commands/test.py
+++ b/hokusai/commands/test.py
@@ -8,7 +8,7 @@ from hokusai.lib.common import print_green, shout, EXIT_SIGNALS
 from hokusai.lib.exceptions import CalledProcessError, HokusaiError
 from hokusai.services.docker import Docker
 from hokusai.lib.template_selector import TemplateSelector
-from hokusai.services.kubernetes_spec import KubernetesSpec
+from hokusai.services.yaml_spec import YamlSpec
 
 @command()
 def test(build, cleanup, filename, service_name):
@@ -17,7 +17,7 @@ def test(build, cleanup, filename, service_name):
   else:
     yaml_template = TemplateSelector().get(filename)
 
-  docker_compose_yml = KubernetesSpec(yaml_template).to_file()
+  docker_compose_yml = YamlSpec(yaml_template).to_file()
 
   def on_cleanup(*args):
     shout("docker-compose -f %s -p hokusai stop" % docker_compose_yml)

--- a/hokusai/lib/config.py
+++ b/hokusai/lib/config.py
@@ -16,9 +16,9 @@ from hokusai.version import VERSION
 HOKUSAI_ENV_VAR_PREFIX = 'HOKUSAI_'
 HOKUSAI_CONFIG_DIR = 'hokusai'
 HOKUSAI_CONFIG_FILE = os.path.join(CWD, HOKUSAI_CONFIG_DIR, 'config.yml')
-BUILD_YAML_FILE = 'build.yml'
-TEST_YML_FILE = 'test.yml'
-DEVELOPMENT_YML_FILE = 'development.yml'
+BUILD_YAML_FILE = 'build'
+TEST_YML_FILE = 'test'
+DEVELOPMENT_YML_FILE = 'development'
 
 class HokusaiConfig(object):
   def create(self, project_name):

--- a/hokusai/lib/config.py
+++ b/hokusai/lib/config.py
@@ -17,7 +17,6 @@ HOKUSAI_ENV_VAR_PREFIX = 'HOKUSAI_'
 HOKUSAI_CONFIG_DIR = 'hokusai'
 HOKUSAI_CONFIG_FILE = os.path.join(CWD, HOKUSAI_CONFIG_DIR, 'config.yml')
 BUILD_YAML_FILE = 'build.yml'
-LEGACY_BUILD_YAML_FILE = 'common.yml'
 TEST_YML_FILE = 'test.yml'
 DEVELOPMENT_YML_FILE = 'development.yml'
 

--- a/hokusai/lib/config.py
+++ b/hokusai/lib/config.py
@@ -22,6 +22,10 @@ TEST_YML_FILE = 'test'
 DEVELOPMENT_YML_FILE = 'development'
 
 class HokusaiConfig(object):
+  def __init__(self):
+    if not os.path.isdir(HOKUSAI_TMP_DIR):
+      os.mkdir(HOKUSAI_TMP_DIR)
+
   def create(self, project_name):
     config = OrderedDict([
       ('project-name', project_name)

--- a/hokusai/lib/config.py
+++ b/hokusai/lib/config.py
@@ -15,6 +15,7 @@ from hokusai.version import VERSION
 
 HOKUSAI_ENV_VAR_PREFIX = 'HOKUSAI_'
 HOKUSAI_CONFIG_DIR = 'hokusai'
+HOKUSAI_TMP_DIR = os.path.join(CWD, '.hokusai-tmp')
 HOKUSAI_CONFIG_FILE = os.path.join(CWD, HOKUSAI_CONFIG_DIR, 'config.yml')
 BUILD_YAML_FILE = 'build'
 TEST_YML_FILE = 'test'

--- a/hokusai/lib/template_selector.py
+++ b/hokusai/lib/template_selector.py
@@ -1,0 +1,21 @@
+import os
+
+from hokusai.lib.exceptions import HokusaiError
+
+class TemplateSelector(object):
+  def get(self, path):
+    _path_root, _file_ext = os.path.splitext(path)
+
+    if _file_ext:
+      if not os.path.isfile(path):
+        raise HokusaiError("File %s does not exist." % path)
+      return path
+
+    if os.path.isfile(path + '.yml'):
+      return path + '.yml'
+    if os.path.isfile(path + '.yaml'):
+      return path + '.yaml'
+    if os.path.isfile(path + '.yml.j2'):
+      return path + '.yml.j2'
+    if os.path.isfile(path + '.yaml.j2'):
+      return path + '.yaml.j2'

--- a/hokusai/services/configmap.py
+++ b/hokusai/services/configmap.py
@@ -5,7 +5,7 @@ from tempfile import NamedTemporaryFile
 
 import json
 
-from hokusai.lib.config import config
+from hokusai.lib.config import config, HOKUSAI_TMP_DIR
 from hokusai.lib.common import print_green, shout
 from hokusai.services.kubectl import Kubectl
 from hokusai.lib.exceptions import HokusaiError
@@ -29,7 +29,7 @@ class ConfigMap(object):
     }
 
   def _to_file(self):
-    f = NamedTemporaryFile(delete=False)
+    f = NamedTemporaryFile(delete=False, dir=HOKUSAI_TMP_DIR)
     f.write(json.dumps(self.struct))
     f.close()
     return f

--- a/hokusai/services/deployment.py
+++ b/hokusai/services/deployment.py
@@ -11,7 +11,7 @@ from hokusai.services.kubectl import Kubectl
 from hokusai.services.ecr import ECR, ClientError
 from hokusai.lib.common import print_green, print_red, print_yellow, shout, shout_concurrent
 from hokusai.services.command_runner import CommandRunner
-from hokusai.services.kubernetes_spec import KubernetesSpec
+from hokusai.services.yaml_spec import YamlSpec
 from hokusai.lib.exceptions import CalledProcessError, HokusaiError
 from hokusai.lib.constants import YAML_HEADER
 
@@ -69,13 +69,13 @@ class Deployment(object):
     else:
       kubernetes_yml = filename
 
-    kubernetes_spec = KubernetesSpec(kubernetes_yml).to_list()
+    yaml_spec = YamlSpec(kubernetes_yml).to_list()
 
     # If a review app, a canary app or the canonical app while updating config,
     # bust the deployment cache and populate deployments from the yaml file
     if filename or update_config:
       self.cache = []
-      for item in kubernetes_spec:
+      for item in yaml_spec:
         if item['kind'] == 'Deployment':
           self.cache.append(item)
 
@@ -83,7 +83,7 @@ class Deployment(object):
     if update_config:
       print_green("Patching Deployments in spec %s with image digest %s" % (kubernetes_yml, digest), newline_after=True)
       payload = []
-      for item in kubernetes_spec:
+      for item in yaml_spec:
         if item['kind'] == 'Deployment':
           item['spec']['template']['metadata']['labels']['deploymentTimestamp'] = deployment_timestamp
           item['spec']['progressDeadlineSeconds'] = timeout

--- a/hokusai/services/deployment.py
+++ b/hokusai/services/deployment.py
@@ -6,7 +6,7 @@ from tempfile import NamedTemporaryFile
 import yaml
 
 from hokusai import CWD
-from hokusai.lib.config import HOKUSAI_CONFIG_DIR, config
+from hokusai.lib.config import HOKUSAI_CONFIG_DIR, HOKUSAI_TMP_DIR, config
 from hokusai.services.kubectl import Kubectl
 from hokusai.services.ecr import ECR, ClientError
 from hokusai.lib.common import print_green, print_red, print_yellow, shout, shout_concurrent
@@ -92,7 +92,7 @@ class Deployment(object):
               container['image'] = "%s@%s" % (self.ecr.project_repo, digest)
         payload.append(item)
 
-      f = NamedTemporaryFile(delete=False)
+      f = NamedTemporaryFile(delete=False, dir=HOKUSAI_TMP_DIR)
       f.write(YAML_HEADER)
       f.write(yaml.safe_dump_all(payload, default_flow_style=False))
       f.close()

--- a/hokusai/services/docker.py
+++ b/hokusai/services/docker.py
@@ -1,7 +1,7 @@
 import os
 
 from hokusai import CWD
-from hokusai.lib.config import HOKUSAI_CONFIG_DIR, BUILD_YAML_FILE, LEGACY_BUILD_YAML_FILE, config
+from hokusai.lib.config import HOKUSAI_CONFIG_DIR, BUILD_YAML_FILE, config
 from hokusai.lib.common import shout
 from hokusai.lib.exceptions import HokusaiError
 
@@ -9,15 +9,12 @@ class Docker(object):
   def build(self, filename):
     if filename is None:
       docker_compose_yml = os.path.join(CWD, HOKUSAI_CONFIG_DIR, BUILD_YAML_FILE)
-      legacy_docker_compose_yml = os.path.join(CWD, HOKUSAI_CONFIG_DIR, LEGACY_BUILD_YAML_FILE)
 
       if not os.path.isfile(docker_compose_yml) and not os.path.isfile(legacy_docker_compose_yml):
         raise HokusaiError("Yaml files %s / %s do not exist." % (docker_compose_yml, legacy_docker_compose_yml))
 
       if os.path.isfile(docker_compose_yml):
         build_command = "docker-compose -f %s -p hokusai build" % docker_compose_yml
-      if os.path.isfile(legacy_docker_compose_yml):
-        build_command = "docker-compose -f %s -p hokusai build" % legacy_docker_compose_yml
     else:
       build_command = "docker-compose -f %s -p hokusai build" % filename
 

--- a/hokusai/services/docker.py
+++ b/hokusai/services/docker.py
@@ -4,7 +4,7 @@ from hokusai import CWD
 from hokusai.lib.config import HOKUSAI_CONFIG_DIR, BUILD_YAML_FILE, config
 from hokusai.lib.common import shout
 from hokusai.lib.template_selector import TemplateSelector
-from hokusai.services.kubernetes_spec import KubernetesSpec
+from hokusai.services.yaml_spec import YamlSpec
 
 class Docker(object):
   def build(self, filename):
@@ -13,7 +13,7 @@ class Docker(object):
     else:
       yaml_template = TemplateSelector().get(filename)
 
-    docker_compose_yml = KubernetesSpec(yaml_template).to_file()
+    docker_compose_yml = YamlSpec(yaml_template).to_file()
     build_command = "docker-compose -f %s -p hokusai build" % docker_compose_yml
 
     if config.pre_build:

--- a/hokusai/services/docker.py
+++ b/hokusai/services/docker.py
@@ -3,20 +3,18 @@ import os
 from hokusai import CWD
 from hokusai.lib.config import HOKUSAI_CONFIG_DIR, BUILD_YAML_FILE, config
 from hokusai.lib.common import shout
-from hokusai.lib.exceptions import HokusaiError
+from hokusai.lib.template_selector import TemplateSelector
+from hokusai.services.kubernetes_spec import KubernetesSpec
 
 class Docker(object):
   def build(self, filename):
     if filename is None:
-      docker_compose_yml = os.path.join(CWD, HOKUSAI_CONFIG_DIR, BUILD_YAML_FILE)
-
-      if not os.path.isfile(docker_compose_yml) and not os.path.isfile(legacy_docker_compose_yml):
-        raise HokusaiError("Yaml files %s / %s do not exist." % (docker_compose_yml, legacy_docker_compose_yml))
-
-      if os.path.isfile(docker_compose_yml):
-        build_command = "docker-compose -f %s -p hokusai build" % docker_compose_yml
+      yaml_template = TemplateSelector().get(os.path.join(CWD, HOKUSAI_CONFIG_DIR, BUILD_YAML_FILE))
     else:
-      build_command = "docker-compose -f %s -p hokusai build" % filename
+      yaml_template = TemplateSelector().get(filename)
+
+    docker_compose_yml = KubernetesSpec(yaml_template).to_file()
+    build_command = "docker-compose -f %s -p hokusai build" % docker_compose_yml
 
     if config.pre_build:
       build_command = "%s && %s" % (config.pre_build, build_command)

--- a/hokusai/services/yaml_spec.py
+++ b/hokusai/services/yaml_spec.py
@@ -13,7 +13,7 @@ from hokusai.lib.exceptions import HokusaiError
 
 from hokusai.services.ecr import ECR
 
-class KubernetesSpec(object):
+class YamlSpec(object):
   def __init__(self, kubernetes_yaml):
     self.kubernetes_yaml = kubernetes_yaml
     self.ecr = ECR()

--- a/hokusai/services/yaml_spec.py
+++ b/hokusai/services/yaml_spec.py
@@ -3,9 +3,7 @@ import atexit
 
 import yaml
 
-from tempfile import NamedTemporaryFile
-
-from hokusai.lib.config import config
+from hokusai.lib.config import config, HOKUSAI_TMP_DIR
 from hokusai.lib.config_loader import ConfigLoader
 from hokusai.lib.template_renderer import TemplateRenderer
 
@@ -39,7 +37,7 @@ class YamlSpec(object):
     return rendered_template
 
   def to_file(self):
-    f = NamedTemporaryFile(delete=False)
+    f = open(os.path.join(HOKUSAI_TMP_DIR, os.path.basename(self.kubernetes_yaml)), 'w+b')
     f.write(self.to_string())
     f.close()
     self.tmp_filename = f.name
@@ -49,5 +47,7 @@ class YamlSpec(object):
     return list(yaml.safe_load_all(self.to_string()))
 
   def cleanup(self):
-    if self.tmp_filename is not None:
+    try:
       os.unlink(self.tmp_filename)
+    except:
+      pass

--- a/test/integration/test_review_app.py
+++ b/test/integration/test_review_app.py
@@ -1,0 +1,28 @@
+import os
+
+import httpretty
+
+from mock import patch
+
+from test import HokusaiIntegrationTestCase
+
+from hokusai import CWD
+from hokusai.commands.namespace import create_new_app_yaml
+
+class TestReviewApp(HokusaiIntegrationTestCase):
+    @patch('hokusai.lib.command.sys.exit')
+    @httpretty.activate
+    def test_create_review_app_yaml_file(self, mocked_sys_exit):
+        httpretty.register_uri(httpretty.POST, "https://sts.amazonaws.com/",
+                                body=open(os.path.join(os.getcwd(), 'test', 'fixtures', 'sts-get-caller-identity-response.xml')).read(),
+                                content_type="application/xml")
+        httpretty.register_uri(httpretty.POST, "https://api.ecr.us-east-1.amazonaws.com/",
+                                body=open(os.path.join(os.getcwd(), 'test', 'fixtures', 'ecr-repositories-response.json')).read(),
+                                content_type="application/x-amz-json-1.1")
+
+        review_app_yaml_file = os.path.join(CWD, 'hokusai', 'a-review-app.yml')
+        try:
+            create_new_app_yaml(os.path.abspath(os.path.join(CWD, 'test/fixtures/project/hokusai/minikube.yml')), 'a-review-app')
+            self.assertTrue(os.path.isfile(review_app_yaml_file))
+        finally:
+            os.remove(review_app_yaml_file)

--- a/test/unit/test_template_selector.py
+++ b/test/unit/test_template_selector.py
@@ -1,0 +1,46 @@
+import os
+
+import yaml
+
+from test import HokusaiUnitTestCase
+
+from hokusai import CWD
+from hokusai.lib.exceptions import HokusaiError
+
+from hokusai.lib.template_selector import TemplateSelector
+
+class TestTemplateSelector(HokusaiUnitTestCase):
+  def setUp(self):
+    self.template_path = os.path.join(CWD, 'test/fixtures/project/hokusai')
+
+  def test_finds_yml_file(self):
+    test_file = os.path.join(self.template_path, 'test.yml')
+    open(test_file, 'a').close()
+    self.assertEqual(TemplateSelector().get(os.path.join(self.template_path, 'test')), test_file)
+    os.remove(test_file)
+
+  def test_finds_yaml_file(self):
+    test_file = os.path.join(self.template_path, 'test.yaml')
+    open(test_file, 'a').close()
+    self.assertEqual(TemplateSelector().get(os.path.join(self.template_path, 'test')), test_file)
+    os.remove(test_file)
+
+  def test_finds_yml_j2_file(self):
+    test_file = os.path.join(self.template_path, 'test.yml.j2')
+    open(test_file, 'a').close()
+    self.assertEqual(TemplateSelector().get(os.path.join(self.template_path, 'test')), test_file)
+    os.remove(test_file)
+
+  def test_finds_yaml_j2_file(self):
+    test_file = os.path.join(self.template_path, 'test.yaml.j2')
+    open(test_file, 'a').close()
+    self.assertEqual(TemplateSelector().get(os.path.join(self.template_path, 'test')), test_file)
+    os.remove(test_file)
+
+  def test_finds_explicit_file_or_errors(self):
+    with self.assertRaises(HokusaiError):
+      TemplateSelector().get(os.path.join(self.template_path, 'test.yml'))
+    test_file = os.path.join(self.template_path, 'test.yml')
+    open(test_file, 'a').close()
+    self.assertEqual(TemplateSelector().get(os.path.join(self.template_path, 'test.yml')), test_file)
+    os.remove(test_file)

--- a/test/unit/test_yaml_spec.py
+++ b/test/unit/test_yaml_spec.py
@@ -7,26 +7,26 @@ from test import HokusaiUnitTestCase
 from hokusai import CWD
 from hokusai.lib.exceptions import HokusaiError
 
-from hokusai.services.kubernetes_spec import KubernetesSpec
+from hokusai.services.yaml_spec import YamlSpec
 
 httpretty.enable()
 httpretty.HTTPretty.allow_net_connect = False
 
-class TestKubernetesSpec(HokusaiUnitTestCase):
+class TestYamlSpec(HokusaiUnitTestCase):
   def setUp(self):
     self.kubernetes_yml = os.path.join(CWD, 'test/fixtures/kubernetes-config.yml')
 
   @httpretty.activate
-  def test_kubernetes_spec(self):
+  def test_yaml_spec(self):
     httpretty.register_uri(httpretty.POST, "https://sts.amazonaws.com/",
                             body=open(os.path.join(os.getcwd(), 'test', 'fixtures', 'sts-get-caller-identity-response.xml')).read(),
                             content_type="application/xml")
     httpretty.register_uri(httpretty.POST, "https://api.ecr.us-east-1.amazonaws.com/",
                             body=open(os.path.join(os.getcwd(), 'test', 'fixtures', 'ecr-repositories-response.json')).read(),
                             content_type="application/x-amz-json-1.1")
-    kubernetes_spec = KubernetesSpec(self.kubernetes_yml).to_list()
-    self.assertEqual(kubernetes_spec[0]['metadata']['name'], 'hello')
-    self.assertEqual(kubernetes_spec[0]['spec']['template']['spec']['containers'][0]['name'], 'web')
-    self.assertEqual(kubernetes_spec[0]['spec']['template']['spec']['containers'][0]['image'], 'eggs')
-    self.assertEqual(kubernetes_spec[0]['spec']['template']['spec']['containers'][1]['name'], 'worker')
-    self.assertEqual(kubernetes_spec[0]['spec']['template']['spec']['containers'][1]['image'], 'eggs')
+    yaml_spec = YamlSpec(self.kubernetes_yml).to_list()
+    self.assertEqual(yaml_spec[0]['metadata']['name'], 'hello')
+    self.assertEqual(yaml_spec[0]['spec']['template']['spec']['containers'][0]['name'], 'web')
+    self.assertEqual(yaml_spec[0]['spec']['template']['spec']['containers'][0]['image'], 'eggs')
+    self.assertEqual(yaml_spec[0]['spec']['template']['spec']['containers'][1]['name'], 'worker')
+    self.assertEqual(yaml_spec[0]['spec']['template']['spec']['containers'][1]['image'], 'eggs')


### PR DESCRIPTION
- Adds TemplateSelector - For a given filename, will look for a file extension yml, yaml, yml.j2 or yaml.j2 in that order, and return the first one it finds so we can experiment with linter settings 
- Remove looking for the "legacy" docker-compose build file which was before named "common"
- Generalize KubernetesSpec to YamlSpec and render docker-compose test / development files as Jinja templates as well (this necessitates Hokusai using a project-local tmp directory)
- Utilize a project-local hokusai tmp directory for other tmpfiles