### PR TITLE
feat: Introduce 'hokusai registry retag' command.

### DIFF
--- a/hokusai/cli/registry.py
+++ b/hokusai/cli/registry.py
@@ -47,3 +47,15 @@ def images(tag_exists, reverse_sort, limit, filter_tags, digests, verbose):
   """Print images and tags in the project's registry"""
   set_verbosity(verbose)
   hokusai.images(tag_exists, reverse_sort, limit, filter_tags, digests)
+
+@registry.command(context_settings=CONTEXT_SETTINGS)
+@click.argument('tag1', type=click.Choice(['staging', 'production']))
+@click.argument('tag2', type=click.STRING)
+@click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
+def retag(tag1, tag2, verbose):
+  """
+  On the registry, make tag1 point to the same image pointed to by tag2.\n
+  Tag1 must be either 'staging' or 'production'.
+  """
+  set_verbosity(verbose)
+  hokusai.retag(tag1, tag2)

--- a/hokusai/commands/__init__.py
+++ b/hokusai/commands/__init__.py
@@ -15,5 +15,6 @@ from hokusai.commands.run import run
 from hokusai.commands.setup import setup
 from hokusai.commands.kubernetes import k8s_create, k8s_update, k8s_delete, k8s_status, k8s_copy_config
 from hokusai.commands.namespace import create_new_app_yaml
+from hokusai.commands.retag import retag
 from hokusai.commands.test import test
 from hokusai.commands.version import version

--- a/hokusai/commands/retag.py
+++ b/hokusai/commands/retag.py
@@ -1,0 +1,16 @@
+from hokusai.lib.command import command
+from hokusai.lib.common import print_green, print_yellow
+from hokusai.services.ecr import ECR, ClientError
+
+@command()
+def retag(tag_to_change, tag_to_match):
+  ecr = ECR()
+
+  if not ecr.project_repo_exists():
+    raise HokusaiError("Project repo does not exist.  Aborting.")
+
+  try:
+    ecr.retag(tag_to_match, tag_to_change)
+    print_green("Updated ECR '%s' tag to point to the image that '%s' tag points to." % (tag_to_change, tag_to_match), newline_after=True)
+  except (ValueError, ClientError) as e:
+    print_yellow("WARNING: Updating ECR tag failed due to the error: '%s'" % str(e), newline_before=True, newline_after=True)

--- a/hokusai/commands/retag.py
+++ b/hokusai/commands/retag.py
@@ -7,7 +7,7 @@ def retag(tag_to_change, tag_to_match):
   ecr = ECR()
 
   if not ecr.project_repo_exists():
-    raise HokusaiError("Project repo does not exist.  Aborting.")
+    raise HokusaiError("Project repo does not exist. Aborting.")
 
   try:
     ecr.retag(tag_to_match, tag_to_change)

--- a/hokusai/commands/retag.py
+++ b/hokusai/commands/retag.py
@@ -1,5 +1,5 @@
 from hokusai.lib.command import command
-from hokusai.lib.common import print_green, print_yellow
+from hokusai.lib.common import print_green, print_red
 from hokusai.services.ecr import ECR, ClientError
 
 @command()
@@ -13,4 +13,4 @@ def retag(tag_to_change, tag_to_match):
     ecr.retag(tag_to_match, tag_to_change)
     print_green("Updated ECR '%s' tag to point to the image that '%s' tag points to." % (tag_to_change, tag_to_match), newline_after=True)
   except (ValueError, ClientError) as e:
-    print_yellow("WARNING: Updating ECR tag failed due to the error: '%s'" % str(e), newline_before=True, newline_after=True)
+    print_red("WARNING: Updating ECR tag failed due to the error: '%s'" % str(e), newline_before=True, newline_after=True)


### PR DESCRIPTION
For https://artsyproduct.atlassian.net/browse/PLATFORM-3372.

`hokusai staging/production deploy` (ultimately calling [service/deployment](https://github.com/artsy/hokusai/blob/master/hokusai/services/deployment.py)) does two things (among others). It updates an app's Kubernetes deployment with a new docker image. And it updates the app's docker registry tags (`staging`, `production`, etc.) so that those tags point to that image.

Some of our apps have no Kubernetes deployments. They are run by Jenkins in cron fashion. The Jenkins jobs pull `staging` tag which corresponds to the state of code-repo's `master` branch. For these apps, we don't want Kubernetes-deployment, but we do want tag-updating.

Our CI on `master` branch [pushes a new image](https://app.circleci.com/pipelines/github/artsy/hokusai-sandbox/407/workflows/7b0f668b-9bf4-4a3f-96c2-8ee388b24c96/jobs/553) and tag it by the SHA of the last Git commit. What we want is a hokusai command that updates `staging/production` tag to point to the image pointed to by that SHA tag.

Usage:

```
jian@artsy:~/code/hokusai-sandbox$ /home/jian/.pyenv/versions/hokusai3/bin/hokusai registry retag --help
Usage: hokusai registry retag [OPTIONS] TAG1 TAG2

  On the registry, make tag1 point to the same image pointed to by tag2.

  Tag1 must be either 'staging' or 'production'.

Options:
  -v, --verbose  Verbose output
  -h, --help     Show this message and exit.
jian@artsy:~/code/hokusai-sandbox$ /home/jian/.pyenv/versions/hokusai3/bin/hokusai registry retag staging 9f5b9df9c2d571f773d2986751e959d4168c7103
Updated ECR 'staging' tag to point to the image that '9f5b9df9c2d571f773d2986751e959d4168c7103' tag points to.
```