### PR TITLE
Fix for Dockerfile smell DL3007

### DIFF
--- a/hokusai/templates/Dockerfile.j2
+++ b/hokusai/templates/Dockerfile.j2
@@ -1,4 +1,4 @@
-FROM nginx:latest
+FROM nginx:1.23.4-bullseye
 
 ADD https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_amd64 /usr/local/bin/dumb-init
 RUN chmod +x /usr/local/bin/dumb-init


### PR DESCRIPTION
Hi!
The Dockerfile placed at "hokusai/templates/Dockerfile.j2" contains the best practice violation [DL3007](https://github.com/hadolint/hadolint/wiki/DL3007) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3007 occurs when the tag "latest" is used instead of a specific version tag for the base image.
In this pull request, we propose a fix for that smell generated by our fixing tool. We have verified that the patch is correct before opening the pull request.
To fix this smell, specifically, we use a heuristic approach that selects the most probable version tag for the base image in order to replace the "latest" tag. In detail, it selects the most recent image tag which corresponds to the same image digest that currently corresponds to the "latest" tag.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance