### PR TITLE
fix beta download command

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ Merges to `main` branch automatically distribute Pyinstaller-built binaries for 
 The beta binary can be installed by:
 
 ```
-curl -sSL https://raw.githubusercontent.com/artsy/hokusai/main/get-hokusai.sh beta | sudo bash
+curl -sSL https://raw.githubusercontent.com/artsy/hokusai/main/get-hokusai.sh | sudo bash -s beta
 ```
 
 To create a new release, bump Hokusai version in [pyproject.toml](pyproject.toml) and [hokusai/VERSION](hokusai/VERSION), update [CHANGELOG](./CHANGELOG.md), and open a PR to merge `main` into `release` branch.

--- a/get-hokusai.sh
+++ b/get-hokusai.sh
@@ -16,8 +16,5 @@ fi
 
 echo "Installing Hokusai @ $VERSION to $TARGET"
 
-TMPFILE=hokusai-$VERSION-$(uname -s)-x86_64
-
-curl https://artsy-provisioning-public.s3.amazonaws.com/hokusai/hokusai-$VERSION-$(uname -s)-x86_64 -o $TMPFILE
-chmod +x $TMPFILE
-sudo mv $TMPFILE $TARGET
+curl https://artsy-provisioning-public.s3.amazonaws.com/hokusai/hokusai-$VERSION-$(uname -s)-x86_64 -o $TARGET
+chmod +x $TARGET


### PR DESCRIPTION
- revert `get-hokusai.sh` script. the readme already says to use `sudo` so no need to embed it in script.
- fix beta download command.