### PR TITLE
Fix make image by setting prompt-toolkit's version to bigger than 2.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(name='hokusai',
       install_requires=[
           'click~=6.7',
           'click-repl~=0.1',
-          'prompt-toolkit~=3.0.18',
+          'prompt-toolkit >= 2.0.0',
           'MarkupSafe~=1.0',
           'Jinja2~=2.10',
           'packaging',


### PR DESCRIPTION
## Description
Currently, the make image CircleCI is failing because `prompt-toolkit` version 3.0.18 is not found. The error states that only versions lower than 3.0 are available.
When testing locally, `make image` passed successfully. 