### PR TITLE
Further Python 3 fixes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,8 @@
 .hokusai-tmp
 .idea
 
+.python-version
+
 build
 dist
 docs

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Full details are in the [Review App reference](./docs/Review_Apps.md).
 
 ## Distributing Hokusai
 
-Merges to master automatically distribute Pyinstaller versions for beta testing at https://artsy-provisioning-public.s3.amazonaws.com/hokusai/hokusai-head-Darwin-x86_64 and https://artsy-provisioning-public.s3.amazonaws.com/hokusai/hokusai-head-Linux-x86_64 respectively.
+Merges to master automatically distribute Pyinstaller versions for beta testing at https://artsy-provisioning-public.s3.amazonaws.com/hokusai/hokusai-beta-Darwin-x86_64 and https://artsy-provisioning-public.s3.amazonaws.com/hokusai/hokusai-beta-Linux-x86_64 respectively.
 
 To create a new release, bump the version by editing the `./hokusai VERSION` file, create an entry in CHANGELOG.md and open a PR from `master` to the `release` branch of this repo.
 

--- a/get-hokusai.sh
+++ b/get-hokusai.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+
+if [ "$1" ]; then
+  VERSION=$1
+else
+  VERSION=latest
+fi
+
+if [ "$2" ]; then
+  TARGET=$2
+else
+  TARGET=/usr/local/bin/hokusai
+fi
+
+echo "Installing Hokusai @ $VERSION to $TARGET"
+
+curl https://artsy-provisioning-public.s3.amazonaws.com/hokusai/hokusai-$VERSION-$(uname -s)-x86_64 -o $TARGET
+chmod +x $TARGET

--- a/hokusai.spec
+++ b/hokusai.spec
@@ -13,11 +13,17 @@ else:
 
 block_cipher = None
 
+import sys
+if sys.version_info[0] >= 3:
+  hidden_imports = ['configparser']
+else:
+  hidden_imports = ['ConfigParser']
+
 a = Analysis(['bin/hokusai'],
              pathex=['.'],
              binaries=[],
              datas=[('./hokusai/templates/*.j2', 'hokusai/templates/'), ('./hokusai/templates/.dockerignore.j2', 'hokusai/templates/'), ('./hokusai/templates/hokusai/*.j2', 'hokusai/templates/hokusai/'), ('./hokusai/VERSION', 'hokusai/')] + cert_datas,
-             hiddenimports=['ConfigParser'],
+             hiddenimports=hidden_imports,
              hookspath=[],
              runtime_hooks=[],
              excludes=[],

--- a/hokusai/lib/command.py
+++ b/hokusai/lib/command.py
@@ -28,9 +28,13 @@ def command(config_check=True):
         raise
       except (CalledProcessError, Exception) as e:
         if get_verbosity() or os.environ.get('DEBUG'):
-          print_red(traceback.format_exc(e))
+          print_red(traceback.format_exc())
         else:
           print_red("ERROR: %s" % str(e))
+        if hasattr(e, 'output'):
+          print(e.output.decode('utf-8'))
+        elif hasattr(e, 'message'):
+          print(e.message.decode('utf-8'))
         sys.exit(1)
     return wrapper
   return decorator

--- a/hokusai/services/configmap.py
+++ b/hokusai/services/configmap.py
@@ -46,7 +46,7 @@ class ConfigMap(object):
 
   def load(self):
     payload = shout(self.kctl.command("get configmap %s -o json" % self.name))
-    struct = json.loads(payload)
+    struct = json.loads(payload.decode('utf-8'))
     if 'data' in struct:
       self.struct['data'] = struct['data']
     else:

--- a/hokusai/services/kubectl.py
+++ b/hokusai/services/kubectl.py
@@ -17,7 +17,7 @@ class Kubectl(object):
   def get_object(self, obj):
     cmd = self.command("get %s -o json" % obj)
     try:
-      return json.loads(shout(cmd))
+      return json.loads(shout(cmd).decode('utf-8'))
     except ValueError:
       return None
 
@@ -27,7 +27,7 @@ class Kubectl(object):
     else:
       cmd = self.command("get %s -o json" % obj)
     try:
-      return json.loads(shout(cmd))['items']
+      return json.loads(shout(cmd).decode('utf-8'))['items']
     except ValueError:
       return []
 


### PR DESCRIPTION
Follow-up to https://github.com/artsy/hokusai/pull/212

- Fixes to JSON decoding and error handling in Python 3
- Fixes to Pyinstaller hidden import loading in Python 3
- Add a `get-hokusai.sh` script to install hokusai pyisntaller builds for latest, beta, beta3 releases easily