### PR TITLE
Fixes to release process / pip distribution

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,7 +168,7 @@ jobs:
     steps:
       - checkout
       - run: HOMEBREW_NO_AUTO_UPDATE=1 brew install awscli openssl pyenv
-      - run: pyenv install 2.7.16
+      - run: PYTHON_CONFIGURE_OPTS="--enable-framework" pyenv install 2.7.16
       - run: echo 'eval "$(pyenv init -)"' >> ~/.bash_profile
       - run: pyenv local 2.7.16
       - run: pip install --upgrade pip

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,3 +4,4 @@ include hokusai/lib/*
 include hokusai/services/*
 include hokusai/templates/*
 include hokusai/templates/hokusai/*
+include hokusai/VERSION


### PR DESCRIPTION
- Fix to release_version_macos CircleCI job
- `pip install hokusai` failing on installing from .tar.gz (but not from using a `.whl` oddly enough) - the `VERSION` file needs to be in the MANIFEST.in file to be included 

```
Installing build dependencies ... done
  Running command /Users/isacpetruzzi/Envs/test/bin/python /Users/isacpetruzzi/Envs/test/lib/python3.5/site-packages/pip/_vendor/pep517/_in_process.py get_requires_for_build_wheel /var/folders/sg/bpbnfprn1rbb1jpkldt5d10c0000gp/T/tmplqrvqyso
  Traceback (most recent call last):
    File "/Users/isacpetruzzi/Envs/test/lib/python3.5/site-packages/pip/_vendor/pep517/_in_process.py", line 280, in <module>
      main()
    File "/Users/isacpetruzzi/Envs/test/lib/python3.5/site-packages/pip/_vendor/pep517/_in_process.py", line 263, in main
      json_out['return_val'] = hook(**hook_input['kwargs'])
    File "/Users/isacpetruzzi/Envs/test/lib/python3.5/site-packages/pip/_vendor/pep517/_in_process.py", line 114, in get_requires_for_build_wheel
      return hook(config_settings)
    File "/private/var/folders/sg/bpbnfprn1rbb1jpkldt5d10c0000gp/T/pip-build-env-0hvm11u9/overlay/lib/python3.5/site-packages/setuptools/build_meta.py", line 163, in get_requires_for_build_wheel
      config_settings, requirements=['wheel'])
    File "/private/var/folders/sg/bpbnfprn1rbb1jpkldt5d10c0000gp/T/pip-build-env-0hvm11u9/overlay/lib/python3.5/site-packages/setuptools/build_meta.py", line 143, in _get_build_requires
      self.run_setup()
    File "/private/var/folders/sg/bpbnfprn1rbb1jpkldt5d10c0000gp/T/pip-build-env-0hvm11u9/overlay/lib/python3.5/site-packages/setuptools/build_meta.py", line 267, in run_setup
      self).run_setup(setup_script=setup_script)
    File "/private/var/folders/sg/bpbnfprn1rbb1jpkldt5d10c0000gp/T/pip-build-env-0hvm11u9/overlay/lib/python3.5/site-packages/setuptools/build_meta.py", line 158, in run_setup
      exec(compile(code, __file__, 'exec'), locals())
    File "setup.py", line 8, in <module>
      version=open(os.path.join(os.path.dirname(__file__), "hokusai", "VERSION")).read().strip(),
  FileNotFoundError: [Errno 2] No such file or directory: 'hokusai/VERSION'
  Getting requirements to build wheel ... error
ERROR: Command errored out with exit status 1: /Users/isacpetruzzi/Envs/test/bin/python /Users/isacpetruzzi/Envs/test/lib/python3.5/site-packages/pip/_vendor/pep517/_in_process.py get_requires_for_build_wheel /var/folders/sg/bpbnfprn1rbb1jpkldt5d10c0000gp/T/tmplqrvqyso Check the logs for full command output.
```

