### PR TITLE
fix: create release tag script not compatible with sh

### DIFF
--- a/scripts/create_release_tag.sh
+++ b/scripts/create_release_tag.sh
@@ -16,7 +16,7 @@ fi
 echo "On branch: $CIRCLE_BRANCH"
 
 # fail if not 'release' branch
-if [[ "$CIRCLE_BRANCH" != 'release' ]]
+if [ "$CIRCLE_BRANCH" != 'release' ]
 then
   echo "Error: not on release branch"
   exit 1


### PR DESCRIPTION
Error from [recent release build](https://app.circleci.com/pipelines/github/artsy/hokusai/807/workflows/f842916a-9437-4c93-9a8f-ce981de539d1/jobs/3432) reveals that `sh` does not support double brackets for string comparison. Switch to single bracket.

```
#!/bin/bash -eo pipefail
scripts/create_release_tag.sh
On branch: release
scripts/create_release_tag.sh: 19: [[: not found
Creating v1.0.5 tag
CircleCI received exit code 0
```

