### PR TITLE
fix: skip project config check when configuring hokusai

### DIFF
--- a/hokusai/commands/configure.py
+++ b/hokusai/commands/configure.py
@@ -21,7 +21,7 @@ from hokusai.lib.command import command
 from hokusai.lib.common import print_green, get_region_name
 from hokusai.lib.exceptions import HokusaiError
 
-@command()
+@command(config_check=False)
 def configure(kubectl_version, bucket_name, key_name, config_file, install_to, install_config_to):
   if global_config.is_present() and global_config.kubectl_version is not None:
     kubectl_version = global_config.kubectl_version


### PR DESCRIPTION
The `hokusai configure` command globally configures hokusai by installing kubectl and fetching kubernetes configuration files from S3.

The command does not need to run within the context of a hokusai-configured project so I think we can safely skip this check like we currently do for `setup` and `version` commands.

Addresses #248 