### PR TITLE
fix ssl linking in pyinstaller builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,7 @@ jobs:
       xcode: "9.0"
     steps:
       - checkout
-      - run: HOMEBREW_NO_AUTO_UPDATE=1 brew install awscli
+      - run: HOMEBREW_NO_AUTO_UPDATE=1 brew install awscli openssl
       - run: make dependencies
       - run: make build VERSION=beta
       - run: make publish-beta
@@ -110,7 +110,7 @@ jobs:
       xcode: "9.0"
     steps:
       - checkout
-      - run: HOMEBREW_NO_AUTO_UPDATE=1 brew install awscli
+      - run: HOMEBREW_NO_AUTO_UPDATE=1 brew install awscli openssl
       - run: make dependencies
       - run: make build
       - run: make build VERSION=latest

--- a/bin/hokusai
+++ b/bin/hokusai
@@ -1,5 +1,11 @@
 #!/usr/bin/env python
 
+import sys
+import os
+
+if getattr(sys, 'frozen', False):
+    os.environ['SSL_CERT_FILE'] = os.path.join(sys._MEIPASS, 'lib', 'cert.pem')
+
 from hokusai.cli import *
 
 if __name__ == '__main__':

--- a/hokusai.spec
+++ b/hokusai.spec
@@ -1,12 +1,18 @@
 # -*- mode: python -*-
 
-block_cipher = None
+from PyInstaller.utils.hooks import exec_statement
 
+cert_datas = exec_statement("""
+    import ssl
+    print(ssl.get_default_verify_paths().cafile)""").strip().split()
+cert_datas = [(f, 'lib') for f in cert_datas]
+
+block_cipher = None
 
 a = Analysis(['bin/hokusai'],
              pathex=['.'],
              binaries=[],
-             datas=[('./hokusai/templates/*.j2', 'hokusai/templates/'), ('./hokusai/templates/.dockerignore.j2', 'hokusai/templates/'), ('./hokusai/templates/hokusai/*.j2', 'hokusai/templates/hokusai/'), ('./hokusai/VERSION', 'hokusai/')],
+             datas=[('./hokusai/templates/*.j2', 'hokusai/templates/'), ('./hokusai/templates/.dockerignore.j2', 'hokusai/templates/'), ('./hokusai/templates/hokusai/*.j2', 'hokusai/templates/hokusai/'), ('./hokusai/VERSION', 'hokusai/')] + cert_datas,
              hiddenimports=['ConfigParser'],
              hookspath=[],
              runtime_hooks=[],


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/PLATFORM-2543 and https://github.com/artsy/hokusai/issues/206 - fixes the Pyinstaller build so it includes the correct homebrew-installed openssl libs

Tested on the macos Pytinstaller build.

@artsyjian once merged can you test the beta build on Linux?