### PR TITLE
fix: raise exception if retag fails.

### DIFF
--- a/hokusai/commands/retag.py
+++ b/hokusai/commands/retag.py
@@ -1,5 +1,6 @@
 from hokusai.lib.command import command
 from hokusai.lib.common import print_green, print_red
+from hokusai.lib.exceptions import HokusaiError
 from hokusai.services.ecr import ECR, ClientError
 
 @command()
@@ -13,4 +14,4 @@ def retag(tag_to_change, tag_to_match):
     ecr.retag(tag_to_match, tag_to_change)
     print_green("Updated ECR '%s' tag to point to the image that '%s' tag points to." % (tag_to_change, tag_to_match), newline_after=True)
   except (ValueError, ClientError) as e:
-    print_red("WARNING: Updating ECR tag failed due to the error: '%s'" % str(e), newline_before=True, newline_after=True)
+    raise HokusaiError("Updating ECR tag failed due to the error: '%s'" % str(e))


### PR DESCRIPTION
Fix for https://github.com/artsy/hokusai/pull/262.

Discovered that [CI build succeeded](https://app.circleci.com/pipelines/github/artsy/fulcrum/2281/workflows/259f9c19-c2fe-41df-bd0b-408d001b9bbd/jobs/3450) even though retag failed.

Update retag to raise exception.