### PR TITLE
fea: mask printing errors when shelling out to a subcommand

### DIFF
--- a/hokusai/lib/command.py
+++ b/hokusai/lib/command.py
@@ -20,7 +20,7 @@ def command(config_check=True):
         else:
           sys.exit(result)
       except HokusaiError as e:
-        print_red(e.message)
+        print_red("ERROR: %s" % e.message)
         sys.exit(e.return_code)
       except SystemExit:
         raise

--- a/hokusai/lib/common.py
+++ b/hokusai/lib/common.py
@@ -17,7 +17,7 @@ from botocore import session as botosession
 from termcolor import cprint
 
 from hokusai.lib.config import config
-from hokusai.lib.exceptions import CalledProcessError
+from hokusai.lib.exceptions import HokusaiError, CalledProcessError
 
 CONTEXT_SETTINGS = {
   'terminal_width': 10000,
@@ -78,10 +78,13 @@ def returncode(command, mask=()):
   return call(verbose(command, mask=mask), stderr=STDOUT, shell=True)
 
 def shout(command, print_output=False, mask=()):
-  if print_output:
-    return check_call(verbose(command, mask=mask), stderr=STDOUT, shell=True)
-  else:
-    return check_output(verbose(command, mask=mask), stderr=STDOUT, shell=True)
+  try:
+    if print_output:
+      return check_call(verbose(command, mask=mask), stderr=STDOUT, shell=True)
+    else:
+      return check_output(verbose(command, mask=mask), stderr=STDOUT, shell=True)
+  except CalledProcessError as e:
+    raise HokusaiError(str(e), return_code=e.returncode, mask=mask)
 
 def shout_concurrent(commands, print_output=False, mask=()):
   if print_output:

--- a/hokusai/lib/exceptions.py
+++ b/hokusai/lib/exceptions.py
@@ -1,6 +1,11 @@
+import re
+
 from subprocess import CalledProcessError
 
 class HokusaiError(Exception):
-  def __init__(self, message, return_code=1):
-    self.message = message
+  def __init__(self, message, return_code=1, mask=()):
+    if mask:
+      self.message = re.sub(mask[0], mask[1], message)
+    else:
+      self.message = message
     self.return_code = return_code

--- a/test/unit/test_command.py
+++ b/test/unit/test_command.py
@@ -8,6 +8,7 @@ from test import HokusaiUnitTestCase
 from test.utils import captured_output
 
 from hokusai.lib.command import command
+from hokusai.lib.exceptions import HokusaiError
 
 @command()
 def foo_command(foo):
@@ -15,6 +16,10 @@ def foo_command(foo):
     return 0
   else:
     raise ValueError('Bad command')
+
+@command()
+def error_command(msg):
+  raise HokusaiError(msg, mask=(r'^(\w*).*$', r'\1 ***'))
 
 class TestCommand(HokusaiUnitTestCase):
   @patch('hokusai.lib.command.sys.exit', return_code=True)
@@ -28,3 +33,10 @@ class TestCommand(HokusaiUnitTestCase):
       foo_command(False)
       mocked_sys_exit.assert_called_once_with(1)
       self.assertIn('ERROR: Bad command', out.getvalue().strip())
+
+  @patch('hokusai.lib.command.sys.exit', return_code=True)
+  def test_command_catches_masked_exceptions(self, mocked_sys_exit):
+    with captured_output() as (out, err):
+      error_command('Ohai!')
+      mocked_sys_exit.assert_called_once_with(1)
+      self.assertIn('ERROR: Ohai ***', out.getvalue().strip())


### PR DESCRIPTION
Addresses https://github.com/artsy/hokusai/issues/237

We already mask verbose output if the kwarg `mask` is provided to a subcommand - this fix wraps `CalledProcessError`s in our custom exception class `HokusaiError` and applies the mask to `HokusaiError` `message` attribute if provided.
