### PR TITLE
feat: bump Docker Compose version to v2.17.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apk add --no-cache \
       openssl-dev
 
 # Install Docker Compose, AWS CLI
-RUN pip --no-cache-dir install docker-compose==1.25.5 && \
+RUN pip --no-cache-dir install docker-compose==2.17.2 && \
       pip --no-cache-dir install awscli --upgrade
 
 # Install the AWS IAM Authenticator

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.9.10-alpine
 
+ARG COMPOSE_VERSION=2.17.2
+ARG AUTHENTICATOR_VERSION=0.4.0
+
 WORKDIR /src
 
 # Install Docker
@@ -14,13 +17,16 @@ RUN apk add --no-cache \
       openssh \
       openssl-dev
 
-# Install Docker Compose, AWS CLI
-RUN pip --no-cache-dir install docker-compose==2.17.2 && \
-      pip --no-cache-dir install awscli --upgrade
+# Install Docker Compose
+RUN curl -SL https://github.com/docker/compose/releases/download/v${COMPOSE_VERSION}/docker-compose-linux-x86_64 -o /usr/local/bin/docker-compose && \
+  chmod a+x /usr/local/bin/docker-compose
 
 # Install the AWS IAM Authenticator
-RUN curl -L https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.4.0/aws-iam-authenticator_0.4.0_linux_amd64 -o /usr/local/bin/aws-iam-authenticator && \
+RUN curl -SL https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v${AUTHENTICATOR_VERSION}/aws-iam-authenticator_${AUTHENTICATOR_VERSION}_linux_amd64 -o /usr/local/bin/aws-iam-authenticator && \
       chmod a+x /usr/local/bin/aws-iam-authenticator
+
+# Install AWS CLI
+RUN pip --no-cache-dir install awscli --upgrade
 
 COPY . /src
 


### PR DESCRIPTION
[PLATFORM-5143]

In order to support Docker multi-stage build, specifically the [`target` field in a `docker-compose.yml`](https://docs.docker.com/compose/compose-file/compose-file-v3/#target). That doc seems to say Compose spec must be versioned 3.4 or up for the field to work. In my testing, spec with version 2 also works, as long as `docker-compose` CLI understands the field.

The current version [does not understand the field](https://app.circleci.com/pipelines/github/artsy/exchange/7430/workflows/c657cf83-a96c-4792-945e-a43ae6f9b247/jobs/12202).


[PLATFORM-5143]: https://artsyproduct.atlassian.net/browse/PLATFORM-5143?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ