### PR TITLE
Fea use rollout restart

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,9 +21,9 @@ jobs:
     machine:
       image: circleci/classic:201808-01
     environment:
-      K8S_VERSION: v1.10.7
+      K8S_VERSION: v1.17.17
       KUBECONFIG: /home/circleci/.kube/config
-      MINIKUBE_VERSION: v0.30.0
+      MINIKUBE_VERSION: v1.22.0
       MINIKUBE_WANTUPDATENOTIFICATION: false
       MINIKUBE_WANTREPORTERRORPROMPT: false
       MINIKUBE_HOME: /home/circleci


### PR DESCRIPTION
Figured I'd PR this since I have been using `kubectl rollout restart` (available since v1.15) to refresh/restart deployments and the `deploymentTimestamp` metadata annotation hack necessary to trigger a deployment rollout pre- v1.15 ... this always caused problems with deployment selectors matching labels when it went out-of-sync...

Also fixed up the Kubernetes integration tests a bit so the correct configmap is created for the test deployment and pods can start, which means we can trigger a refresh, wait for it to complete before tearing down the stack.

Maybe I'll do some long-overdue refactoring now that I have some free time :D