### PR TITLE
fix: Makefile curl on dockerhub api which has changed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ publish-pip:
 	twine upload dist/* --verbose
 
 publish-dockerhub:
-	if [ "$(shell curl --silent https://index.docker.io/v1/repositories/artsy/hokusai/tags/$(VERSION) --output /dev/null --write-out %{http_code})" -eq 404 ]; then \
+	if [ "$(shell curl --silent https://hub.docker.com/v2/namespaces/artsy/repositories/hokusai/tags/$(VERSION) --output /dev/null --write-out %{http_code})" -eq 404 ]; then \
 	  docker tag hokusai:latest artsy/hokusai:$(VERSION) && \
 	  docker push artsy/hokusai:$(VERSION) && \
 	  docker tag hokusai:latest artsy/hokusai:$(MINOR_VERSION) && \


### PR DESCRIPTION
https://artsy.slack.com/archives/CA8SANW3W/p1669143642481589?thread_ts=1669137745.068279&cid=CA8SANW3W

`make publish-dockerhub` sanity checks by curl'ing against Dockerhub API to see if the new Hokusai version already exists. This curl [no longer works](https://app.circleci.com/pipelines/github/artsy/hokusai/722/workflows/e8ff870b-9f86-4b4d-bb3b-100cd009ad4f/jobs/3023) b/c Dockerhub [changed their API](https://www.docker.com/blog/docker-hub-v1-api-deprecation/). Update URL to their new API.