### PR TITLE
feat: force x86_64 (amd64) when building docker image

### DIFF
--- a/hokusai/services/docker.py
+++ b/hokusai/services/docker.py
@@ -17,7 +17,7 @@ class Docker:
 
     # docker-compose v2 switched to using '-' as separator in image name, resulting in 'hokusai-<project>'
     # COMPOSE_COMPATIBILITY=true forces v2 to use '_', resulting in 'hokusai_<project>', matching v1
-    build_command = "COMPOSE_COMPATIBILITY=true docker-compose -f %s -p hokusai build" % docker_compose_yml
+    build_command = "DOCKER_DEFAULT_PLATFORM=linux/amd64 COMPOSE_COMPATIBILITY=true docker-compose -f %s -p hokusai build" % docker_compose_yml
 
     if config.pre_build:
       build_command = "%s && %s" % (config.pre_build, build_command)


### PR DESCRIPTION
Solves https://github.com/artsy/hokusai/issues/339

Currently Hokusai/docker-compose/docker builds image compatible with the build machine's CPU architecture. On M1 Mac, this would be `linux/arm64`, therefore the image does not work on Kubernetes servers that are x86_64, breaking Hokusai's assumption that build machine has same CPU architecture as Kubernetes servers.

Let Hokusai build only x86_64 (amd64) Docker images.