### PR TITLE
Work around PEP-517 pip build system installing dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,3 @@ backports-abc = "*"
 futures = "*"
 nbformat = "==4.4.0"
 pylint = "*"
-
-[build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"


### PR DESCRIPTION
I started to get errors installing hokusai via `pip install .` in a Docker container due to unavailable gcc tools and realized introducing the `pyproject.toml` file caused pip to use `poetry` as its build system which then installed dev dependencies.

Pip introduced support for [PEP-517 -- A build-system independent format for source trees](https://www.python.org/dev/peps/pep-0517/#source-trees) in version 10 which respects the `pyproject.toml` file and support for the `build-backend` in [version 19](https://pip.pypa.io/en/stable/reference/pip/#pep-517-and-518-support).  These errors only manifest while running on pip version 19 or 20 so followed the lead of [this PR](https://github.com/corrscope/corrscope/pull/229/files) to default to the legacy build backend (i.e. `setuptools`).

Here are similar issues:
- https://github.com/pypa/pip/issues/6314
- https://github.com/python-poetry/poetry/issues/826

`pip install -e .` / `pip install .` now work as expected and only install dependencies specified in setup.py.  It may be nice in the future to use poetry as a production build backend but will require further investigation.
