### PR TITLE
chore: switch test_integration image to a supported one

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
       - run:
           name: install conntrack
           command: |
-            apt-get -qq update && apt-get -qq install conntrack
+            sudo apt-get -qq update && sudo apt-get -qq install conntrack
       - run:
           name: start minikube
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,11 @@ jobs:
           name: setup minikube
           command: |
             curl -Lo minikube https://github.com/kubernetes/minikube/releases/download/${MINIKUBE_VERSION}/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
+      # required by minikube for k8s v1.18 onwards
+      - run:
+          name: install conntrack
+          command: |
+            apt-get -qq update && apt-get -qq install conntrack
       - run:
           name: start minikube
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
 
   test_integration:
     machine:
-      image: circleci/classic:201808-01
+      image: ubuntu-2004:202201-02
     environment:
       K8S_VERSION: v1.17.17
       KUBECONFIG: /home/circleci/.kube/config

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,7 @@ jobs:
           name: Update pyenv
           command: |
             cd /opt/circleci/.pyenv/plugins/python-build/../.. 
+            git checkout master
             git pull
             cd -
       - run: pyenv install 2.7.16

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   test_linux2:
     docker:
-      - image: python:2.7.16
+      - image: python:2.7
     steps:
       - checkout
       - run: make dependencies
@@ -66,16 +66,6 @@ jobs:
           command: |
             kubectl cluster-info
             kubectl get pods --all-namespaces
-      - run:
-          name: Update pyenv
-          command: |
-            cd /opt/circleci/.pyenv/plugins/python-build/../.. 
-            git checkout master
-            git pull
-            cd -
-      - run: pyenv install 2.7.16
-      - run: echo 'eval "$(pyenv init -)"' >> ~/.bash_profile
-      - run: pyenv local 2.7.16
       - run: make dependencies
       - run: make integration
 
@@ -120,9 +110,9 @@ jobs:
     steps:
       - checkout
       - run: HOMEBREW_NO_AUTO_UPDATE=1 brew install pyenv
-      - run: pyenv install 2.7.16
+      - run: pyenv install 2.7.18
       - run: echo 'eval "$(pyenv init -)"' >> ~/.bash_profile
-      - run: pyenv local 2.7.16
+      - run: pyenv local 2.7.18
       - run: pip install --upgrade pip
       - run: make dependencies
       - run: make test
@@ -146,9 +136,9 @@ jobs:
     steps:
       - checkout
       - run: HOMEBREW_NO_AUTO_UPDATE=1 brew install awscli openssl pyenv
-      - run: PYTHON_CONFIGURE_OPTS="--enable-framework" pyenv install 2.7.16
+      - run: PYTHON_CONFIGURE_OPTS="--enable-framework" pyenv install 2.7.18
       - run: echo 'eval "$(pyenv init -)"' >> ~/.bash_profile
-      - run: pyenv local 2.7.16
+      - run: pyenv local 2.7.18
       - run: pip install --upgrade pip
       - run: make dependencies
       - run: make build VERSION=beta
@@ -174,9 +164,9 @@ jobs:
     steps:
       - checkout
       - run: HOMEBREW_NO_AUTO_UPDATE=1 brew install awscli openssl pyenv
-      - run: PYTHON_CONFIGURE_OPTS="--enable-framework" pyenv install 2.7.16
+      - run: PYTHON_CONFIGURE_OPTS="--enable-framework" pyenv install 2.7.18
       - run: echo 'eval "$(pyenv init -)"' >> ~/.bash_profile
-      - run: pyenv local 2.7.16
+      - run: pyenv local 2.7.18
       - run: pip install --upgrade pip
       - run: make dependencies
       - run: make build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
     machine:
       image: ubuntu-2004:202201-02
     environment:
-      K8S_VERSION: v1.17.17
+      K8S_VERSION: v1.18.10
       KUBECONFIG: /home/circleci/.kube/config
       MINIKUBE_VERSION: v1.22.0
       MINIKUBE_WANTUPDATENOTIFICATION: false

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ To install the Hokusai package in "editable mode" from a checkout of this reposi
 
 ## Testing Hokusai
 
-Hokusai is currently tested on Pythons 2.7.16 and 3.5.8.
+Hokusai is currently tested on Pythons 2.7.18 and 3.5.8.
 
 1) Install poetry (see above).
 


### PR DESCRIPTION
CircleCI sent an email regarding deprecation of machine images.

<details><summary>Email Screenshot</summary>

<img width="877" alt="Screen Shot 2022-03-16 at 4 18 24 PM" src="https://user-images.githubusercontent.com/29984068/158683199-9f675dca-92fe-43fe-801f-7b6fb6829654.png">

</details>

Hokusai currently uses the `circleci/classic:201808-01` in the test_integration job. I located [this blog post](https://circleci.com/blog/ubuntu-14-16-image-deprecation/) which states that in addition to 14.04 images, 16.04 images are also affected by this. Specifically the section "_Does the Ubuntu 14.04 and 16.04 image deprecation affect me?_" (includes the image tag we use):

> In addition, the following Ubuntu 16.04-based images will be removed:
>
> circleci/classic:201808-01 <-- THIS IMAGE
> ubuntu-1604:201903-01
> ubuntu-1604:202004-01
> ubuntu-1604:202007-01
> ...

Updated the config following the [suggested migration steps](https://circleci.com/docs/2.0/images/linux-vm/16.04-to-20.04-migration/#switching-to-a-supported-image) to use a supported image instead.