### PR TITLE
fix: push command not interpreting --force flag properly [#FF]

### DIFF
--- a/hokusai/cli/registry.py
+++ b/hokusai/cli/registry.py
@@ -23,13 +23,7 @@ def registry(context_settings=CONTEXT_SETTINGS):
 def push(tag, local_tag, build, filename, force, overwrite, skip_latest, verbose):
   """Build and push an image to the project's registry tagged as the git SHA1 of HEAD"""
   set_verbosity(verbose)
-  force or hokusai.git_status_check()
-  ecr = hokusai.ecr_check()
-  remote_tag = hokusai.remote_tag_check(tag, overwrite, ecr)
-  if build:
-    hokusai.build_and_push(remote_tag, local_tag, filename, ecr, skip_latest)
-  else:
-    hokusai.push(remote_tag, local_tag, ecr, skip_latest)
+  hokusai.push(tag, local_tag, build, filename, force, overwrite, skip_latest)
 
 
 @registry.command(context_settings=CONTEXT_SETTINGS)

--- a/hokusai/cli/registry.py
+++ b/hokusai/cli/registry.py
@@ -23,7 +23,13 @@ def registry(context_settings=CONTEXT_SETTINGS):
 def push(tag, local_tag, build, filename, force, overwrite, skip_latest, verbose):
   """Build and push an image to the project's registry tagged as the git SHA1 of HEAD"""
   set_verbosity(verbose)
-  hokusai.push(tag, local_tag, build, filename, force, overwrite, skip_latest)
+  force or hokusai.git_status_check()
+  ecr = hokusai.ecr_check()
+  remote_tag = hokusai.remote_tag_check(tag, overwrite, ecr)
+  if build:
+    hokusai.build_and_push(remote_tag, local_tag, filename, ecr, skip_latest)
+  else:
+    hokusai.push(remote_tag, local_tag, ecr, skip_latest)
 
 
 @registry.command(context_settings=CONTEXT_SETTINGS)

--- a/hokusai/cli/registry.py
+++ b/hokusai/cli/registry.py
@@ -23,7 +23,7 @@ def registry(context_settings=CONTEXT_SETTINGS):
 def push(tag, local_tag, build, filename, force, overwrite, skip_latest, verbose):
   """Build and push an image to the project's registry tagged as the git SHA1 of HEAD"""
   set_verbosity(verbose)
-  hokusai.push(tag, local_tag, build, filename, force, overwrite, skip_latest)
+  hokusai.push_image(tag, local_tag, build, filename, force, overwrite, skip_latest)
 
 
 @registry.command(context_settings=CONTEXT_SETTINGS)

--- a/hokusai/commands/__init__.py
+++ b/hokusai/commands/__init__.py
@@ -10,7 +10,7 @@ from hokusai.commands.gitcompare import gitcompare
 from hokusai.commands.env import get_env, set_env, unset_env
 from hokusai.commands.images import images
 from hokusai.commands.logs import logs
-from hokusai.commands.push import push
+from hokusai.commands.push import push_image
 from hokusai.commands.pull import pull
 from hokusai.commands.run import run
 from hokusai.commands.setup import setup

--- a/hokusai/commands/__init__.py
+++ b/hokusai/commands/__init__.py
@@ -10,11 +10,7 @@ from hokusai.commands.gitcompare import gitcompare
 from hokusai.commands.env import get_env, set_env, unset_env
 from hokusai.commands.images import images
 from hokusai.commands.logs import logs
-from hokusai.commands.push import build_and_push
-from hokusai.commands.push import ecr_check
-from hokusai.commands.push import git_status_check
 from hokusai.commands.push import push
-from hokusai.commands.push import remote_tag_check
 from hokusai.commands.pull import pull
 from hokusai.commands.run import run
 from hokusai.commands.setup import setup

--- a/hokusai/commands/__init__.py
+++ b/hokusai/commands/__init__.py
@@ -10,7 +10,11 @@ from hokusai.commands.gitcompare import gitcompare
 from hokusai.commands.env import get_env, set_env, unset_env
 from hokusai.commands.images import images
 from hokusai.commands.logs import logs
+from hokusai.commands.push import build_and_push
+from hokusai.commands.push import ecr_check
+from hokusai.commands.push import git_status_check
 from hokusai.commands.push import push
+from hokusai.commands.push import remote_tag_check
 from hokusai.commands.pull import pull
 from hokusai.commands.run import run
 from hokusai.commands.setup import setup

--- a/hokusai/commands/push.py
+++ b/hokusai/commands/push.py
@@ -26,7 +26,7 @@ def git_status_check():
     raise HokusaiError("Aborting. Re-run command with --force flag, if you are confident.")
 
 @command()
-def push(remote_tag, local_tag, build, filename, force, overwrite, skip_latest=False):
+def push_image(remote_tag, local_tag, build, filename, force, overwrite, skip_latest=False):
   force or git_status_check()
   ecr = ecr_check()
   remote_tag = remote_tag_check(remote_tag, overwrite, ecr)

--- a/hokusai/commands/push.py
+++ b/hokusai/commands/push.py
@@ -9,10 +9,10 @@ from hokusai.services.docker import Docker
 
 @command()
 def push(tag, local_tag, build, filename, force, overwrite, skip_latest=False):
-  if force is None and shout('git status --porcelain'):
+  if not force and shout('git status --porcelain'):
     raise HokusaiError("Working directory is not clean.  Aborting.")
 
-  if force is None and shout('git status --porcelain --ignored'):
+  if not force and shout('git status --porcelain --ignored'):
     raise HokusaiError("Working directory contains ignored files and/or directories.  Aborting.")
 
   ecr = ECR()

--- a/hokusai/commands/push.py
+++ b/hokusai/commands/push.py
@@ -1,32 +1,34 @@
-import os
-
 from hokusai.lib.command import command
 from hokusai.lib.config import config
 from hokusai.services.ecr import ECR
-from hokusai.lib.common import print_green, print_red, shout
+from hokusai.lib.common import print_green, print_yellow, shout
 from hokusai.lib.exceptions import HokusaiError
 from hokusai.services.docker import Docker
 
 def build_and_push(remote_tag, local_tag, filename, ecr, skip_latest=False):
+  """Build Docker image and push it to ECR"""
   Docker().build(filename)
   push_only(remote_tag, local_tag, ecr, skip_latest)
 
 def ecr_check():
+  """Check that ECR has a repo for the project"""
   ecr = ECR()
   if not ecr.project_repo_exists():
-    raise HokusaiError("ECR repo %s does not exist... did you run `hokusai setup` for this project?" % config.project_name)
+    raise HokusaiError("ECR repo %s does not exist. Has 'hokusai setup' been run for this project?" % config.project_name)
   return ecr
 
 def git_status_check():
+  """Check working directory's Git status"""
   git_status_files = shout('git status --porcelain --ignored')
   if git_status_files:
-    print_red("The following files/directories are either changed, untracked, or Git ignored.")
-    print_red("If they are not excluded by .dockerignore, they may get copied into the resulting Docker image.")
-    print(git_status_files)
-    raise HokusaiError("Aborting. Re-run command with --force flag, if you are confident.")
+    print_yellow("The following files/directories are either changed, untracked, or Git ignored.")
+    print_yellow("If they are not excluded by .dockerignore, they may get copied into the resulting Docker image.")
+    print_yellow(git_status_files)
+    raise HokusaiError("Working directory unclean. Aborting. Use '--force' to force.")
 
 @command()
 def push_image(remote_tag, local_tag, build, filename, force, overwrite, skip_latest=False):
+  """Push Docker image to ECR"""
   force or git_status_check()
   ecr = ecr_check()
   remote_tag = remote_tag_check(remote_tag, overwrite, ecr)
@@ -36,6 +38,7 @@ def push_image(remote_tag, local_tag, build, filename, force, overwrite, skip_la
     push_only(remote_tag, local_tag, ecr, skip_latest)
 
 def push_only(remote_tag, local_tag, ecr, skip_latest=False):
+  """Push Docker Compose built image to ECR"""
   shout(ecr.get_login(), mask=(r'^(docker login -u) .+ (-p) .+ (.+)$', r'\1 ****** \2 ***** \3'))
   docker_compose_repo = "hokusai_" + config.project_name
   tag_and_push(docker_compose_repo, local_tag, ecr.project_repo, remote_tag)
@@ -43,14 +46,15 @@ def push_only(remote_tag, local_tag, ecr, skip_latest=False):
     tag_and_push(docker_compose_repo, local_tag, ecr.project_repo, 'latest')
 
 def remote_tag_check(remote_tag, overwrite, ecr):
+  """Set the tag to be used in ECR and see whether it already exists there"""
   if remote_tag is None:
     remote_tag = shout('git rev-parse HEAD').strip()
   if not overwrite and ecr.tag_exists(remote_tag):
-    print_red("Tag %s already exists in registry." % remote_tag)
-    raise HokusaiError("Aborting. Re-run command with --overwrite, if it's okay to overwrite tag in registry")
+    raise HokusaiError("Tag %s already exists in registry. Aborting. Use '--overwrite' to overwrite registry's tag." % remote_tag)
   return remote_tag
 
 def tag_and_push(local_repo, local_tag, remote_repo, remote_tag):
+  """Push local Docker repo:tag to remote repo:tag"""
   shout("docker tag %s:%s %s:%s" % (local_repo, local_tag, remote_repo, remote_tag))
   shout("docker push %s:%s" % (remote_repo, remote_tag), print_output=True)
   print_green("Pushed %s:%s to %s:%s" % (local_repo, local_tag, remote_repo, remote_tag), newline_after=True)

--- a/hokusai/commands/push.py
+++ b/hokusai/commands/push.py
@@ -18,18 +18,18 @@ def ecr_check():
   return ecr
 
 def git_status_check():
-  git_unclean_files = shout('git status --porcelain --ignored')
-  if git_unclean_files:
+  git_status_files = shout('git status --porcelain --ignored')
+  if git_status_files:
     print_red("The following files/directories are either changed, untracked, or Git ignored.")
     print_red("If they are not excluded by .dockerignore, they may get copied into the resulting Docker image.")
-    print(git_unclean_files)
+    print(git_status_files)
     raise HokusaiError("Aborting. Re-run command with --force flag, if you are confident.")
 
 @command()
-def push(tag, local_tag, build, filename, force, overwrite, skip_latest=False):
+def push(remote_tag, local_tag, build, filename, force, overwrite, skip_latest=False):
   force or git_status_check()
   ecr = ecr_check()
-  remote_tag = remote_tag_check(tag, overwrite, ecr)
+  remote_tag = remote_tag_check(remote_tag, overwrite, ecr)
   if build:
     build_and_push(remote_tag, local_tag, filename, ecr, skip_latest)
   else:

--- a/hokusai/commands/push.py
+++ b/hokusai/commands/push.py
@@ -9,37 +9,41 @@ from hokusai.lib.exceptions import HokusaiError
 from hokusai.services.docker import Docker
 
 @command()
-def push(tag, local_tag, build, filename, force, overwrite, skip_latest=False):
-  if not force:
-    git_unclean_files = shout('git status --porcelain --ignored')
-    if git_unclean_files:
-      print_red("The following files/directories are either changed, untracked, or ignored.")
-      print_red("If they are not excluded by .dockerignore, they may get copied into the resulting Docker image.")
-      print(git_unclean_files)
-      raise HokusaiError("Aborting. Re-run command with --force flag, if you are not concerned.")
+def build_and_push(remote_tag, local_tag, filename, ecr, skip_latest=False):
+  Docker().build(filename)
+  push(remote_tag, local_tag, ecr, skip_latest)
 
+def ecr_check():
   ecr = ECR()
   if not ecr.project_repo_exists():
     raise HokusaiError("ECR repo %s does not exist... did you run `hokusai setup` for this project?" % config.project_name)
+  return ecr
 
+@command()
+def git_status_check():
+  git_unclean_files = shout('git status --porcelain --ignored')
+  if git_unclean_files:
+    print_red("The following files/directories are either changed, untracked, or ignored.")
+    print_red("If they are not excluded by .dockerignore, they may get copied into the resulting Docker image.")
+    print(git_unclean_files)
+    raise HokusaiError("Aborting. Re-run command with --force flag, if you are confident.")
+
+@command()
+def push(remote_tag, local_tag, ecr, skip_latest=False):
   shout(ecr.get_login(), mask=(r'^(docker login -u) .+ (-p) .+ (.+)$', r'\1 ****** \2 ***** \3'))
-  if tag is None:
-    tag = shout('git rev-parse HEAD').strip()
+  docker_compose_repo = "hokusai_" + config.project_name
+  tag_and_push(docker_compose_repo, local_tag, ecr.project_repo, remote_tag)
+  if not skip_latest:
+    tag_and_push(docker_compose_repo, local_tag, ecr.project_repo, 'latest')
 
-  if overwrite is None and ecr.tag_exists(tag):
-    raise HokusaiError("Tag %s already exists in registry.  Aborting." % tag)
+def remote_tag_check(remote_tag, overwrite, ecr):
+  if remote_tag is None:
+    remote_tag = shout('git rev-parse HEAD').strip()
+  if not overwrite and ecr.tag_exists(remote_tag):
+    raise HokusaiError("Tag %s already exists in registry.  Aborting." % remote_tag)
+  return remote_tag
 
-  if build:
-    Docker().build()
-
-  build_tag = "hokusai_%s:%s" % (config.project_name, local_tag)
-
-  shout("docker tag %s %s:%s" % (build_tag, ecr.project_repo, tag))
-  shout("docker push %s:%s" % (ecr.project_repo, tag), print_output=True)
-  print_green("Pushed %s to %s:%s" % (build_tag, ecr.project_repo, tag), newline_after=True)
-
-  if skip_latest: return
-
-  shout("docker tag %s %s:%s" % (build_tag, ecr.project_repo, 'latest'))
-  shout("docker push %s:%s" % (ecr.project_repo, 'latest'), print_output=True)
-  print_green("Pushed %s to %s:%s" % (build_tag, ecr.project_repo, 'latest'), newline_after=True)
+def tag_and_push(local_repo, local_tag, remote_repo, remote_tag):
+  shout("docker tag %s:%s %s:%s" % (local_repo, local_tag, remote_repo, remote_tag))
+  shout("docker push %s:%s" % (remote_repo, remote_tag), print_output=True)
+  print_green("Pushed %s:%s to %s:%s" % (local_repo, local_tag, remote_repo, remote_tag), newline_after=True)

--- a/hokusai/commands/push.py
+++ b/hokusai/commands/push.py
@@ -23,7 +23,7 @@ def ecr_check():
 def git_status_check():
   git_unclean_files = shout('git status --porcelain --ignored')
   if git_unclean_files:
-    print_red("The following files/directories are either changed, untracked, or ignored.")
+    print_red("The following files/directories are either changed, untracked, or Git ignored.")
     print_red("If they are not excluded by .dockerignore, they may get copied into the resulting Docker image.")
     print(git_unclean_files)
     raise HokusaiError("Aborting. Re-run command with --force flag, if you are confident.")
@@ -40,7 +40,8 @@ def remote_tag_check(remote_tag, overwrite, ecr):
   if remote_tag is None:
     remote_tag = shout('git rev-parse HEAD').strip()
   if not overwrite and ecr.tag_exists(remote_tag):
-    raise HokusaiError("Tag %s already exists in registry.  Aborting." % remote_tag)
+    print_red("Tag %s already exists in registry." % remote_tag)
+    raise HokusaiError("Aborting. Re-run command with --overwrite, if it's okay to overwrite tag in registry")
   return remote_tag
 
 def tag_and_push(local_repo, local_tag, remote_repo, remote_tag):

--- a/test/unit/test_commands/test_push.py
+++ b/test/unit/test_commands/test_push.py
@@ -1,0 +1,75 @@
+import pytest
+
+import hokusai.commands.push
+from hokusai.commands.push import push_image
+
+def setup_spies(mocker):
+  mocker.patch('hokusai.commands.push.build_and_push')
+  mocker.patch('hokusai.commands.push.ecr_check', return_value='')
+  mocker.patch('hokusai.commands.push.git_status_check')
+  mocker.patch('hokusai.commands.push.push_only')
+  mocker.patch('hokusai.commands.push.remote_tag_check', return_value='')
+  build_and_push_spy = mocker.spy(hokusai.commands.push, 'build_and_push')
+  ecr_check_spy = mocker.spy(hokusai.commands.push, 'ecr_check')
+  git_status_check_spy = mocker.spy(hokusai.commands.push, 'git_status_check')
+  push_only_spy = mocker.spy(hokusai.commands.push, 'push_only')
+  remote_tag_check_spy = mocker.spy(hokusai.commands.push, 'remote_tag_check')
+  return build_and_push_spy, ecr_check_spy, git_status_check_spy, push_only_spy, remote_tag_check_spy
+
+def describe_push_image():
+  def it_builds_when_build_is_true(mocker):
+    build_and_push_spy, ecr_check_spy, git_status_check_spy, push_only_spy, remote_tag_check_spy = setup_spies(mocker)
+    args = {
+      'remote_tag': 'remotefoo',
+      'local_tag': 'localfoo',
+      'build': True,
+      'filename': 'foofile',
+      'force': False,
+      'overwrite': False,
+      'skip_latest': False,
+    }
+    with pytest.raises(SystemExit):
+      push_image(**args)
+    assert build_and_push_spy.call_count == 1
+    assert ecr_check_spy.call_count == 1
+    assert git_status_check_spy.call_count == 1
+    assert push_only_spy.call_count == 0
+    assert remote_tag_check_spy.call_count == 1
+
+  def it_skips_build_when_build_is_false(mocker):
+    build_and_push_spy, ecr_check_spy, git_status_check_spy, push_only_spy, remote_tag_check_spy = setup_spies(mocker)
+    args = {
+      'remote_tag': 'remotefoo',
+      'local_tag': 'localfoo',
+      'build': False,
+      'filename': 'foofile',
+      'force': False,
+      'overwrite': False,
+      'skip_latest': False,
+    }
+    with pytest.raises(SystemExit):
+      push_image(**args)
+    assert build_and_push_spy.call_count == 0
+    assert ecr_check_spy.call_count == 1
+    assert git_status_check_spy.call_count == 1
+    assert push_only_spy.call_count == 1
+    assert remote_tag_check_spy.call_count == 1
+
+  def it_skips_git_status_check_when_force_is_true(mocker):
+    build_and_push_spy, ecr_check_spy, git_status_check_spy, push_only_spy, remote_tag_check_spy = setup_spies(mocker)
+    args = {
+      'remote_tag': 'remotefoo',
+      'local_tag': 'localfoo',
+      'build': False,
+      'filename': 'foofile',
+      'force': True,
+      'overwrite': False,
+      'skip_latest': False,
+    }
+    with pytest.raises(SystemExit):
+      push_image(**args)
+    assert build_and_push_spy.call_count == 0
+    assert ecr_check_spy.call_count == 1
+    assert git_status_check_spy.call_count == 0
+    assert push_only_spy.call_count == 1
+    assert remote_tag_check_spy.call_count == 1

--- a/test/unit/test_commands/test_push.py
+++ b/test/unit/test_commands/test_push.py
@@ -1,7 +1,8 @@
 import pytest
 
 import hokusai.commands.push
-from hokusai.commands.push import push_image
+from hokusai.commands.push import build_and_push, ecr_check, git_status_check, push_image, push_only, remote_tag_check, tag_and_push
+from hokusai.lib.exceptions import HokusaiError
 
 def setup_spies(mocker):
   mocker.patch('hokusai.commands.push.build_and_push')
@@ -15,6 +16,54 @@ def setup_spies(mocker):
   push_only_spy = mocker.spy(hokusai.commands.push, 'push_only')
   remote_tag_check_spy = mocker.spy(hokusai.commands.push, 'remote_tag_check')
   return build_and_push_spy, ecr_check_spy, git_status_check_spy, push_only_spy, remote_tag_check_spy
+
+def describe_build_and_push():
+  def it_builds_and_pushes(mocker):
+    mocker.patch('hokusai.commands.push.Docker.build')
+    mocker.patch('hokusai.commands.push.push_only')
+    docker_build_spy = mocker.spy(hokusai.commands.push.Docker, 'build')
+    push_only_spy = mocker.spy(hokusai.commands.push, 'push_only')
+    args = {
+      'remote_tag': 'remotefoo',
+      'local_tag': 'localfoo',
+      'filename': 'foofile',
+      'ecr': None,
+      'skip_latest': False
+    }
+    build_and_push(**args)
+    assert docker_build_spy.call_count == 1
+    assert push_only_spy.call_count == 1
+
+def describe_ecr_check():
+  def it_raises_when_repo_does_not_exist(mocker):
+    class mock_ECR:
+      def __init__(self):
+        pass
+      def project_repo_exists(self):
+        return False
+    mocker.patch('hokusai.commands.push.ECR').side_effect = mock_ECR
+    with pytest.raises(HokusaiError):
+      ecr_check()
+
+  def it_returns_ecr_object_when_repo_exists(mocker):
+    class mock_ECR:
+      def __init__(self):
+        pass
+      def project_repo_exists(self):
+        return True
+    mocker.patch('hokusai.commands.push.ECR').side_effect = mock_ECR
+    obj = ecr_check()
+    assert isinstance(obj, mock_ECR)
+
+def describe_git_status_check():
+  def it_raises_if_working_dir_unclean(mocker):
+    mocker.patch('hokusai.commands.push.shout', return_value='foo')
+    with pytest.raises(HokusaiError):
+      git_status_check()
+
+  def it_does_not_raise_if_working_dir_is_clean(mocker):
+    mocker.patch('hokusai.commands.push.shout', return_value=None)
+    git_status_check()
 
 def describe_push_image():
   def it_builds_when_build_is_true(mocker):
@@ -73,3 +122,95 @@ def describe_push_image():
     assert git_status_check_spy.call_count == 0
     assert push_only_spy.call_count == 1
     assert remote_tag_check_spy.call_count == 1
+
+def describe_push_only():
+  class mock_ECR:
+    def __init__(self):
+      pass
+    def get_login(self):
+      pass
+    def project_repo(self):
+      pass
+
+  def it_pushes_tag_and_latest(mocker):
+    args = {
+      'remote_tag': 'remotefoo',
+      'local_tag': 'localfoo',
+      'ecr': mock_ECR(),
+      'skip_latest': False,
+    }
+    mocker.patch('hokusai.commands.push.shout')
+    mocker.patch('hokusai.commands.push.tag_and_push')
+    tag_and_push_spy = mocker.spy(hokusai.commands.push, 'tag_and_push')
+    push_only(**args)
+    assert tag_and_push_spy.call_count == 2
+
+  def it_skips_latest_when_skip_latest_is_true(mocker):
+    mock_ecr = mock_ECR()
+    args = {
+      'remote_tag': 'remotefoo',
+      'local_tag': 'localfoo',
+      'ecr': mock_ecr,
+      'skip_latest': True,
+    }
+    mocker.patch('hokusai.commands.push.shout')
+    mocker.patch('hokusai.commands.push.tag_and_push')
+    tag_and_push_spy = mocker.spy(hokusai.commands.push, 'tag_and_push')
+    push_only(**args)
+    assert tag_and_push_spy.call_count == 1
+    tag_and_push_spy.assert_has_calls([
+      mocker.call(
+        'hokusai_hello',
+        'localfoo',
+        mock_ecr.project_repo,
+        'remotefoo'
+      )
+    ])
+
+def describe_remote_tag_check():
+  def describe_tag_does_not_exist_in_ecr():
+    class mock_ECR:
+      def __init__(self):
+        pass
+      def tag_exists(self, tag):
+        return False
+
+    def it_returns_same_tag_that_was_passed_in(mocker):
+      mock_ecr = mock_ECR()
+      mocker.patch('hokusai.commands.push.shout')
+      tag = remote_tag_check(remote_tag='foo', overwrite=False, ecr=mock_ecr)
+      assert tag == 'foo'
+
+    def it_returns_git_head_sha_as_tag_when_none_was_passed_in(mocker):
+      mock_ecr = mock_ECR()
+      mocker.patch('hokusai.commands.push.shout', return_value='foo')
+      tag = remote_tag_check(remote_tag=None, overwrite=False, ecr=mock_ecr)
+      assert tag == 'foo'
+
+  def describe_tag_exists_in_ecr():
+    class mock_ECR:
+      def __init__(self):
+        pass
+      def tag_exists(self, tag):
+        return True
+
+    def it_raises_if_tag_exists_in_ecr(mocker):
+      mock_ecr = mock_ECR()
+      mocker.patch('hokusai.commands.push.shout')
+      with pytest.raises(HokusaiError):
+        remote_tag_check(remote_tag='foo', overwrite=False, ecr=mock_ecr)
+
+    def it_does_not_raise_if_tag_exists_in_ecr_and_overwrite_is_true(mocker):
+      mock_ecr = mock_ECR()
+      mocker.patch('hokusai.commands.push.shout')
+      remote_tag_check(remote_tag='foo', overwrite=True, ecr=mock_ecr)
+
+def describe_tag_and_push():
+  def it_tags_and_pushes(mocker):
+    mocker.patch('hokusai.commands.push.shout')
+    shout_spy = mocker.spy(hokusai.commands.push, 'shout')
+    tag_and_push('localfoorepo', 'localfootag', 'removefoorepo', 'remotefootag')
+    shout_spy.assert_has_calls([
+      mocker.call('docker tag localfoorepo:localfootag removefoorepo:remotefootag'),
+      mocker.call('docker push removefoorepo:remotefootag', print_output=True)
+    ])


### PR DESCRIPTION
`hokusai registry push` has a [`--force` option](https://github.com/artsy/hokusai/blob/d5f2cd3f5125c90041c5ea3a897d8e9245994200/hokusai/cli/registry.py#L19) for skipping Git status check. The option's `is_flag` is `True`, meaning if `--force` is not specified, it defaults to `False`. If `--force` is specified, it's value is `True`. So [`push`'s `force` param](https://github.com/artsy/hokusai/blob/d5f2cd3f5125c90041c5ea3a897d8e9245994200/hokusai/cli/registry.py#L23) always has value: `True` or `False`, never `None`.

The param is passed down to [`push` command](https://github.com/artsy/hokusai/blob/d5f2cd3f5125c90041c5ea3a897d8e9245994200/hokusai/commands/push.py#L11) which interprets it incorrectly - it tests `force` for `None`. This makes Git status checks always skipped.

There is a [similar error](https://github.com/artsy/hokusai/blob/d5f2cd3f5125c90041c5ea3a897d8e9245994200/hokusai/commands/push.py#L26) with the [`--overwrite` option](https://github.com/artsy/hokusai/blob/d5f2cd3f5125c90041c5ea3a897d8e9245994200/hokusai/cli/registry.py#L20).

This PR is to fix those errors, so that going forward, `--force` will be required to skip Git status check, and `--overwrite` will be required to overwrite tag in ECR.

Secondly, the Git status checks are a bit misleading. [`git status --porcelain --ignored`](https://github.com/artsy/hokusai/blob/d5f2cd3f5125c90041c5ea3a897d8e9245994200/hokusai/commands/push.py#L15) doesn't just list Git ignored files, it also lists untracked or modified files (as does `git status --porcelain`). If there are only untracked/modified files (no Git ignored files), `git status --porcelain --ignored` will say that there are Git ignored files, which is not true. this PR proposes to run `git status --procelain --ignored` only, and just show user the file list. And in the output, be more explicit about the [motivation](https://github.com/artsy/hokusai/blob/main/docs/Getting_Started.md) (item # 5) behind this check, which is to avoid copying unused/sensitive files into the Docker image, which I think should help user decide whether it's safe to force.

Users who have been using `hokusai registry push` locally likely have not used `--force` and `--overwrite`, so they will start encountering the output. I imagine they will switch to running the command with those flags all the time, but at least they will have been informed of the danger of doing so. I think they primarily use the command for creating Review Apps. [Force's review app script](https://github.com/artsy/force/blob/e3bee1f06162ffea072d6e8a215d6934331405b1/scripts/build_review_app.sh#L38) does use `--force` and `--overwrite`, so no change required there.

Lastly, I found the `push` command (one function with 7 `if`s) a bit hard to follow, so I refactored it and added tests to ensure it still behaves correctly.
