### PR TITLE
fix: CI build failures related to Poetry and Python install.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
       - run:
           name: install python
           command: |
-            PYTHON_CONFIGURE_OPTS="--enable-framework" pyenv install 3.9.10
+            pyenv install 3.9.10
             pyenv local 3.9.10
             pip install --upgrade pip
       - run:
@@ -127,7 +127,7 @@ jobs:
       - run:
           name: install python
           command: |
-            PYTHON_CONFIGURE_OPTS="--enable-framework" pyenv install 3.9.10
+            pyenv install 3.9.10
             pyenv local 3.9.10
             pip install --upgrade pip
       - run:
@@ -226,7 +226,7 @@ jobs:
       - run:
           name: install python
           command: |
-            PYTHON_CONFIGURE_OPTS="--enable-framework" pyenv install 3.9.10
+            pyenv install 3.9.10
             pyenv local 3.9.10
             pip install --upgrade pip
       - run:

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ BINARY_SUFFIX ?= -$(VERSION)-$(shell uname -s)-$(shell uname -m)
 
 dependencies:
 	pip install --upgrade pip
-	pip install poetry==1.3.0 --quiet --ignore-installed
+	pip install poetry==1.2.2 --quiet --ignore-installed
 	poetry --version
 	poetry install --no-root
 

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ BINARY_SUFFIX ?= -$(VERSION)-$(shell uname -s)-$(shell uname -m)
 
 dependencies:
 	pip install --upgrade pip
+	# pin version due to https://github.com/python-poetry/poetry/issues/7184
 	pip install poetry==1.2.2 --quiet --ignore-installed
 	poetry --version
 	poetry install --no-root

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ BINARY_SUFFIX ?= -$(VERSION)-$(shell uname -s)-$(shell uname -m)
 dependencies:
 	pip install --upgrade pip
 	pip install poetry --quiet --ignore-installed
-	poetry install --no-root
+	poetry -vvv install --no-root
 
 tests:
 	coverage run --omit="test/*" -m unittest discover test

--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,10 @@ MINOR_VERSION ?= $(shell cat hokusai/VERSION | awk -F"." '{ print $$1"."$$2 }')
 BINARY_SUFFIX ?= -$(VERSION)-$(shell uname -s)-$(shell uname -m)
 
 dependencies:
-	python -c "import shutil; print(shutil.get_terminal_size())"
 	pip install --upgrade pip
-	pip install poetry --quiet --ignore-installed
-	poetry -vvv install --no-root
+	pip install poetry==1.3.1 --quiet --ignore-installed
+	poetry --version
+	poetry install --no-root
 
 tests:
 	coverage run --omit="test/*" -m unittest discover test

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ BINARY_SUFFIX ?= -$(VERSION)-$(shell uname -s)-$(shell uname -m)
 
 dependencies:
 	pip install --upgrade pip
-	pip install poetry==1.3.1 --quiet --ignore-installed
+	pip install poetry==1.3.0 --quiet --ignore-installed
 	poetry --version
 	poetry install --no-root
 

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ MINOR_VERSION ?= $(shell cat hokusai/VERSION | awk -F"." '{ print $$1"."$$2 }')
 BINARY_SUFFIX ?= -$(VERSION)-$(shell uname -s)-$(shell uname -m)
 
 dependencies:
+	python -c "import shutil; print(shutil.get_terminal_size())"
 	pip install --upgrade pip
 	pip install poetry --quiet --ignore-installed
 	poetry -vvv install --no-root

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <a href="https://en.wikipedia.org/wiki/Hokusai"><img height="300" src="hokusai.jpg"></a>
 
-Hokusai is a Docker + Kubernetes CLI for application developers..
+Hokusai is a Docker + Kubernetes CLI for application developers.
 
 Hokusai "dockerizes" applications and manages their lifecycle throughout development, testing, and release cycles.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <a href="https://en.wikipedia.org/wiki/Hokusai"><img height="300" src="hokusai.jpg"></a>
 
-Hokusai is a Docker + Kubernetes CLI for application developers.
+Hokusai is a Docker + Kubernetes CLI for application developers..
 
 Hokusai "dockerizes" applications and manages their lifecycle throughout development, testing, and release cycles.
 


### PR DESCRIPTION
[Builds have been failing](https://app.circleci.com/pipelines/github/artsy/hokusai/744/workflows/7d7329ba-33b1-4c38-82f0-45d816c6bbbb) at `poetry install` step. This is due to [new versions of Poetry (1.3.0+) failing to get terminal size within CI environment](https://github.com/python-poetry/poetry/issues/7184).

Let's pin Poetry to v1.2.2 (latest that does not suffer that problem) in CI, until Poetry folks have fixed the problem.

The builds are also [failing on a permissions error](https://app.circleci.com/pipelines/github/artsy/hokusai/756/workflows/bcf21e32-1460-44a2-a6f4-42fd66398144/jobs/3191) related to `--enable-framework` option for macOS python install. That option was [added in 2020 as a hotfix](https://github.com/artsy/hokusai/pull/222). I wonder if it is still relevant. Let's remove the option, let `main` build , and test Beta release.