### PR TITLE
update: default to main instead of master

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,9 @@ Hokusai is currently tested on Pythons 2.7.16 and 3.5.8.
 
 2) Install dependencies: `poetry install --no-root`.
 
-3) Run tests
+3) make sure you installed minikube with `brew install minikube` and run with `minikube start `
+
+4) Run tests
 
 All tests can be run with `make tests`.
 

--- a/hokusai/cli/production.py
+++ b/hokusai/cli/production.py
@@ -36,7 +36,7 @@ def delete(filename, verbose):
 
 
 @production.command(context_settings=CONTEXT_SETTINGS)
-@click.option('--check-branch', type=click.STRING, default=detect_branch(), help='Check branch before updating (default: main)')
+@click.option('--check-branch', type=click.STRING, default=detect_branch(), help='Check branch before updating (default: origin default or main)')
 @click.option('--check-remote', type=click.STRING, help='Check remotes before updating (otherwise check all remotes)')
 @click.option('--skip-checks', type=click.BOOL, is_flag=True, help='Skip all checks and update configuration recklessly')
 @click.option('-f', '--filename', type=click.STRING, help='Use the given Kubernetes Yaml file (default ./hokusai/production.yml)')

--- a/hokusai/cli/production.py
+++ b/hokusai/cli/production.py
@@ -34,7 +34,7 @@ def delete(filename, verbose):
 
 
 @production.command(context_settings=CONTEXT_SETTINGS)
-@click.option('--check-branch', type=click.STRING, default="master", help='Check branch before updating (default: master)')
+@click.option('--check-branch', type=click.STRING, default="main", help='Check branch before updating (default: main)')
 @click.option('--check-remote', type=click.STRING, help='Check remotes before updating (otherwise check all remotes)')
 @click.option('--skip-checks', type=click.BOOL, is_flag=True, help='Skip all checks and update configuration recklessly')
 @click.option('-f', '--filename', type=click.STRING, help='Use the given Kubernetes Yaml file (default ./hokusai/production.yml)')

--- a/hokusai/cli/production.py
+++ b/hokusai/cli/production.py
@@ -4,7 +4,7 @@ import hokusai
 
 from hokusai.cli.base import base
 from hokusai.lib.common import set_verbosity, CONTEXT_SETTINGS
-from hokusai.lib.default_branch import detect_branch
+from hokusai.lib.branch_detection import detect_branch
 
 KUBE_CONTEXT = 'production'
 

--- a/hokusai/cli/production.py
+++ b/hokusai/cli/production.py
@@ -4,6 +4,7 @@ import hokusai
 
 from hokusai.cli.base import base
 from hokusai.lib.common import set_verbosity, CONTEXT_SETTINGS
+from hokusai.lib.default_branch import detect_branch
 
 KUBE_CONTEXT = 'production'
 
@@ -33,8 +34,9 @@ def delete(filename, verbose):
   hokusai.k8s_delete(KUBE_CONTEXT, filename=filename)
 
 
+
 @production.command(context_settings=CONTEXT_SETTINGS)
-@click.option('--check-branch', type=click.STRING, default="main", help='Check branch before updating (default: main)')
+@click.option('--check-branch', type=click.STRING, default=detect_branch(), help='Check branch before updating (default: main)')
 @click.option('--check-remote', type=click.STRING, help='Check remotes before updating (otherwise check all remotes)')
 @click.option('--skip-checks', type=click.BOOL, is_flag=True, help='Skip all checks and update configuration recklessly')
 @click.option('-f', '--filename', type=click.STRING, help='Use the given Kubernetes Yaml file (default ./hokusai/production.yml)')

--- a/hokusai/cli/staging.py
+++ b/hokusai/cli/staging.py
@@ -4,7 +4,7 @@ import hokusai
 
 from hokusai.cli.base import base
 from hokusai.lib.common import set_verbosity, CONTEXT_SETTINGS
-from hokusai.lib.default_branch import detect_branch
+from hokusai.lib.branch_detection import detect_branch
 
 KUBE_CONTEXT = 'staging'
 

--- a/hokusai/cli/staging.py
+++ b/hokusai/cli/staging.py
@@ -4,6 +4,7 @@ import hokusai
 
 from hokusai.cli.base import base
 from hokusai.lib.common import set_verbosity, CONTEXT_SETTINGS
+from hokusai.lib.default_branch import detect_branch
 
 KUBE_CONTEXT = 'staging'
 
@@ -34,7 +35,7 @@ def delete(filename, verbose):
 
 
 @staging.command(context_settings=CONTEXT_SETTINGS)
-@click.option('--check-branch', type=click.STRING, default="main", help='Check branch before updating (default: main)')
+@click.option('--check-branch', type=click.STRING, default=detect_branch(), help='Check branch before updating (default: main)')
 @click.option('--check-remote', type=click.STRING, help='Check remotes before updating (otherwise check all remotes)')
 @click.option('--skip-checks', type=click.BOOL, is_flag=True, help='Skip all checks and update configuration recklessly')
 @click.option('-f', '--filename', type=click.STRING, help='Use the given Kubernetes Yaml file (default ./hokusai/staging.yml)')

--- a/hokusai/cli/staging.py
+++ b/hokusai/cli/staging.py
@@ -34,7 +34,7 @@ def delete(filename, verbose):
 
 
 @staging.command(context_settings=CONTEXT_SETTINGS)
-@click.option('--check-branch', type=click.STRING, default="master", help='Check branch before updating (default: master)')
+@click.option('--check-branch', type=click.STRING, default="main", help='Check branch before updating (default: main)')
 @click.option('--check-remote', type=click.STRING, help='Check remotes before updating (otherwise check all remotes)')
 @click.option('--skip-checks', type=click.BOOL, is_flag=True, help='Skip all checks and update configuration recklessly')
 @click.option('-f', '--filename', type=click.STRING, help='Use the given Kubernetes Yaml file (default ./hokusai/staging.yml)')

--- a/hokusai/cli/staging.py
+++ b/hokusai/cli/staging.py
@@ -35,7 +35,7 @@ def delete(filename, verbose):
 
 
 @staging.command(context_settings=CONTEXT_SETTINGS)
-@click.option('--check-branch', type=click.STRING, default=detect_branch(), help='Check branch before updating (default: main)')
+@click.option('--check-branch', type=click.STRING, default=detect_branch(), help='Check branch before updating (default: origin default or main)')
 @click.option('--check-remote', type=click.STRING, help='Check remotes before updating (otherwise check all remotes)')
 @click.option('--skip-checks', type=click.BOOL, is_flag=True, help='Skip all checks and update configuration recklessly')
 @click.option('-f', '--filename', type=click.STRING, help='Use the given Kubernetes Yaml file (default ./hokusai/staging.yml)')

--- a/hokusai/commands/setup.py
+++ b/hokusai/commands/setup.py
@@ -38,7 +38,7 @@ def setup(project_name, template_remote, template_dir, template_vars, allow_miss
     if len(git_repo_and_branch) == 2:
       git_branch = git_repo_and_branch[1]
     else:
-      git_branch = "master"
+      git_branch = "main"
     shout("git clone -b %s --single-branch %s %s" % (git_branch, git_repo, scratch_dir))
 
   custom_template_dir = None

--- a/hokusai/lib/branch_detection.py
+++ b/hokusai/lib/branch_detection.py
@@ -1,4 +1,7 @@
 from hokusai.lib.common import shout
+# This method is looking up the local git default branch (HEAD) and returning its name
+# For example if HEAD is "main" it will return "main"
+# If for any reason the lookup fails, it will return "main" as the default.
 
 def detect_branch():
   try: 

--- a/hokusai/lib/default_branch.py
+++ b/hokusai/lib/default_branch.py
@@ -1,0 +1,9 @@
+from hokusai.lib.common import shout
+
+def detect_branch():
+  try: 
+    default_branch = shout("git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@'")
+    return default_branch
+  except: 
+    return "main"
+  


### PR DESCRIPTION
In order to go with the current standard we need hokusai to default to the main branch with its commands. 