### PR TITLE
fix homebrew formula

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,7 +192,8 @@ jobs:
 
             git config user.name "Hokusai CI"
             git config user.email "it@artsymail.com"
-            git commit -am "Release Hokusai Beta"
+            git add ./Formula/hokusai-beta.rb
+            git commit -m "Release Hokusai Beta"
             git push origin main
 
             cd /tmp
@@ -321,7 +322,8 @@ jobs:
 
             git config user.name "Hokusai CI"
             git config user.email "it@artsymail.com"
-            git commit -am "Release Hokusai $VERSION"
+            git add ./Formula/hokusai.rb
+            git commit -m "Release Hokusai $VERSION"
             git push origin main
 
             cd /tmp

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,7 +185,7 @@ jobs:
               version 'beta'
 
               def install
-                prefix.install Dir["*"]
+                bin.install Dir["*"]
               end
             end
             EOF
@@ -315,7 +315,7 @@ jobs:
               version '$VERSION'
 
               def install
-                prefix.install Dir["*"]
+                bin.install Dir["*"]
               end
             end
             EOF


### PR DESCRIPTION
Ammend https://github.com/artsy/hokusai/pull/301

- use `bin.install` in homebrew formula, so that `brew install` creates `/usr/local/bin/hokusai` symlink
- let the build explicitly `git add` the formula file, so that if the file is not yet tracked by git, it will be