### PR TITLE
fix: docker-compose build's tty output format overwhelms CI UI output

### DIFF
--- a/hokusai/services/docker.py
+++ b/hokusai/services/docker.py
@@ -17,7 +17,11 @@ class Docker:
 
     # docker-compose v2 switched to using '-' as separator in image name, resulting in 'hokusai-<project>'
     # COMPOSE_COMPATIBILITY=true forces v2 to use '_', resulting in 'hokusai_<project>', matching v1
-    build_command = "DOCKER_DEFAULT_PLATFORM=linux/amd64 COMPOSE_COMPATIBILITY=true docker-compose -f %s -p hokusai build" % docker_compose_yml
+    env_vars = "DOCKER_DEFAULT_PLATFORM=linux/amd64 COMPOSE_COMPATIBILITY=true"
+
+    compose_command = f"docker-compose -f {docker_compose_yml} -p hokusai build"
+    compose_options = "--progress plain"
+    build_command = f"{env_vars} {compose_command} {compose_options}"
 
     if config.pre_build:
       build_command = "%s && %s" % (config.pre_build, build_command)


### PR DESCRIPTION
Turns out the [newer Docker Compose version](https://github.com/artsy/hokusai/pull/353) builds using [BuildKit](https://docs.docker.com/build/buildkit/) (by default). That can be disabled via Env var `DOCKER_BUILDKIT=0`. However, since BuildKit promises better performance, let's try leaving it on.

Though there's a small problem with BuildKit, where its build progress output is TTY (interactive) by default, which continuously (every fraction of a second) refreshes the screen, [overwhelming CI job's UI output](https://app.circleci.com/pipelines/github/artsy/exchange/7437/workflows/d7c0b694-37a4-433b-9f23-f5366af1fffa/jobs/12220). I don't see a benefit of this output format. Let's pass `docker-compose` the `--progress plain` option to bring back the old output format. This option differs a bit between V1 and V2 of Compose, but looks like `plain` should work across:
```
$ docker-compose-v1.27.4 build --help | grep -- progress
    --progress string       Set type of progress output (auto, plain, tty).
$ docker-compose-v2.17.2 build --help | grep -- progress
      --progress string         Set type of progress output (auto, tty, plain, quiet) (default "auto")
```
Here's how the two output format differs:
```
$ docker-compose version
Docker Compose version v2.17.2

$ docker-compose build
[+] Building 0.8s (5/5) FINISHED
 => [internal] load build definition from Dockerfile                                                                                          0.2s
 => => transferring dockerfile: 31B                                                                                                           0.0s
 => [internal] load .dockerignore                                                                                                             0.4s
 => => transferring context: 2B                                                                                                               0.0s
 => [internal] load metadata for docker.io/library/debian:latest                                                                              0.3s
 => CACHED [1/1] FROM docker.io/library/debian@sha256:0a78ed641b76252739e28ebbbe8cdbd80dc367fba4502565ca839e5803cfd86e                        0.0s
 => exporting to image                                                                                                                        0.0s
 => => exporting layers                                                                                                                       0.0s
 => => writing image sha256:14a83ce66c4c9f3c11864e82963b1b2a5a01d233f17af726b2010fe60efc409e                                                  0.0s
 => => naming to docker.io/library/foobar:latest                                                                                              0.0s

$ docker-compose build --progress plain
#1 [internal] load .dockerignore
#1 transferring context: 2B 0.0s done
#1 DONE 0.3s

#2 [internal] load build definition from Dockerfile
#2 transferring dockerfile: 31B 0.1s done
#2 DONE 0.4s

#3 [internal] load metadata for docker.io/library/debian:latest
#3 DONE 0.3s

#4 [1/1] FROM docker.io/library/debian@sha256:0a78ed641b76252739e28ebbbe8cdbd80dc367fba4502565ca839e5803cfd86e
#4 CACHED

#5 exporting to image
#5 exporting layers done
#5 writing image sha256:14a83ce66c4c9f3c11864e82963b1b2a5a01d233f17af726b2010fe60efc409e 0.0s done
#5 naming to docker.io/library/foobar:latest done
#5 DONE 0.0s
```
