### PR TITLE
For post deployment git tagging, force git to replace local tags.

### DIFF
--- a/hokusai/services/deployment.py
+++ b/hokusai/services/deployment.py
@@ -173,7 +173,7 @@ class Deployment(object):
             attempts += 1
             print_green("Creating Git deployment tags '%s', '%s', and pushing them to %s..." % (self.context, deployment_tag, remote))
             print_green("Attempt# %s." % attempts)
-            shout("git fetch %s --tags" % remote)
+            shout("git fetch -f %s --tags" % remote)
             shout("git tag -f %s %s" % (self.context, tag), print_output=True)
             shout("git tag -f %s %s" % (deployment_tag, tag), print_output=True)
             shout("git push -f --no-verify %s refs/tags/%s" % (remote, self.context), print_output=True)


### PR DESCRIPTION
We might have finally caught the git fetch error that has been causing post deploy Git tagging to fail on Circle. In this case, it happened locally from running `hokusai pipeline promote` for causality:

https://artsy.slack.com/archives/CP9P4KR35/p1592934718274700

```
WARNING: Creating Git deployment tags failed due to the error:
From github.com:artsy/causality
 * branch              HEAD       -> FETCH_HEAD
 ! [rejected]          production -> production  (would clobber existing tag)
 ! [rejected]          staging    -> staging  (would clobber existing tag)
Failed all attempts at pushing Git deployment tags! Please do it manually.
```

Looks like this is what happened: Local staging/production tag exist but are out of sync with origin, which is expected. Hokusai gets to post deployment Git tagging step and performs git fetch. Git, and that specific version of it, by default does not overwrite out of sync tags, so throws error.

My understanding is that Git tags are only ever created/modified by hokusai. Therefore, adding `-f` to git fetch should be an easy good fix to the problem.
