### PR TITLE
downgrade virtualenv to version 15.1.0 before installing pipenv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ VERSION ?= $(shell cat hokusai/VERSION)
 MINOR_VERSION ?= $(shell cat hokusai/VERSION | awk -F"." '{ print $$1"."$$2 }')
 
 dependencies:
+	pip install virtualenv==20.0.20
 	pip install pipenv --quiet --ignore-installed
 	pipenv install --dev
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ VERSION ?= $(shell cat hokusai/VERSION)
 MINOR_VERSION ?= $(shell cat hokusai/VERSION | awk -F"." '{ print $$1"."$$2 }')
 
 dependencies:
-	pip install virtualenv==20.0.20
+	pip install virtualenv==15.1.0
 	pip install pipenv --quiet --ignore-installed
 	pipenv install --dev
 


### PR DESCRIPTION
Fixes the build failure `ImportError: cannot import name ensure_file_on_disk` [when creating a virtualenv](https://circleci.com/gh/artsy/hokusai/1035) by downgrading virtualenv to version 15.1.0