### PR TITLE
feat: discontinue ecr repository exists test before run a kubectl command

### DIFF
--- a/hokusai/services/command_runner.py
+++ b/hokusai/services/command_runner.py
@@ -16,9 +16,6 @@ class CommandRunner(object):
     self.ecr = ECR()
 
   def run(self, image_tag, cmd, tty=None, env=(), constraint=()):
-    if not self.ecr.project_repo_exists():
-      raise HokusaiError("Project repo does not exist.  Aborting.")
-
     if os.environ.get('USER') is not None:
       # The regex used for the validation of name is '[a-z0-9]([-a-z0-9]*[a-z0-9])?'
       user = re.sub("[^0-9a-z]+", "-", os.environ.get('USER').lower())


### PR DESCRIPTION
Since Hokusai runs in the operator node (which includes Jenkins and other ci/cron/task executors), testing if a repository exists from this context doesn't help to tell if an image could be pulled from k8s agent node. 
The motivation for this change was this bug:
 - Jenkins injecting AWS credentials that has no access to ECR target repository
 - K8s node has access to ECR target repository
 - hokusai production/staging run command fails due operator (jenkins) node AWS credentials having no access to ECR
So this PR:
 - Remove ECR repo check on `hokusai production/staging run...`

Negative impact:
 - No negative impact is expected, since: 
   - testing repository doesn't help to tell if a specific tag/hash is present
   - testing repository doens't help to tell if a specific k8s agent node has access to ecr