### PR TITLE
feat: add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: daily
+    # Limit to 0 to enable only security updates:
+    open-pull-requests-limit: 0
+    assignees:
+      - mc-jones
+    reviewers:
+      - artsy/platform-engineers


### PR DESCRIPTION
This enables security alerts for Github-native dependabot and puts it in line with the security alert playbook.

Step 1 (already complete): Enable "Dependabot security updates" under the repo's Security & analysis settings.

Step 2 (this PR): Commit a minimal .github/dependabot.yml specifying open-pull-requests-limit: 0 (a hack to enable only security updates, which can't otherwise be configured).

https://artsyproduct.atlassian.net/browse/PLATFORM-3886