### PR TITLE
fix: python3 fixes

### DIFF
--- a/hokusai/commands/configure.py
+++ b/hokusai/commands/configure.py
@@ -9,8 +9,10 @@ from distutils.dir_util import mkpath
 
 if sys.version_info[0] >= 3:
   from urllib.parse import urlparse
+  from urllib.request import urlretrieve
 else:
   from urlparse import urlparse
+  from urllib import urlretrieve
 
 import boto3
 
@@ -40,7 +42,7 @@ def configure(kubectl_version, bucket_name, key_name, config_file, install_to, i
 
   print_green("Downloading and installing kubectl...", newline_before=True, newline_after=True)
   tmpdir = tempfile.mkdtemp()
-  urllib.urlretrieve("https://storage.googleapis.com/kubernetes-release/release/v%s/bin/%s/amd64/kubectl" % (kubectl_version, platform.system().lower()), os.path.join(tmpdir, 'kubectl'))
+  urlretrieve("https://storage.googleapis.com/kubernetes-release/release/v%s/bin/%s/amd64/kubectl" % (kubectl_version, platform.system().lower()), os.path.join(tmpdir, 'kubectl'))
   os.chmod(os.path.join(tmpdir, 'kubectl'), 0o755)
   shutil.move(os.path.join(tmpdir, 'kubectl'), os.path.join(install_to, 'kubectl'))
   shutil.rmtree(tmpdir)

--- a/hokusai/commands/images.py
+++ b/hokusai/commands/images.py
@@ -18,9 +18,9 @@ def images(tag_exists, reverse_sort, limit, filter_tags, digests):
 
   images = ecr.images
   sorted_images = sorted(images, key=itemgetter('imagePushedAt'), reverse=not reverse_sort)
-  filtered_images = filter(lambda image: 'imageTags' in image.keys(), sorted_images)
+  filtered_images = list(filter(lambda image: 'imageTags' in image.keys(), sorted_images))
   if filter_tags:
-    filtered_images = filter(lambda image: filter_tags in ', '.join(image['imageTags']), filtered_images)
+    filtered_images = list(filter(lambda image: filter_tags in ', '.join(image['imageTags']), filtered_images))
 
   if digests:
     print_green('Image Pushed At           | Image Digest                                                            | Image Tags', newline_before=True)

--- a/hokusai/commands/logs.py
+++ b/hokusai/commands/logs.py
@@ -26,7 +26,7 @@ def logs(context, timestamps, follow, tail, previous, labels, namespace=None):
     selectors.append(l)
 
   pods = kctl.get_objects('pod', selector=(',').join(selectors))
-  pods = filter(lambda pod: pod['status']['phase'] == 'Running', pods)
+  pods = list(filter(lambda pod: pod['status']['phase'] == 'Running', pods))
   containers = []
 
   for pod in pods:

--- a/hokusai/services/ecr.py
+++ b/hokusai/services/ecr.py
@@ -99,7 +99,7 @@ class ECR(object):
 
   def deployment_tags(self, context):
     context_re = re.compile(r"%s--\d\d\d\d-\d\d-\d\d--\d\d\-\d\d-\d\d" % context)
-    return sorted(filter(lambda x: context_re.match(x), self.tags()))
+    return sorted(list(filter(lambda x: context_re.match(x), self.tags())))
 
   def current_deployment_tag(self, context):
     context_re = re.compile(r"%s--\d\d\d\d-\d\d-\d\d--\d\d\-\d\d-\d\d" % context)


### PR DESCRIPTION
Fixing some errors I encountered when running Hokusai via python 3 locally

When running `hokusai configure`
```
Traceback (most recent call last):
  File "/home/izak/.pyenv/versions/3.7.7/lib/python3.7/site-packages/hokusai/lib/command.py", line 17, in wrapper
    result = func(*args, **kwargs)
  File "/home/izak/.pyenv/versions/3.7.7/lib/python3.7/site-packages/hokusai/commands/configure.py", line 43, in configure
    urllib.urlretrieve("https://storage.googleapis.com/kubernetes-release/release/v%s/bin/%s/amd64/kubectl" % (kubectl_version, platform.system().lower()), os.path.join(tmpdir, 'kubectl'))
AttributeError: module 'urllib' has no attribute 'urlretrieve
```

so fixed up imports...

And when running `hokusai registry images`

```
Traceback (most recent call last):
  File "/home/izak/.pyenv/versions/3.7.7/lib/python3.7/site-packages/hokusai/lib/command.py", line 17, in wrapper
    result = func(*args, **kwargs)
  File "/home/izak/.pyenv/versions/3.7.7/lib/python3.7/site-packages/hokusai/commands/images.py", line 32, in images
    for image in filtered_images[:limit]:
TypeError: 'filter' object is not subscriptable
```

so need to cast the return value of `filter` which is an iterable but not a list in py3 to a list