### PR TITLE
fix: mask CalledProcessError msg and output attributes and treat HokusaiError separately from CalledProccessError on exit

### DIFF
--- a/hokusai/lib/command.py
+++ b/hokusai/lib/command.py
@@ -19,22 +19,34 @@ def command(config_check=True):
           sys.exit(0)
         else:
           sys.exit(result)
-      except HokusaiError as e:
-        print_red(e.message)
-        sys.exit(e.return_code)
       except SystemExit:
         raise
       except KeyboardInterrupt:
         raise
-      except (CalledProcessError, Exception) as e:
+      except HokusaiError as e:
+        print_red("ERROR: %s" % e.message)
+        sys.exit(e.return_code)
+      except CalledProcessError as e:
         if get_verbosity() or os.environ.get('DEBUG'):
           print_red(traceback.format_exc())
         else:
           print_red("ERROR: %s" % str(e))
         if hasattr(e, 'output') and e.output is not None:
-          print(e.output.decode('utf-8'))
-        elif hasattr(e, 'message') and e.message is not None:
-          print(e.message.decode('utf-8'))
+          if str == bytes:
+            # Python 2
+            print_red("ERROR: %s" % e.output)
+          else:
+            # Python 3
+            if type(e.output) == bytes:
+              print_red("ERROR: %s" % e.output.decode('utf-8'))
+            else:
+              print_red("ERROR: %s" % e.output)
+        sys.exit(e.returncode)
+      except Exception as e:
+        if get_verbosity() or os.environ.get('DEBUG'):
+          print_red(traceback.format_exc())
+        else:
+          print_red("ERROR: %s" % str(e))
         sys.exit(1)
     return wrapper
   return decorator

--- a/hokusai/lib/common.py
+++ b/hokusai/lib/common.py
@@ -78,10 +78,36 @@ def returncode(command, mask=()):
   return call(verbose(command, mask=mask), stderr=STDOUT, shell=True)
 
 def shout(command, print_output=False, mask=()):
-  if print_output:
-    return check_call(verbose(command, mask=mask), stderr=STDOUT, shell=True)
-  else:
-    return check_output(verbose(command, mask=mask), stderr=STDOUT, shell=True)
+  try:
+    if print_output:
+      return check_call(verbose(command, mask=mask), stderr=STDOUT, shell=True)
+    else:
+      return check_output(verbose(command, mask=mask), stderr=STDOUT, shell=True)
+  except CalledProcessError as e:
+    if mask:
+      if hasattr(e, 'cmd') and e.cmd is not None:
+        if str == bytes:
+          # Python 2
+          cmd = re.sub(mask[0], mask[1], e.cmd)
+        else:
+          # Python 3
+          if type(e.cmd) == bytes:
+            cmd = re.sub(mask[0], mask[1], e.cmd.decode('utf-8'))
+          else:
+            cmd = re.sub(mask[0], mask[1], e.cmd)
+        e.cmd = cmd
+      if hasattr(e, 'output') and e.output is not None:
+        if str == bytes:
+          # Python 2
+          output = re.sub(mask[0], mask[1], e.output)
+        else:
+          # Python 3
+          if type(e.output) == bytes:
+            output = re.sub(mask[0], mask[1], e.output.decode('utf-8'))
+          else:
+            output = re.sub(mask[0], mask[1], e.output)
+        e.output = output
+    raise
 
 def shout_concurrent(commands, print_output=False, mask=()):
   if print_output:


### PR DESCRIPTION
Another approach following https://github.com/artsy/hokusai/pull/238

Addresses https://github.com/artsy/hokusai/issues/237

We already mask verbose output if the kwarg `mask` is provided to a subcommand via the `shout` function - this fix also applies the mask to a `CalledProcessessError`'s `cmd` and `output` attributes, should one be raised.

Also fix exception handling in the `@command` decorator and treat `HokusaiError`s separately from `CalledProcessError`s - branching for Python 2/3 compatibility.
