### PR TITLE
only link cafile in Darwin PyInstaller builds

### DIFF
--- a/hokusai.spec
+++ b/hokusai.spec
@@ -1,11 +1,15 @@
 # -*- mode: python -*-
 
-from PyInstaller.utils.hooks import exec_statement
+import platform
 
-cert_datas = exec_statement("""
-    import ssl
-    print(ssl.get_default_verify_paths().cafile)""").strip().split()
-cert_datas = [(f, 'lib') for f in cert_datas]
+if platform.system() == "Darwin":
+  from PyInstaller.utils.hooks import exec_statement
+  cert_datas = exec_statement("""
+      import ssl
+      print(ssl.get_default_verify_paths().cafile)""").strip().split()
+  cert_datas = [(f, 'lib') for f in cert_datas]
+else:
+  cert_datas = []
 
 block_cipher = None
 


### PR DESCRIPTION
Only link our cafile in Pyinstaller builds on Darwin.  @artsyjian we'll have to figure out the certs that are needed for a Linux PyInstaller build if we want to use it, but given we install on Debian/Ubuntu via pip in most cases this should not be a huge blocker.