### PR TITLE
Install JQ in hokusai image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ RUN apk add \
       curl \
       docker \
       git \
-      openssh
+      openssh \
+      jq
 
 # Install Docker Compose, AWS CLI
 RUN pip install docker-compose==1.25.5 && \


### PR DESCRIPTION
JQ is required for the new version of [Slack Orb](https://github.com/CircleCI-Public/slack-orb/wiki/FAQ). The size is [< 1MB](https://pkgs.alpinelinux.org/package/edge/main/x86/jq) so hopefully not a lot of overhead. 🙏 