### PR TITLE
Fixes to exception and tempfile handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,11 @@ $ pip uninstall hokusai
 $ brew link --overwrite hokusai
 ```
 
+If you are on Linux:
+```
+curl -sSL https://raw.githubusercontent.com/artsy/hokusai/master/get-hokusai.sh | sudo bash
+```
+
 ### Alternate Installation Methods
 
 #### Via pip

--- a/hokusai/lib/command.py
+++ b/hokusai/lib/command.py
@@ -31,9 +31,9 @@ def command(config_check=True):
           print_red(traceback.format_exc())
         else:
           print_red("ERROR: %s" % str(e))
-        if hasattr(e, 'output'):
+        if hasattr(e, 'output') and e.output is not None:
           print(e.output.decode('utf-8'))
-        elif hasattr(e, 'message'):
+        elif hasattr(e, 'message') and e.message is not None:
           print(e.message.decode('utf-8'))
         sys.exit(1)
     return wrapper

--- a/hokusai/lib/config.py
+++ b/hokusai/lib/config.py
@@ -27,15 +27,6 @@ class HokusaiConfig(object):
   def __init__(self):
     if not os.path.isdir(HOKUSAI_TMP_DIR):
       os.mkdir(HOKUSAI_TMP_DIR)
-    atexit.register(self.cleanup)
-
-  def cleanup(self):
-    if os.environ.get('DEBUG'):
-      return
-    try:
-      shutil.rmtree(HOKUSAI_TMP_DIR)
-    except:
-      pass
 
   def create(self, project_name):
     config = OrderedDict([

--- a/hokusai/services/configmap.py
+++ b/hokusai/services/configmap.py
@@ -29,7 +29,7 @@ class ConfigMap(object):
     }
 
   def _to_file(self):
-    f = NamedTemporaryFile(delete=False, dir=HOKUSAI_TMP_DIR)
+    f = NamedTemporaryFile(delete=False, dir=HOKUSAI_TMP_DIR, mode='w')
     f.write(json.dumps(self.struct))
     f.close()
     return f

--- a/hokusai/services/deployment.py
+++ b/hokusai/services/deployment.py
@@ -94,7 +94,7 @@ class Deployment(object):
               container['image'] = "%s@%s" % (self.ecr.project_repo, digest)
         payload.append(item)
 
-      f = NamedTemporaryFile(delete=False, dir=HOKUSAI_TMP_DIR)
+      f = NamedTemporaryFile(delete=False, dir=HOKUSAI_TMP_DIR, mode='w')
       f.write(YAML_HEADER)
       f.write(yaml.safe_dump_all(payload, default_flow_style=False))
       f.close()

--- a/hokusai/services/yaml_spec.py
+++ b/hokusai/services/yaml_spec.py
@@ -1,5 +1,6 @@
 import os
 import atexit
+from tempfile import NamedTemporaryFile
 
 import yaml
 
@@ -44,7 +45,7 @@ class YamlSpec(object):
     file_basename = os.path.basename(self.template_file)
     if file_basename.endswith('.j2'):
       file_basename = file_basename.rstrip('.j2')
-    f = open(os.path.join(HOKUSAI_TMP_DIR, file_basename), 'w')
+    f = NamedTemporaryFile(delete=False, dir=HOKUSAI_TMP_DIR)
     self.tmp_filename = f.name
     f.write(self.to_string())
     f.close()

--- a/hokusai/services/yaml_spec.py
+++ b/hokusai/services/yaml_spec.py
@@ -45,7 +45,7 @@ class YamlSpec(object):
     file_basename = os.path.basename(self.template_file)
     if file_basename.endswith('.j2'):
       file_basename = file_basename.rstrip('.j2')
-    f = NamedTemporaryFile(delete=False, dir=HOKUSAI_TMP_DIR)
+    f = NamedTemporaryFile(delete=False, dir=HOKUSAI_TMP_DIR, mode='w')
     self.tmp_filename = f.name
     f.write(self.to_string())
     f.close()


### PR DESCRIPTION
- Fixes the exception `AttributeError: 'NoneType' object has no attribute 'decode'` when catching an exception with no message or output attribute
- Fixes running hokusai in two terminal windows concurrently stomping on each other's temp directories
- Updates README.md with a 1-liner to install Hokusai via curl / bash