### PR TITLE
fix: failed beta release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,13 @@ jobs:
             pyenv install 3.9.10
             pyenv local 3.9.10
             pip install --upgrade pip
+      - run:
+          # awscli is not required for this job. but it is for the other macos jobs.
+          # so might as well test the install here.
+          name: install awscli
+          command: |
+            curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"
+            sudo installer -pkg AWSCLIV2.pkg -target /
       - run: make dependencies
       - run: pyenv rehash
       - run: make test
@@ -87,6 +94,15 @@ jobs:
       - run: make integration
       - run: coverage report
 
+  test_docker_build:
+    docker:
+      - image: docker:18.09
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run: apk add curl make
+      - run: make image
+
   release_beta_s3_linux:
     docker:
       - image: python:3.9.10
@@ -114,6 +130,11 @@ jobs:
             PYTHON_CONFIGURE_OPTS="--enable-framework" pyenv install 3.9.10
             pyenv local 3.9.10
             pip install --upgrade pip
+      - run:
+          name: install awscli
+          command: |
+            curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"
+            sudo installer -pkg AWSCLIV2.pkg -target /
       - run: make dependencies
       - run: make build VERSION=beta
       - run: make publish-beta
@@ -158,6 +179,11 @@ jobs:
             PYTHON_CONFIGURE_OPTS="--enable-framework" pyenv install 3.9.10
             pyenv local 3.9.10
             pip install --upgrade pip
+      - run:
+          name: install awscli
+          command: |
+            curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"
+            sudo installer -pkg AWSCLIV2.pkg -target /
       - run: make dependencies
       - run: make build
       - run: make build VERSION=latest
@@ -268,10 +294,15 @@ workflows:
           filters:
             branches:
               ignore: release
+      - test_docker_build:
+          filters:
+            branches:
+              ignore: release
       - release_beta_s3_linux:
           requires:
             - test_linux
             - test_integration
+            - test_docker_build
           filters:
             branches:
               only: main
@@ -279,6 +310,7 @@ workflows:
           requires:
             - test_macos
             - test_integration
+            - test_docker_build
           filters:
             branches:
               only: main

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,5 @@ RUN curl -L https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/do
 
 COPY . /src
 
-# Workaround pip using dependencies from pyproject.toml https://github.com/python-poetry/poetry/issues/826
-RUN mv pyproject.toml pyproject.toml.bak
-
 # Install Hokusai
 RUN pip install .


### PR DESCRIPTION
Fix two failures in [beta release](https://app.circleci.com/pipelines/github/artsy/hokusai/635/workflows/3ace4a2e-685f-4fa8-af03-c5cc56de3816).

- `release_beta_s3_macos` failed at installing `awscli`. Some mysterious Python conflict. Switch to a binary install. Add this install to `test_macos` build so that such problem can be tested (prior to merge into `main`)

- `release_beta_dockerhub` failed at `pip install`. Resolve by undoing the `mv pyproject.toml...` command so Pip can read that file (that lists project dependencies). Add `test_docker_build` for branch builds, to catch such problem earlier. Let `release_beta_s3_linux` and `release_beta_s3_macos` require it. `release_beta_dockerhub` doesn't have to require b/c it does docker build anyway.