### PR TITLE
require all tests before beta, update get-hokusai script.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -302,6 +302,7 @@ workflows:
       - release_beta_s3_linux:
           requires:
             - test_linux
+            - test_macos
             - test_integration
             - test_docker_build
           filters:
@@ -309,6 +310,7 @@ workflows:
               only: main
       - release_beta_s3_macos:
           requires:
+            - test_linux
             - test_macos
             - test_integration
             - test_docker_build
@@ -318,7 +320,9 @@ workflows:
       - release_beta_dockerhub:
           requires:
             - test_linux
+            - test_macos
             - test_integration
+            - test_docker_build
           filters:
             branches:
               only: main

--- a/README.md
+++ b/README.md
@@ -244,11 +244,13 @@ Tip: Set `DEBUG=1` environment variable to print boto logging
 
 ## Distributing Hokusai
 
-Merges to `main` branch automatically distribute Pyinstaller-built binaries for beta testing. The files are uploaded to:
+Merges to `main` branch automatically distribute Pyinstaller-built binaries for beta testing.
 
-https://artsy-provisioning-public.s3.amazonaws.com/hokusai/hokusai-beta-Darwin-x86_64
+The beta binary can be installed by:
 
-https://artsy-provisioning-public.s3.amazonaws.com/hokusai/hokusai-beta-Linux-x86_64
+```
+curl -sSL https://raw.githubusercontent.com/artsy/hokusai/main/get-hokusai.sh beta | sudo bash
+```
 
 To create a new release, bump Hokusai version in [pyproject.toml](pyproject.toml) and [hokusai/VERSION](hokusai/VERSION), update [CHANGELOG](./CHANGELOG.md), and open a PR to merge `main` into `release` branch.
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Transitioning teams to the Docker / Kubernetes ecosystem can be intimidating, an
 We recommend installing via Homebrew:
 
 ```
+$ brew update
 $ brew tap artsy/formulas
 $ brew install hokusai
 ```

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Note: If you want to create a PyInstaller distribution (by running `make build`)
 
 ### Virtualenv
 
-We recommended using a virtual environment to isolate Hokusai's dependencies from that of other projects on your local environment.
+We recommend using a virtual environment to isolate Hokusai's dependencies from that of other projects on your local environment.
 
 The Pyenv install comes with [pyenv-virtualenv](https://github.com/pyenv/pyenv-virtualenv) which can be used to create virtual environments.
 

--- a/get-hokusai.sh
+++ b/get-hokusai.sh
@@ -16,5 +16,8 @@ fi
 
 echo "Installing Hokusai @ $VERSION to $TARGET"
 
-curl https://artsy-provisioning-public.s3.amazonaws.com/hokusai/hokusai-$VERSION-$(uname -s)-x86_64 -o $TARGET
-chmod +x $TARGET
+TMPFILE=hokusai-$VERSION-$(uname -s)-x86_64
+
+curl https://artsy-provisioning-public.s3.amazonaws.com/hokusai/hokusai-$VERSION-$(uname -s)-x86_64 -o $TMPFILE
+chmod +x $TMPFILE
+sudo mv $TMPFILE $TARGET


### PR DESCRIPTION
Minor improvements:

- require all tests to pass before releasing any beta
- `brew update` is required to detect latest version of Homebrew formula
- `sudo` is required for `get-hokusai.sh` to install hokusai binary into `/usr/local/bin`
- instruct to use `get-hokusai.sh` to install beta