### PR TITLE
Improve Dockerfile to reduce its image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,4 @@ RUN curl -L https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/do
 COPY . /src
 
 # Install Hokusai
-RUN pip install .
+RUN pip install --no-cache-dir .


### PR DESCRIPTION
Hi there,

Thanks for maintaining hokusai. I've made a small improvement to the Dockerfile that I think could help optimize the image size.

Summary of Change:
* I added the `--no-cache-dir` to the `pip` command to disable the package cache.


Impact on the image size:
* Image size before repair: 539.42 MB
* Image size after repair: 529.35 MB
* Difference: 10.07 MB (1.87%)

I hope that you will find these changes useful to you. :smile:
Let me know if you have any questions or concerns.

Thanks,