### PR TITLE
fix: release build failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -274,6 +274,7 @@ jobs:
     steps:
       - checkout
       - run: make dependencies
+      - run: scripts/create_release_tag.sh
       - run: make publish-to-pip
 
   release_homebrew:

--- a/scripts/create_release_tag.sh
+++ b/scripts/create_release_tag.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 # This script is to be run within CircleCI only for 'release' branch builds.
 # It reads the new release version from RELEASE_VERSION file and creates a Git tag for it (locally in CircleCI).


### PR DESCRIPTION
Fix problems encountered in [Release build](https://app.circleci.com/pipelines/github/artsy/hokusai/800/workflows/33d7f7b9-d8cc-47bd-bd0b-c7eb5a021fdd).

- `release_dockerhub` failed due to build container doesn't have Bash wanted by [tag creation script](https://github.com/artsy/hokusai/blob/e2172b0a8f0a6b5f5533f9a712205ea9419f1422/scripts/create_release_tag.sh#L1). Change script to use `sh`.
- `release_pip` succeeded but after `pip install hokusai`, `hokusai version` [reports a dev version](https://github.com/artsy/hokusai/pull/340#issuecomment-1453813388). This is due to not invoking `create_release_tag.sh` in that step. Add it.