### PR TITLE
Bump docker-compose to 1.25.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apk add \
       openssh
 
 # Install Docker Compose, AWS CLI
-RUN pip install docker-compose==1.22.0 && \
+RUN pip install docker-compose==1.25.5 && \
       pip install awscli --upgrade
 
 # Install the AWS IAM Authenticator


### PR DESCRIPTION
Updates docker compose version to support version `3.8` templates, allowing for multi-stage builds.

I chose to upgrade conservatively to [1.25.5](https://docs.docker.com/compose/release-notes/#1255) because it includes the specific template version, the latest  version is 1.26.2 but comes with python version restrictions. 

Should resolve https://app.circleci.com/pipelines/github/artsy/horizon/796/workflows/1c1a2450-d3b8-4671-b62c-1c4e642ffa39/jobs/694

<img width="1050" alt="Screen Shot 2020-08-18 at 12 51 38 PM" src="https://user-images.githubusercontent.com/1497424/90542142-aa100a80-e151-11ea-9582-d16500917224.png">

