### PR TITLE
fix: release build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -353,6 +353,7 @@ workflows:
           requires:
             - release_s3_linux
             - release_s3_macos
+            - release_dockerhub
           filters:
             branches:
               only: release

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ GIT_TAG ?= $(shell which git) tag --sign
 
 DIST_DIR ?= dist/
 PROJECT = github.com/artsy/hokusai
-VERSION ?= $(shell poetry version --short)
-MINOR_VERSION ?= $(shell poetry version --short | awk -F"." '{ print $$1"."$$2 }')
+VERSION ?= $(shell cat hokusai/VERSION)
+MINOR_VERSION ?= $(shell cat hokusai/VERSION | awk -F"." '{ print $$1"."$$2 }')
 
 dependencies:
 	pip install --upgrade pip
@@ -88,7 +88,7 @@ publish-version:
 publish-pip:
 	pip install --upgrade wheel
 	poetry build
-	twine upload dist/*
+	twine upload dist/* --verbose
 
 publish-dockerhub:
 	if [ "$(shell curl --silent https://index.docker.io/v1/repositories/artsy/hokusai/tags/$(VERSION) --output /dev/null --write-out %{http_code})" -eq 404 ]; then \


### PR DESCRIPTION
Fix bunch of errors in [v1.0.0 release build](https://app.circleci.com/pipelines/github/artsy/hokusai/663/workflows/538b1ab8-3180-4584-9965-045fce1c8935).

These changes were already pushed to `release` directly, and its [build](https://app.circleci.com/pipelines/github/artsy/hokusai/665/workflows/6f58180e-ed5b-402e-8ad0-56bba34d2429) worked (ignore `release_pip` step which failed b/c it's trying to upload v1.0.0 artifacts again).