### PR TITLE
fix: reverted promt-toolkit version due to mismatch with python 3.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(name='hokusai',
       install_requires=[
           'click~=6.7',
           'click-repl~=0.1',
-          'prompt-toolkit~=3.0.18',
+          'prompt-toolkit~=1.0.16',
           'MarkupSafe~=1.0',
           'Jinja2~=2.10',
           'packaging',


### PR DESCRIPTION
* reverted prompt-toolkit version to 1.0.16 since later versions are not compatible with python 3.5 [https://pypi.org/project/prompt-toolkit/#history](url)
* this change may remove the possibility to install ipdb / ipython in dev mode which was added here: [https://github.com/artsy/hokusai/pull/254](url)