### PR TITLE
#WIP #FF fea: Log config changes.

### DIFF
--- a/hokusai/commands/env.py
+++ b/hokusai/commands/env.py
@@ -31,6 +31,7 @@ def set_env(context, environment, namespace=None):
     split = s.split('=', 1)
     configmap.update(split[0], split[1])
   configmap.save()
+  # TODO: pass to log_configmap_changes only var names, not their values.
   log_configmap_changes(context, 'set', environment)
 
 @command()

--- a/hokusai/commands/env.py
+++ b/hokusai/commands/env.py
@@ -32,7 +32,7 @@ def set_env(context, environment, namespace=None):
     configmap.update(split[0], split[1])
   configmap.save()
   # TODO: pass to log_configmap_changes only var names, not their values.
-  log_configmap_changes(context, 'set', environment)
+  log_configmap_changes(context, namespace, 'set', environment)
 
 @command()
 def unset_env(context, environment, namespace=None):
@@ -41,5 +41,5 @@ def unset_env(context, environment, namespace=None):
   for s in environment:
     configmap.delete(s)
   configmap.save()
-  log_configmap_changes(context, 'unset', environment)
+  log_configmap_changes(context, namespace, 'unset', environment)
 

--- a/hokusai/commands/env.py
+++ b/hokusai/commands/env.py
@@ -3,6 +3,7 @@ from hokusai.lib.command import command
 from hokusai.services.configmap import ConfigMap
 from hokusai.lib.common import print_green, print_smart
 from hokusai.lib.exceptions import HokusaiError
+from hokusai.lib.log_configmap_changes import log_configmap_changes
 
 
 @command()
@@ -30,7 +31,7 @@ def set_env(context, environment, namespace=None):
     split = s.split('=', 1)
     configmap.update(split[0], split[1])
   configmap.save()
-
+  log_configmap_changes(context, 'set', environment)
 
 @command()
 def unset_env(context, environment, namespace=None):
@@ -39,3 +40,5 @@ def unset_env(context, environment, namespace=None):
   for s in environment:
     configmap.delete(s)
   configmap.save()
+  log_configmap_changes(context, 'unset', environment)
+

--- a/hokusai/lib/log_configmap_changes.py
+++ b/hokusai/lib/log_configmap_changes.py
@@ -1,0 +1,30 @@
+import datetime
+
+from hokusai.lib.config import config
+from hokusai.lib.s3 import append_or_create_object
+
+def log_configmap_changes(context, action, varlist):
+  var_names = []
+  for s in varlist:
+    # if the vars are being set, varlist is a list of key=value pairs.
+    # if the vars are being unset, varlist is a list of keys.
+    # in either case, split returns the key.
+    split = s.split('=', 1)
+    var_names.append(split[0])
+
+  timestamp = datetime.datetime.utcnow()
+  log = "%s: %s: %s\n" % (timestamp, action, ' '.join(var_names))
+
+  # TODO: pass bucket/key in as a var.
+  s3_bucket = 'artsy-hokusai'
+  s3_key = 'configmap-changes/' + \
+            config.project_name + \
+            '/' + context + '/' + \
+            datetime.datetime.utcnow().strftime('%Y-%m-%d')
+
+  try:
+    # log to s3 object.
+    append_or_create_object(log, s3_bucket, s3_key)
+  except:
+    # catch and ignore all exceptions, failure to log configmap changes shall not be fatal.
+    pass

--- a/hokusai/lib/log_configmap_changes.py
+++ b/hokusai/lib/log_configmap_changes.py
@@ -3,17 +3,24 @@ import datetime
 from hokusai.lib.config import config
 from hokusai.lib.s3 import append_or_create_object
 
-def log_configmap_changes(context, action, varlist):
+def log_configmap_changes(context, namespace, action, varlist):
   var_names = []
   for s in varlist:
     # if the vars are being set, varlist is a list of key=value pairs.
     # if the vars are being unset, varlist is a list of keys.
     # in either case, split returns the key.
+    # what if user mistakenly pass value=key? we log the value which can be a secret. yikes!
     split = s.split('=', 1)
     var_names.append(split[0])
 
+  # ugly, but upstream passes None for default namespace.
+  if (namespace is None):
+    ns = 'default'
+  else:
+    ns = namespace
+
   timestamp = datetime.datetime.utcnow()
-  log = "%s: %s: %s\n" % (timestamp, action, ' '.join(var_names))
+  log = "time: %s, namespace: %s, action: %s, var: %s\n" % (timestamp, ns, action, ' '.join(var_names))
 
   # TODO: pass bucket/key in as a var.
   s3_bucket = 'artsy-hokusai'

--- a/hokusai/lib/s3.py
+++ b/hokusai/lib/s3.py
@@ -1,0 +1,38 @@
+import botocore
+import boto3
+
+from hokusai.lib.common import get_region_name
+
+def append_or_create_object(data, s3_bucket, s3_key):
+  s3_client = boto3.client('s3', region_name=get_region_name())
+
+  # let upstream handle exceptions.
+  if object_exists(s3_client, s3_bucket, s3_key):
+    append_to_object(s3_client, data, s3_bucket, s3_key)
+  else:
+    create_object(s3_client, data, s3_bucket, s3_key)
+
+def object_exists(s3_client, s3_bucket, s3_key):
+  try:
+    s3_client.head_object(Bucket=s3_bucket, Key=s3_key)
+  except botocore.exceptions.ClientError as e:
+    if e.response['Error']['Code'] == "404":
+      # catch the case where key does not exist.
+      return False
+    else:
+      # some other exception, pass it upstream.
+      raise
+
+  # key exists.
+  return True
+  
+def create_object(s3_client, data, s3_bucket, s3_key):
+  # let upstream handle exceptions.
+  s3_client.put_object(Bucket=s3_bucket, Key=s3_key, Body=data)
+
+def append_to_object(s3_client, data, s3_bucket, s3_key):
+  # let upstream handle exceptions.
+  response = s3_client.get_object(Bucket=s3_bucket, Key=s3_key)
+  new_data = response['Body'].read() + data
+  s3_client.put_object(Bucket=s3_bucket, Key=s3_key, Body=new_data)
+


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PLATFORM-2958
Supported by: https://github.com/artsy/infrastructure/pull/257

To demonstrate the idea of logging config changes.

Every run of `hokusai...env set/unset...` generates a log like these (values may be sensitive so are omitted):
```
time: 2020-11-03 00:15:32.537098, namespace: default, action: set, var: FOO
time: 2020-11-03 00:16:10.925644, namespace: default, action: unset, var: FOO
```
and ships it to S3:
![Screenshot from 2020-11-02 19-57-37](https://user-images.githubusercontent.com/63004951/97935171-c2052c80-1d45-11eb-9fd5-1a053ed50941.png)

Might these logs be useful?

The implementation is not ideal. S3 files are clunky to work with, and updating them adds ~1 second delay to Hokusai's response, which is noticeable. If we consider config changes also as `releases`, perhaps better to let Horizon manage storage (in a DB), so that Hokusai can just POST these events to Horizon? And later on we make them retrievable via a `hokusai...env log` command?

If we do go with this implementation, I shall add tests.