### PR TITLE
fix: ghr install for release github step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -254,12 +254,12 @@ jobs:
 
   release_github:
     docker:
-      - image: golang:1.11
+      - image: golang:1.19
     steps:
       - checkout
       - run: apt-get -qq update
       - run: apt-get -qq install awscli
-      - run: go get -u github.com/tcnksm/ghr
+      - run: go install github.com/tcnksm/ghr@latest
       - run: make publish-github
 
   release_pip:


### PR DESCRIPTION
https://artsy.slack.com/archives/CA8SANW3W/p1669145873115029?thread_ts=1669137745.068279&cid=CA8SANW3W

`make publish-github` uses [ghr](https://github.com/tcnksm/ghr) to pubish artifacts on Github. CircleCI `release_github` installs ghr using `go get...` which [no longer works](https://app.circleci.com/pipelines/github/artsy/hokusai/722/workflows/e8ff870b-9f86-4b4d-bb3b-100cd009ad4f/jobs/3026). Use `go install...` instead.