### PR TITLE
docs(getting-started): Update with link to CircleCI setup instructions

### DIFF
--- a/docs/Getting_Started.md
+++ b/docs/Getting_Started.md
@@ -148,3 +148,5 @@ Deploy the new commit to staging with `hokusai production deploy {TAG}` where TA
 ```bash
 hokusai pipeline promote
 ```
+
+For those wishing to configure automatic deployments through Github and CircleCI, [these instructions](https://github.com/artsy/README/blob/main/playbooks/deployments.md#setting-up-a-project-in-circleci).

--- a/docs/Getting_Started.md
+++ b/docs/Getting_Started.md
@@ -149,4 +149,4 @@ Deploy the new commit to staging with `hokusai production deploy {TAG}` where TA
 hokusai pipeline promote
 ```
 
-For those wishing to configure automatic deployments through Github and CircleCI, [these instructions](https://github.com/artsy/README/blob/main/playbooks/deployments.md#setting-up-a-project-in-circleci).
+For those wishing to configure automatic deployments through Github and CircleCI, see [these instructions](https://github.com/artsy/README/blob/main/playbooks/deployments.md#setting-up-a-project-in-circleci).


### PR DESCRIPTION
Missed this step, so thought it would helpful to update getting started docs with link to [further setup](https://github.com/artsy/README/blob/main/playbooks/deployments.md#setting-up-a-project-in-circleci).