### PR TITLE
doc: README added python version flag to mkvirtualenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ echo 'source '/usr/local/bin/virtualenvwrapper.sh' >> ~/.bash_profile
 Create and activate the virtual environment:
 
 ```
-mkvirtualenv hokusai
+mkvirtualenv -p 3.5.8 hokusai
 workon hokusai
 ```
 


### PR DESCRIPTION
- README instruction update: added missing python version flag when creating virtual environment. Not having this flag could cause to pick the system Python over the global Pyenv Python version, which eventually causes failure if the system version is not matching the accepted python version