### PR TITLE
feat: let readme have links to past release prs

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,9 +266,9 @@ To create an official release, such as `v1.2.3`, perform the following:
 - Create a branch named `prepare-v1.2.3` and make the following changes:
   - Bump version in [RELEASE_VERSION](./RELEASE_VERSION) file.
   - Upate [CHANGELOG](./CHANGELOG.md).
-  - Open a PR to merge into `main`.
+  - Open a PR to merge into `main`. Please see [past PRs](https://github.com/artsy/hokusai/pulls?q=is%3Apr+Release+is%3Aclosed+%22prepare+version%22) for example.
 
-- Open a PR to merge `main` into `release`.
+- Open a PR to merge `main` into `release`. Please see [past PRs](https://github.com/artsy/hokusai/pulls?q=is%3Apr+is%3Aclosed+%22release+version%22) for example.
 
 ## The Name
 


### PR DESCRIPTION
Someone releasing Hokusai might want examples for writing the Pull Requests. For that person's convenience, let README link to examples.