### PR TITLE
feat: add image digest support to CommandRunner:run()

### DIFF
--- a/hokusai/services/command_runner.py
+++ b/hokusai/services/command_runner.py
@@ -15,7 +15,7 @@ class CommandRunner(object):
     self.kctl = Kubectl(self.context, namespace=namespace)
     self.ecr = ECR()
 
-  def run(self, image_tag, cmd, tty=None, env=(), constraint=()):
+  def run(self, tag_or_digest, cmd, tty=None, env=(), constraint=()):
     if os.environ.get('USER') is not None:
       # The regex used for the validation of name is '[a-z0-9]([-a-z0-9]*[a-z0-9])?'
       user = re.sub("[^0-9a-z]+", "-", os.environ.get('USER').lower())
@@ -24,7 +24,9 @@ class CommandRunner(object):
       uuid = k8s_uuid()
 
     name = "%s-hokusai-run-%s" % (config.project_name, uuid)
-    image_name = "%s:%s" % (self.ecr.project_repo, image_tag)
+    separator = "@" if ":" in tag_or_digest else ":"
+    image_name = "%s%s%s" % (self.ecr.project_repo, separator, tag_or_digest)
+
     container = {
       "args": cmd.split(' '),
       "name": name,

--- a/hokusai/services/deployment.py
+++ b/hokusai/services/deployment.py
@@ -59,7 +59,7 @@ class Deployment(object):
     # Run the pre-deploy hook for the canonical app or a review app
     if config.pre_deploy and (filename is None or (filename and self.namespace)):
       print_green("Running pre-deploy hook '%s'..." % config.pre_deploy, newline_after=True)
-      return_code = CommandRunner(self.context, namespace=self.namespace).run(tag, config.pre_deploy, constraint=constraint, tty=False)
+      return_code = CommandRunner(self.context, namespace=self.namespace).run(digest, config.pre_deploy, constraint=constraint, tty=False)
       if return_code:
         raise HokusaiError("Pre-deploy hook failed with return code %s" % return_code, return_code=return_code)
 
@@ -135,7 +135,7 @@ class Deployment(object):
     # Run the post-deploy hook for the canonical app or a review app
     if config.post_deploy and (filename is None or (filename and self.namespace)):
       print_green("Running post-deploy hook '%s'..." % config.post_deploy, newline_after=True)
-      return_code = CommandRunner(self.context, namespace=self.namespace).run(tag, config.post_deploy, constraint=constraint, tty=False)
+      return_code = CommandRunner(self.context, namespace=self.namespace).run(digest, config.post_deploy, constraint=constraint, tty=False)
       if return_code:
         print_yellow("WARNING: Running the post-deploy hook failed with return code %s" % return_code, newline_before=True, newline_after=True)
         print_yellow("The image digest %s has been rolled out.  However, you should run the post-deploy hook '%s' manually, or re-run this deployment." % (digest, config.post_deploy), newline_after=True)


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PLATFORM-3772

This change adds _image digest_ support as a function argument to the `CommandRunner:run()` function. The calling code can now pass either a `tag` or a `digest` and the `run()` function will build a valid _image_name_.

The change modifies the _pre-deploy_ and _post-deploy_ hooks within `Deployment:update()` function where an image `tag` is being used to build an _image_name_ instead providing a `digest` to ensure that the same image is used throughout the whole deploy process.


- when a _staging_ `tag` is passed, the _image_name_ is: `123.dkr.ecr.us-east-1.amazonaws.com/some-app:staging`
- when a _sha256:111_ `digest` is passed, the _image_name_ is: `123.dkr.ecr.us-east-1.amazonaws.com/some-app@sha256:111`

This change mitigates the likelihood that a wrong image will be used during the deploy process if a staging deploy is triggered and the `staging` tag is updated during an ongoing production deploy. 