### PR TITLE
feat: CommandRunner to load project's k8s secret if it exists

### DIFF
--- a/hokusai/lib/common.py
+++ b/hokusai/lib/common.py
@@ -154,9 +154,9 @@ def user():
     )
   return user
 
-def validate_env_var(var):
-  ''' raise if env var is NOT of the form KEY=VALUE '''
-  if '=' not in var:
+def validate_key_value(key_value):
+  ''' raise if key_value is NOT of the form KEY=VALUE '''
+  if '=' not in key_value:
     raise HokusaiError(
-      "Error: environment variables must be of the form 'KEY=VALUE'"
+      "Error: key/value pair must be of the form 'KEY=VALUE'"
     )

--- a/hokusai/lib/common.py
+++ b/hokusai/lib/common.py
@@ -143,6 +143,17 @@ def pick_yes():
 def pick_no():
   return random.choice(["Nope", "No", "нет", "Ne", "नहीं", "Daabi", "Nein", "Nay", "Nē", "ні", "خیر", "Nie", "Non", "ניט", "не", "아니", "いや", "没有", "Não"])
 
+def user():
+  ''' obtain user name from environment '''
+  user = None
+  if os.environ.get('USER') is not None:
+    # The regex used for the validation of name is
+    # '[a-z0-9]([-a-z0-9]*[a-z0-9])?'
+    user = re.sub(
+      "[^0-9a-z]+", "-", os.environ.get('USER').lower()
+    )
+  return user
+
 def validate_env_var(var):
   ''' raise if env var is NOT of the form KEY=VALUE '''
   if '=' not in var:

--- a/hokusai/lib/common.py
+++ b/hokusai/lib/common.py
@@ -17,7 +17,7 @@ from botocore import session as botosession
 from termcolor import cprint
 
 from hokusai.lib.config import config
-from hokusai.lib.exceptions import CalledProcessError
+from hokusai.lib.exceptions import CalledProcessError, HokusaiError
 
 CONTEXT_SETTINGS = {
   'terminal_width': 10000,
@@ -142,3 +142,10 @@ def pick_yes():
 
 def pick_no():
   return random.choice(["Nope", "No", "нет", "Ne", "नहीं", "Daabi", "Nein", "Nay", "Nē", "ні", "خیر", "Nie", "Non", "ניט", "не", "아니", "いや", "没有", "Não"])
+
+def validate_env_var(var):
+  ''' raise if env var is NOT of the form KEY=VALUE '''
+  if '=' not in var:
+    raise HokusaiError(
+      "Error: environment variables must be of the form 'KEY=VALUE'"
+    )

--- a/hokusai/services/command_runner.py
+++ b/hokusai/services/command_runner.py
@@ -52,7 +52,8 @@ class CommandRunner:
 
   def _append_envfrom(self, container_spec):
     ''' append envFrrom to given container spec '''
-    container_spec = container_spec.update(
+    spec = copy.deepcopy(container_spec)
+    spec.update(
       {
         'envFrom': [
           {
@@ -69,6 +70,7 @@ class CommandRunner:
         ]
       }
     )
+    return spec
 
   def _append_constraints(self, containers_spec, constraint):
     ''' append constraints to given containers spec '''

--- a/hokusai/services/command_runner.py
+++ b/hokusai/services/command_runner.py
@@ -99,7 +99,7 @@ class CommandRunner:
     spec = self._set_envfrom(spec)
     return spec
 
-  def _overrrides_containers(self, cmd, env, tag_or_digest):
+  def _overrides_containers(self, cmd, env, tag_or_digest):
     ''' generate overrides['spec']['containers'] spec '''
     container_spec = self._overrides_container(
       cmd, env, tag_or_digest
@@ -110,7 +110,7 @@ class CommandRunner:
   def _overrides_spec(self, cmd, constraint, env, tag_or_digest):
     ''' generate overrides['spec'] spec '''
     spec = {}
-    containers_spec = self._overrrides_containers(
+    containers_spec = self._overrides_containers(
       cmd, env, tag_or_digest
     )
     spec.update({'containers': containers_spec})

--- a/hokusai/services/command_runner.py
+++ b/hokusai/services/command_runner.py
@@ -4,7 +4,7 @@ import json
 import pipes
 
 from hokusai.lib.config import config
-from hokusai.lib.common import shout, returncode, k8s_uuid
+from hokusai.lib.common import shout, returncode, k8s_uuid, validate_env_var
 from hokusai.services.ecr import ECR
 from hokusai.services.kubectl import Kubectl
 from hokusai.lib.exceptions import HokusaiError
@@ -37,19 +37,12 @@ class CommandRunner:
     image_name = f"{self.ecr.project_repo}{separator}{tag_or_digest}"
     return image_name
 
-  def _validate_env(self, kv):
-    ''' ensure kv is in KEY=VALUE form '''
-    if '=' not in s:
-      raise HokusaiError(
-        "Error: environment variables must be of the form 'KEY=VALUE'"
-      )
-
   def _append_env(self, container_spec, env):
     ''' append env to given container spec '''
     container_spec['env'] = []
-    for kv in env:
-      self._validate_env(kv)
-      split = kv.split('=', 1)
+    for var in env:
+      validate_env_var(var)
+      split = var.split('=', 1)
       container_spec['env'].append(
         {'name': split[0], 'value': split[1]}
       )

--- a/hokusai/services/command_runner.py
+++ b/hokusai/services/command_runner.py
@@ -72,19 +72,20 @@ class CommandRunner:
     )
     return spec
 
-  def _append_constraints(self, containers_spec, constraint):
-    ''' append constraints to given containers spec '''
-    constraints = constraint or config.run_constraints
+  def _append_constraints(self, containers_spec, constraints):
+    ''' append node constraints to given containers spec '''
+    spec = copy.deepcopy(containers_spec)
+    constraints = constraints or config.run_constraints
     if constraints:
-      containers_spec['nodeSelector'] = {}
+      spec['nodeSelector'] = {}
       for label in constraints:
         if '=' not in label:
           raise HokusaiError(
             "Error: Node selectors must of the form 'key=value'"
           )
         split = label.split('=', 1)
-        containters_spec['nodeSelector'][split[0]] = split[1]
-    return containers_spec
+        spec['nodeSelector'][split[0]] = split[1]
+    return spec
 
   def _overrides_container(self, cmd, env, tag_or_digest):
     ''' generate overrides['spec']['containers'][0] spec '''
@@ -107,14 +108,14 @@ class CommandRunner:
     containers_spec = { "containers": [container_spec] }
     return containers_spec
 
-  def _overrides_spec(self, cmd, constraint, env, tag_or_digest):
+  def _overrides_spec(self, cmd, constraints, env, tag_or_digest):
     ''' generate overrides['spec'] spec '''
     spec = {}
     containers_spec = self._overrrides_containers(
       cmd, env, tag_or_digest
     )
     spec.update(containers_spec)
-    spec = self._append_constraints(spec, constraint)
+    spec = self._append_constraints(spec, constraints)
     return spec
 
   def _overrides(self, cmd, constraint, env, tag_or_digest):

--- a/hokusai/services/command_runner.py
+++ b/hokusai/services/command_runner.py
@@ -1,5 +1,4 @@
 import copy
-import os
 import re
 import json
 import pipes

--- a/hokusai/services/command_runner.py
+++ b/hokusai/services/command_runner.py
@@ -39,8 +39,8 @@ class CommandRunner:
     image_name = f'{self.ecr.project_repo}{separator}{tag_or_digest}'
     return image_name
 
-  def _append_env(self, container_spec, env):
-    ''' append env to given container spec '''
+  def _set_env(self, container_spec, env):
+    ''' set env field of given container spec '''
     spec = copy.deepcopy(container_spec)
     spec['env'] = []
     for var in env:
@@ -51,8 +51,8 @@ class CommandRunner:
       )
     return spec
 
-  def _append_envfrom(self, container_spec):
-    ''' append envFrom to given container spec '''
+  def _set_envfrom(self, container_spec):
+    ''' set envFrom field of given container spec '''
     spec = copy.deepcopy(container_spec)
     spec.update(
       {
@@ -96,8 +96,8 @@ class CommandRunner:
       'image': self._image_name(tag_or_digest),
       'imagePullPolicy': 'Always',
     }
-    spec = self._append_env(spec, env)
-    spec = self._append_envfrom(spec)
+    spec = self._set_env(spec, env)
+    spec = self._set_envfrom(spec)
     return spec
 
   def _overrrides_containers(self, cmd, env, tag_or_digest):

--- a/hokusai/services/command_runner.py
+++ b/hokusai/services/command_runner.py
@@ -52,7 +52,7 @@ class CommandRunner:
     return spec
 
   def _append_envfrom(self, container_spec):
-    ''' append envFrrom to given container spec '''
+    ''' append envFrom to given container spec '''
     spec = copy.deepcopy(container_spec)
     spec.update(
       {

--- a/hokusai/services/command_runner.py
+++ b/hokusai/services/command_runner.py
@@ -1,3 +1,4 @@
+import copy
 import os
 import re
 import json
@@ -39,13 +40,15 @@ class CommandRunner:
 
   def _append_env(self, container_spec, env):
     ''' append env to given container spec '''
-    container_spec['env'] = []
+    spec = copy.deepcopy(container_spec)
+    spec['env'] = []
     for var in env:
       validate_env_var(var)
       split = var.split('=', 1)
-      container_spec['env'].append(
+      spec['env'].append(
         {'name': split[0], 'value': split[1]}
       )
+    return spec
 
   def _append_envfrom(self, container_spec):
     ''' append envFrrom to given container spec '''
@@ -83,15 +86,15 @@ class CommandRunner:
 
   def _overrides_container(self, cmd, env, tag_or_digest):
     ''' generate overrides['spec']['containers'][0] spec '''
-    container_spec = {
+    spec = {
       "args": cmd.split(' '),
       "name": self.container_name,
       "image": self._image_name(tag_or_digest),
       "imagePullPolicy": "Always",
     }
-    container = self._append_env(container_spec, env)
-    container = self._append_envfrom(container_spec)
-    return container_spec
+    spec = self._append_env(spec, env)
+    spec = self._append_envfrom(spec)
+    return spec
 
   def _overrrides_containers(self, cmd, env, tag_or_digest):
     ''' generate overrides['spec']['containers'] spec '''

--- a/hokusai/services/command_runner.py
+++ b/hokusai/services/command_runner.py
@@ -15,18 +15,16 @@ class CommandRunner:
     self.kctl = Kubectl(self.context, namespace=namespace)
     self.ecr = ECR()
 
-  def run(self, tag_or_digest, cmd, tty=None, env=(), constraint=()):
-    if os.environ.get('USER') is not None:
-      # The regex used for the validation of name is '[a-z0-9]([-a-z0-9]*[a-z0-9])?'
-      user = re.sub("[^0-9a-z]+", "-", os.environ.get('USER').lower())
-      uuid = "%s-%s" % (user, k8s_uuid())
-    else:
-      uuid = k8s_uuid()
+  def check_env(env):
+    container['env'] = []
+    for s in env:
+      if '=' not in s:
+        raise HokusaiError("Error: environment variables must be of the form 'KEY=VALUE'")
+      split = s.split('=', 1)
+      container['env'].append({'name': split[0], 'value': split[1]})
 
-    name = "%s-hokusai-run-%s" % (config.project_name, uuid)
-    separator = "@" if ":" in tag_or_digest else ":"
-    image_name = "%s%s%s" % (self.ecr.project_repo, separator, tag_or_digest)
-
+  def create_overrides(self):
+    ''' compile overrides spec for kubectl run '''
     container = {
       "args": cmd.split(' '),
       "name": name,
@@ -46,23 +44,6 @@ class CommandRunner:
         }
       ]
     }
-
-    run_tty = tty if tty is not None else config.run_tty
-    if run_tty:
-      container.update({
-        "stdin": True,
-        "stdinOnce": True,
-        "tty": True
-      })
-
-    if env:
-      container['env'] = []
-      for s in env:
-        if '=' not in s:
-          raise HokusaiError("Error: environment variables must be of the form 'KEY=VALUE'")
-        split = s.split('=', 1)
-        container['env'].append({'name': split[0], 'value': split[1]})
-
     spec = { "containers": [container] }
     constraints = constraint or config.run_constraints
     if constraints:
@@ -72,12 +53,38 @@ class CommandRunner:
           raise HokusaiError("Error: Node selectors must of the form 'key=value'")
         split = label.split('=', 1)
         spec['nodeSelector'][split[0]] = split[1]
-
     overrides = { "apiVersion": "v1", "spec": spec }
 
-    if run_tty:
-      shout(self.kctl.command("run %s -t -i --image=%s --restart=Never --overrides=%s --rm" %
-                     (name, image_name, pipes.quote(json.dumps(overrides)))), print_output=True)
+  def container_name():
+    if os.environ.get('USER') is not None:
+      # The regex used for the validation of name is '[a-z0-9]([-a-z0-9]*[a-z0-9])?'
+      user = re.sub("[^0-9a-z]+", "-", os.environ.get('USER').lower())
+      uuid = "%s-%s" % (user, k8s_uuid())
     else:
-      return returncode(self.kctl.command("run %s --attach --image=%s --overrides=%s --restart=Never --rm" %
-                                        (name, image_name, pipes.quote(json.dumps(overrides)))))
+      uuid = k8s_uuid()
+    name = "%s-hokusai-run-%s" % (config.project_name, uuid)
+    separator = "@" if ":" in tag_or_digest else ":"
+
+  def image_name():
+    image_name = "%s%s%s" % (self.ecr.project_repo, separator, tag_or_digest)
+
+  def run_tty(overrides):
+    container.update({
+      "stdin": True,
+      "stdinOnce": True,
+      "tty": True
+    })
+    shout(self.kctl.command("run %s -t -i --image=%s --restart=Never --overrides=%s --rm" %
+                   (name, image_name, pipes.quote(json.dumps(overrides)))), print_output=True)
+
+  def run_no_tty(overrides):
+    return returncode(self.kctl.command("run %s --attach --image=%s --overrides=%s --restart=Never --rm" %
+                                      (name, image_name, pipes.quote(json.dumps(overrides)))))
+
+  def run(self, tag_or_digest, cmd, tty=None, env=(), constraint=()):
+    run_tty = tty if tty is not None else config.run_tty
+    overrides = self.creat_overrrides()
+    if run_tty:
+      self.run_tty(overrides)
+    else run_no_tty():
+      self.run_no_tty(overrides):

--- a/hokusai/services/command_runner.py
+++ b/hokusai/services/command_runner.py
@@ -3,6 +3,8 @@ import json
 import pipes
 import re
 
+import pdb
+
 from hokusai.lib.common import (
   k8s_uuid, returncode, shout, user, validate_key_value
 )
@@ -165,7 +167,7 @@ class CommandRunner:
   def run(self, tag_or_digest, cmd, tty=None, env=(), constraint=()):
     ''' run command '''
     run_tty = tty if tty is not None else config.run_tty
-    overrides = self._overrrides(
+    overrides = self._overrides(
       cmd, constraint, env, tag_or_digest
     )
     image_name = self._image_name(tag_or_digest)

--- a/hokusai/services/command_runner.py
+++ b/hokusai/services/command_runner.py
@@ -126,12 +126,17 @@ class CommandRunner:
 
   def _run_no_tty(self, cmd, image_name, overrides):
     ''' run command without tty '''
+    args = ' '.join(
+      "run",
+      self.pod_name,
+      "--attach",
+      f"--image={image_name}",
+      f"--overrides={pipes.quote(json.dumps(overrides))}",
+      "--restart=Never",
+      "--rm"
+    )
     return returncode(
-      self.kctl.command(
-        f"run {self.pod_name} --attach --image={image_name} " +
-        f"--overrides={pipes.quote(json.dumps(overrides))} " +
-        f"--restart=Never --rm"
-      )
+      self.kctl.command(args)
     )
 
   def _run_tty(self, cmd, image_name, overrides):
@@ -141,11 +146,18 @@ class CommandRunner:
       "stdinOnce": True,
       "tty": True
     })
+    args = ' '.join(
+      "run",
+      self.pod_name,
+      "-t",
+      "-i",
+      f"--image={image_name}",
+      "--restart=Never",
+      f"--overrides={pipes.quote(json.dumps(overrides))}",
+      "--rm"
+    )
     shout(
-      self.kctl.command(
-        f"run {self.pod_name} -t -i --image={image_name} --restart=Never " +
-        f"--overrides={pipes.quote(json.dumps(overrides))} --rm"
-      ),
+      self.kctl.command(args),
       print_output=True
     )
 

--- a/hokusai/services/command_runner.py
+++ b/hokusai/services/command_runner.py
@@ -4,7 +4,7 @@ import pipes
 import re
 
 from hokusai.lib.common import (
-  k8s_uuid, returncode, shout, user, validate_env_var
+  k8s_uuid, returncode, shout, user, validate_key_value
 )
 from hokusai.lib.config import config
 from hokusai.lib.exceptions import HokusaiError
@@ -44,7 +44,7 @@ class CommandRunner:
     spec = copy.deepcopy(container_spec)
     spec['env'] = []
     for var in env:
-      validate_env_var(var)
+      validate_key_value(var)
       split = var.split('=', 1)
       spec['env'].append(
         {'name': split[0], 'value': split[1]}
@@ -80,10 +80,7 @@ class CommandRunner:
     if constraint:
       spec['nodeSelector'] = {}
       for label in constraint:
-        if '=' not in label:
-          raise HokusaiError(
-            "Error: Node selectors must of the form 'key=value'"
-          )
+        validate_key_value(label)
         split = label.split('=', 1)
         spec['nodeSelector'][split[0]] = split[1]
     return spec

--- a/hokusai/services/command_runner.py
+++ b/hokusai/services/command_runner.py
@@ -101,11 +101,10 @@ class CommandRunner:
 
   def _overrrides_containers(self, cmd, env, tag_or_digest):
     ''' generate overrides['spec']['containers'] spec '''
-    containers_spec = {}
     container_spec = self._overrides_container(
       cmd, env, tag_or_digest
     )
-    containers_spec = { "containers": [container_spec] }
+    spec = { "containers": [container_spec] }
     return containers_spec
 
   def _overrides_spec(self, cmd, constraints, env, tag_or_digest):

--- a/hokusai/services/command_runner.py
+++ b/hokusai/services/command_runner.py
@@ -32,7 +32,19 @@ class CommandRunner:
       "name": name,
       "image": image_name,
       "imagePullPolicy": "Always",
-      'envFrom': [{'configMapRef': {'name': "%s-environment" % config.project_name}}]
+      'envFrom': [
+        {
+          'configMapRef': {
+            'name': f'{config.project_name}-environment'
+          }
+        },
+        {
+          'secretRef': {
+            'name': f'{config.project_name}',
+            'optional': True
+          }
+        }
+      ]
     }
 
     run_tty = tty if tty is not None else config.run_tty

--- a/hokusai/services/command_runner.py
+++ b/hokusai/services/command_runner.py
@@ -14,10 +14,11 @@ class CommandRunner:
     self.context = context
     self.kctl = Kubectl(self.context, namespace=namespace)
     self.ecr = ECR()
-    self.name = self._name()
+    self.pod_name = self._name()
+    self.container_name = self._name()
 
   def _name(self):
-    ''' generate container name '''
+    ''' generate name for pod and container '''
     if os.environ.get('USER') is not None:
       # The regex used for the validation of name is
       # '[a-z0-9]([-a-z0-9]*[a-z0-9])?'
@@ -91,7 +92,7 @@ class CommandRunner:
     ''' generate container spec '''
     container_spec = {
       "args": cmd.split(' '),
-      "name": self.name,
+      "name": self.container_name,
       "image": self._image_name(tag_or_digest),
       "imagePullPolicy": "Always",
     }
@@ -135,7 +136,7 @@ class CommandRunner:
     image_name = self._image_name(tag_or_digest)
     shout(
       self.kctl.command(
-        f"run {self.name} -t -i --image={image_name} --restart=Never " +
+        f"run {self.pod_name} -t -i --image={image_name} --restart=Never " +
         f"--overrides={pipes.quote(json.dumps(overrides))} --rm"
       ),
       print_output=True
@@ -146,7 +147,7 @@ class CommandRunner:
     image_name = self._image_name(tag_or_digest)
     return returncode(
       self.kctl.command(
-        f"run {self.name} --attach --image={image_name} " +
+        f"run {self.pod_name} --attach --image={image_name} " +
         f"--overrides={pipes.quote(json.dumps(overrides))} " +
         f"--restart=Never --rm"
       )

--- a/hokusai/services/command_runner.py
+++ b/hokusai/services/command_runner.py
@@ -4,7 +4,7 @@ import pipes
 import re
 
 from hokusai.lib.common import (
-  shout, returncode, k8s_uuid, user, validate_env_var
+  k8s_uuid, returncode, shout, user, validate_env_var
 )
 from hokusai.lib.config import config
 from hokusai.lib.exceptions import HokusaiError

--- a/hokusai/services/command_runner.py
+++ b/hokusai/services/command_runner.py
@@ -119,14 +119,13 @@ class CommandRunner:
     overrides.update(spec)
     return overrides
 
-  def _run_tty(self, tag_or_digest, cmd, overrides):
+  def _run_tty(self, cmd, image_name, overrides):
     ''' run command with tty '''
     overrides['spec']['containers'][0].update({
       "stdin": True,
       "stdinOnce": True,
       "tty": True
     })
-    image_name = self._image_name(tag_or_digest)
     shout(
       self.kctl.command(
         f"run {self.pod_name} -t -i --image={image_name} --restart=Never " +
@@ -135,9 +134,8 @@ class CommandRunner:
       print_output=True
     )
 
-  def _run_no_tty(self, tag_or_digest, cmd, overrides):
+  def _run_no_tty(self, cmd, image_name, overrides):
     ''' run command without tty '''
-    image_name = self._image_name(tag_or_digest)
     return returncode(
       self.kctl.command(
         f"run {self.pod_name} --attach --image={image_name} " +
@@ -152,7 +150,8 @@ class CommandRunner:
     overrides = self._overrrides(
       cmd, constraint, env, tag_or_digest
     )
+    image_name = self._image_name(tag_or_digest)
     if run_tty:
-      self._run_tty(tag_or_digest, cmd, overrides)
+      self._run_tty(cmd, image_name, overrides)
     else:
-      self._run_no_tty(tag_or_digest, cmd, overrides)
+      self._run_no_tty(cmd, image_name, overrides)

--- a/hokusai/services/command_runner.py
+++ b/hokusai/services/command_runner.py
@@ -4,7 +4,9 @@ import json
 import pipes
 
 from hokusai.lib.config import config
-from hokusai.lib.common import shout, returncode, k8s_uuid, user, validate_env_var
+from hokusai.lib.common import (
+  shout, returncode, k8s_uuid, user, validate_env_var
+)
 from hokusai.services.ecr import ECR
 from hokusai.services.kubectl import Kubectl
 from hokusai.lib.exceptions import HokusaiError

--- a/hokusai/services/command_runner.py
+++ b/hokusai/services/command_runner.py
@@ -52,7 +52,7 @@ class CommandRunner:
         {'name': split[0], 'value': split[1]}
       )
 
-  def _append_envfrom(container_spec):
+  def _append_envfrom(self, container_spec):
     ''' append envFrrom to given container spec '''
     container_spec = container_spec.update(
       {
@@ -72,7 +72,7 @@ class CommandRunner:
       }
     )
 
-  def _append_constraints(containers_spec, constraint):
+  def _append_constraints(self, containers_spec, constraint):
     ''' append constraints to given containers spec '''
     constraints = constraint or config.run_constraints
     if constraints:
@@ -124,7 +124,7 @@ class CommandRunner:
     overrides.update(spec)
     return overrides
 
-  def _run_tty(tag_or_digest, overrides):
+  def _run_tty(self, tag_or_digest, overrides):
     ''' run command with tty '''
     overrides['spec']['containers'][0].update({
       "stdin": True,
@@ -141,7 +141,7 @@ class CommandRunner:
       print_output=True
     )
 
-  def _run_no_tty(tag_or_digest, overrides):
+  def _run_no_tty(self, tag_or_digest, overrides):
     ''' run command without tty '''
     name = self._name()
     image_name = self._image_name(tag_or_digest)

--- a/hokusai/services/command_runner.py
+++ b/hokusai/services/command_runner.py
@@ -14,6 +14,7 @@ class CommandRunner:
     self.context = context
     self.kctl = Kubectl(self.context, namespace=namespace)
     self.ecr = ECR()
+    self.name = self._name()
 
   def _name(self):
     ''' generate container name '''
@@ -90,7 +91,7 @@ class CommandRunner:
     ''' generate container spec '''
     container_spec = {
       "args": cmd.split(' '),
-      "name": self.container_name(),
+      "name": self.name,
       "image": self._image_name(tag_or_digest),
       "imagePullPolicy": "Always",
     }
@@ -131,11 +132,10 @@ class CommandRunner:
       "stdinOnce": True,
       "tty": True
     })
-    name = self._name()
     image_name = self._image_name(tag_or_digest)
     shout(
       self.kctl.command(
-        f"run {name} -t -i --image={image_name} --restart=Never " +
+        f"run {self.name} -t -i --image={image_name} --restart=Never " +
         f"--overrides={pipes.quote(json.dumps(overrides))} --rm"
       ),
       print_output=True
@@ -143,11 +143,10 @@ class CommandRunner:
 
   def _run_no_tty(self, tag_or_digest, cmd, overrides):
     ''' run command without tty '''
-    name = self._name()
     image_name = self._image_name(tag_or_digest)
     return returncode(
       self.kctl.command(
-        f"run {self._name()} --attach --image={image_name} " +
+        f"run {self.name} --attach --image={image_name} " +
         f"--overrides={pipes.quote(json.dumps(overrides))} " +
         f"--restart=Never --rm"
       )

--- a/hokusai/services/command_runner.py
+++ b/hokusai/services/command_runner.py
@@ -17,7 +17,7 @@ class CommandRunner:
     self.kctl = Kubectl(self.context, namespace=namespace)
     self.ecr = ECR()
     self.pod_name = self._name()
-    self.container_name = self._name()
+    self.container_name = self.pod_name
 
   def _name(self):
     ''' generate name for pod and container '''

--- a/hokusai/services/command_runner.py
+++ b/hokusai/services/command_runner.py
@@ -103,7 +103,7 @@ class CommandRunner:
       cmd, env, tag_or_digest
     )
     spec = { 'containers': [container_spec] }
-    return containers_spec
+    return spec
 
   def _overrides_spec(self, cmd, constraint, env, tag_or_digest):
     ''' generate overrides['spec'] spec '''

--- a/hokusai/services/command_runner.py
+++ b/hokusai/services/command_runner.py
@@ -99,21 +99,13 @@ class CommandRunner:
     spec = self._set_envfrom(spec)
     return spec
 
-  def _overrides_containers(self, cmd, env, tag_or_digest):
-    ''' generate overrides['spec']['containers'] spec '''
-    container_spec = self._overrides_container(
-      cmd, env, tag_or_digest
-    )
-    spec = [container_spec]
-    return spec
-
   def _overrides_spec(self, cmd, constraint, env, tag_or_digest):
     ''' generate overrides['spec'] spec '''
     spec = {}
-    containers_spec = self._overrides_containers(
+    container_spec = self._overrides_container(
       cmd, env, tag_or_digest
     )
-    spec.update({'containers': containers_spec})
+    spec.update({'containers': [container_spec]})
     spec = self._set_constraint(spec, constraint)
     return spec
 

--- a/hokusai/services/command_runner.py
+++ b/hokusai/services/command_runner.py
@@ -107,7 +107,7 @@ class CommandRunner:
     containers_spec = { "containers": [container_spec] }
     return containers_spec
 
-  def _overrides_spec(self, cmd, env, tag_or_digest, constraint):
+  def _overrides_spec(self, cmd, constraint, env, tag_or_digest):
     ''' generate spec spec '''
     spec = {}
     containers_spec = self._overrrides_spec_containers(
@@ -117,14 +117,14 @@ class CommandRunner:
     spec = self._append_constraints(spec, constraint)
     return spec
 
-  def _overrides(self, cmd, env, tag_or_digest, constraint):
+  def _overrides(self, cmd, constraint, env, tag_or_digest):
     ''' generate overrides spec '''
     overrides = { "apiVersion": "v1", "spec": spec }
-    spec = self._overrides_spec(cmd, env, tag_or_digest_constraint)
+    spec = self._overrides_spec(cmd, constraint, env, tag_or_digest)
     overrides.update(spec)
     return overrides
 
-  def _run_tty(self, tag_or_digest, overrides):
+  def _run_tty(self, tag_or_digest, cmd, overrides):
     ''' run command with tty '''
     overrides['spec']['containers'][0].update({
       "stdin": True,
@@ -141,7 +141,7 @@ class CommandRunner:
       print_output=True
     )
 
-  def _run_no_tty(self, tag_or_digest, overrides):
+  def _run_no_tty(self, tag_or_digest, cmd, overrides):
     ''' run command without tty '''
     name = self._name()
     image_name = self._image_name(tag_or_digest)
@@ -157,9 +157,9 @@ class CommandRunner:
     ''' run command '''
     run_tty = tty if tty is not None else config.run_tty
     overrides = self._overrrides(
-      cmd, env, tag_or_digest, constraint
+      cmd, constraint, env, tag_or_digest
     )
     if run_tty:
-      self._run_tty(tag_or_digest, overrides)
+      self._run_tty(tag_or_digest, cmd, overrides)
     else:
-      self._run_no_tty(tag_or_digest, overrides)
+      self._run_no_tty(tag_or_digest, cmd, overrides)

--- a/hokusai/services/command_runner.py
+++ b/hokusai/services/command_runner.py
@@ -72,13 +72,13 @@ class CommandRunner:
     )
     return spec
 
-  def _append_constraints(self, containers_spec, constraints):
-    ''' append node constraints to given containers spec '''
+  def _append_constraint(self, containers_spec, constraint):
+    ''' append node constraint to given containers spec '''
     spec = copy.deepcopy(containers_spec)
-    constraints = constraints or config.run_constraints
-    if constraints:
+    constraint = constraint or config.run_constraints
+    if constraint:
       spec['nodeSelector'] = {}
-      for label in constraints:
+      for label in constraint:
         if '=' not in label:
           raise HokusaiError(
             "Error: Node selectors must of the form 'key=value'"
@@ -107,14 +107,14 @@ class CommandRunner:
     spec = { "containers": [container_spec] }
     return containers_spec
 
-  def _overrides_spec(self, cmd, constraints, env, tag_or_digest):
+  def _overrides_spec(self, cmd, constraint, env, tag_or_digest):
     ''' generate overrides['spec'] spec '''
     spec = {}
     containers_spec = self._overrrides_containers(
       cmd, env, tag_or_digest
     )
     spec.update(containers_spec)
-    spec = self._append_constraints(spec, constraints)
+    spec = self._append_constraint(spec, constraint)
     return spec
 
   def _overrides(self, cmd, constraint, env, tag_or_digest):

--- a/hokusai/services/command_runner.py
+++ b/hokusai/services/command_runner.py
@@ -4,7 +4,7 @@ import json
 import pipes
 
 from hokusai.lib.config import config
-from hokusai.lib.common import shout, returncode, k8s_uuid, validate_env_var
+from hokusai.lib.common import shout, returncode, k8s_uuid, user, validate_env_var
 from hokusai.services.ecr import ECR
 from hokusai.services.kubectl import Kubectl
 from hokusai.lib.exceptions import HokusaiError
@@ -19,19 +19,12 @@ class CommandRunner:
 
   def _name(self):
     ''' generate name for pod and container '''
-    user = None
-    if os.environ.get('USER') is not None:
-      # The regex used for the validation of name is
-      # '[a-z0-9]([-a-z0-9]*[a-z0-9])?'
-      user = re.sub(
-        "[^0-9a-z]+", "-", os.environ.get('USER').lower()
-      )
     name = '-'.join(
       filter(
         None,
         [
           f"{config.project_name}-hokusai-run",
-          user,
+          user(),
           k8s_uuid()
         ]
       )

--- a/hokusai/services/command_runner.py
+++ b/hokusai/services/command_runner.py
@@ -19,16 +19,23 @@ class CommandRunner:
 
   def _name(self):
     ''' generate name for pod and container '''
+    user = None
     if os.environ.get('USER') is not None:
       # The regex used for the validation of name is
       # '[a-z0-9]([-a-z0-9]*[a-z0-9])?'
       user = re.sub(
         "[^0-9a-z]+", "-", os.environ.get('USER').lower()
       )
-      uuid = "{user}-{k8s_uuid()}"
-    else:
-      uuid = k8s_uuid()
-    name = "{config.project_name}-hokusai-run-{uuid}"
+    name = '-'.join(
+      filter(
+        None,
+        [
+          f"{config.project_name}-hokusai-run",
+          user,
+          k8s_uuid()
+        ]
+      )
+    )
     return name
 
   def _image_name(self, tag_or_digest):

--- a/hokusai/services/command_runner.py
+++ b/hokusai/services/command_runner.py
@@ -146,14 +146,16 @@ class CommandRunner:
       'tty': True
     })
     args = ' '.join(
-      'run',
-      self.pod_name,
-      '-t',
-      '-i',
-      f'--image={image_name}',
-      '--restart=Never',
-      f'--overrides={pipes.quote(json.dumps(overrides))}',
-      '--rm'
+      [
+        'run',
+        self.pod_name,
+        '-t',
+        '-i',
+        f'--image={image_name}',
+        '--restart=Never',
+        f'--overrides={pipes.quote(json.dumps(overrides))}',
+        '--rm'
+      ]
     )
     shout(
       self.kctl.command(args),

--- a/hokusai/services/command_runner.py
+++ b/hokusai/services/command_runner.py
@@ -102,7 +102,7 @@ class CommandRunner:
     container_spec = self._overrides_container(
       cmd, env, tag_or_digest
     )
-    spec = { 'containers': [container_spec] }
+    spec = [container_spec]
     return spec
 
   def _overrides_spec(self, cmd, constraint, env, tag_or_digest):
@@ -111,15 +111,14 @@ class CommandRunner:
     containers_spec = self._overrrides_containers(
       cmd, env, tag_or_digest
     )
-    spec.update(containers_spec)
+    spec.update({'containers': containers_spec})
     spec = self._set_constraint(spec, constraint)
     return spec
 
   def _overrides(self, cmd, constraint, env, tag_or_digest):
     ''' generate overrides '''
-    overrides = { 'apiVersion': 'v1', 'spec': spec }
     spec = self._overrides_spec(cmd, constraint, env, tag_or_digest)
-    overrides.update(spec)
+    overrides = { 'apiVersion': 'v1', 'spec': spec }
     return overrides
 
   def _run_no_tty(self, cmd, image_name, overrides):

--- a/hokusai/services/command_runner.py
+++ b/hokusai/services/command_runner.py
@@ -73,8 +73,8 @@ class CommandRunner:
     )
     return spec
 
-  def _append_constraint(self, containers_spec, constraint):
-    ''' append node constraint to given containers spec '''
+  def _set_constraint(self, containers_spec, constraint):
+    ''' set nodeSelector field of given containers spec '''
     spec = copy.deepcopy(containers_spec)
     constraint = constraint or config.run_constraints
     if constraint:
@@ -115,7 +115,7 @@ class CommandRunner:
       cmd, env, tag_or_digest
     )
     spec.update(containers_spec)
-    spec = self._append_constraint(spec, constraint)
+    spec = self._set_constraint(spec, constraint)
     return spec
 
   def _overrides(self, cmd, constraint, env, tag_or_digest):

--- a/hokusai/services/command_runner.py
+++ b/hokusai/services/command_runner.py
@@ -1,15 +1,15 @@
 import copy
-import re
 import json
 import pipes
+import re
 
-from hokusai.lib.config import config
 from hokusai.lib.common import (
   shout, returncode, k8s_uuid, user, validate_env_var
 )
+from hokusai.lib.config import config
+from hokusai.lib.exceptions import HokusaiError
 from hokusai.services.ecr import ECR
 from hokusai.services.kubectl import Kubectl
-from hokusai.lib.exceptions import HokusaiError
 
 class CommandRunner:
   def __init__(self, context, namespace=None):

--- a/hokusai/services/command_runner.py
+++ b/hokusai/services/command_runner.py
@@ -124,13 +124,15 @@ class CommandRunner:
   def _run_no_tty(self, cmd, image_name, overrides):
     ''' run command without tty '''
     args = ' '.join(
-      'run',
-      self.pod_name,
-      '--attach',
-      f'--image={image_name}',
-      f'--overrides={pipes.quote(json.dumps(overrides))}',
-      '--restart=Never',
-      '--rm'
+      [
+        'run',
+        self.pod_name,
+        '--attach',
+        f'--image={image_name}',
+        f'--overrides={pipes.quote(json.dumps(overrides))}',
+        '--restart=Never',
+        '--rm'
+      ]
     )
     return returncode(
       self.kctl.command(args)

--- a/hokusai/services/command_runner.py
+++ b/hokusai/services/command_runner.py
@@ -3,8 +3,6 @@ import json
 import pipes
 import re
 
-import pdb
-
 from hokusai.lib.common import (
   k8s_uuid, returncode, shout, user, validate_key_value
 )

--- a/hokusai/services/command_runner.py
+++ b/hokusai/services/command_runner.py
@@ -23,7 +23,7 @@ class CommandRunner:
       filter(
         None,
         [
-          f"{config.project_name}-hokusai-run",
+          f'{config.project_name}-hokusai-run',
           user(),
           k8s_uuid()
         ]
@@ -33,8 +33,8 @@ class CommandRunner:
 
   def _image_name(self, tag_or_digest):
     ''' generate docker image name '''
-    separator = "@" if ":" in tag_or_digest else ":"
-    image_name = f"{self.ecr.project_repo}{separator}{tag_or_digest}"
+    separator = '@' if ':' in tag_or_digest else ':'
+    image_name = f'{self.ecr.project_repo}{separator}{tag_or_digest}'
     return image_name
 
   def _append_env(self, container_spec, env):
@@ -89,10 +89,10 @@ class CommandRunner:
   def _overrides_container(self, cmd, env, tag_or_digest):
     ''' generate overrides['spec']['containers'][0] spec '''
     spec = {
-      "args": cmd.split(' '),
-      "name": self.container_name,
-      "image": self._image_name(tag_or_digest),
-      "imagePullPolicy": "Always",
+      'args': cmd.split(' '),
+      'name': self.container_name,
+      'image': self._image_name(tag_or_digest),
+      'imagePullPolicy': 'Always',
     }
     spec = self._append_env(spec, env)
     spec = self._append_envfrom(spec)
@@ -103,7 +103,7 @@ class CommandRunner:
     container_spec = self._overrides_container(
       cmd, env, tag_or_digest
     )
-    spec = { "containers": [container_spec] }
+    spec = { 'containers': [container_spec] }
     return containers_spec
 
   def _overrides_spec(self, cmd, constraint, env, tag_or_digest):
@@ -118,7 +118,7 @@ class CommandRunner:
 
   def _overrides(self, cmd, constraint, env, tag_or_digest):
     ''' generate overrides '''
-    overrides = { "apiVersion": "v1", "spec": spec }
+    overrides = { 'apiVersion': 'v1', 'spec': spec }
     spec = self._overrides_spec(cmd, constraint, env, tag_or_digest)
     overrides.update(spec)
     return overrides
@@ -126,13 +126,13 @@ class CommandRunner:
   def _run_no_tty(self, cmd, image_name, overrides):
     ''' run command without tty '''
     args = ' '.join(
-      "run",
+      'run',
       self.pod_name,
-      "--attach",
-      f"--image={image_name}",
-      f"--overrides={pipes.quote(json.dumps(overrides))}",
-      "--restart=Never",
-      "--rm"
+      '--attach',
+      f'--image={image_name}',
+      f'--overrides={pipes.quote(json.dumps(overrides))}',
+      '--restart=Never',
+      '--rm'
     )
     return returncode(
       self.kctl.command(args)
@@ -141,19 +141,19 @@ class CommandRunner:
   def _run_tty(self, cmd, image_name, overrides):
     ''' run command with tty '''
     overrides['spec']['containers'][0].update({
-      "stdin": True,
-      "stdinOnce": True,
-      "tty": True
+      'stdin': True,
+      'stdinOnce': True,
+      'tty': True
     })
     args = ' '.join(
-      "run",
+      'run',
       self.pod_name,
-      "-t",
-      "-i",
-      f"--image={image_name}",
-      "--restart=Never",
-      f"--overrides={pipes.quote(json.dumps(overrides))}",
-      "--rm"
+      '-t',
+      '-i',
+      f'--image={image_name}',
+      '--restart=Never',
+      f'--overrides={pipes.quote(json.dumps(overrides))}',
+      '--rm'
     )
     shout(
       self.kctl.command(args),

--- a/test/unit/test_lib/test_common.py
+++ b/test/unit/test_lib/test_common.py
@@ -11,17 +11,17 @@ def describe_user():
       assert user() == None
   def describe_user_set_in_env():
     def it_returns_what_is_set(monkeypatch):
-      monkeypatch.settenv('USER', 'foo')
+      monkeypatch.setenv('USER', 'foo')
       assert user() == 'foo'
-      monkeypatch.settenv('USER', '')
+      monkeypatch.setenv('USER', '')
       assert user() == ''
-    def it_replaces_upper_case_with_lower_case():
-      monkeypatch.settenv('USER', 'foo')
+    def it_replaces_upper_case_with_lower_case(monkeypatch):
+      monkeypatch.setenv('USER', 'foo')
       assert user() == 'foo'
-    def it_replaces_non_alpha_numeric_char_with_dash():
-      monkeypatch.settenv('USER', 'foo.bar')
+    def it_replaces_non_alpha_numeric_char_with_dash(monkeypatch):
+      monkeypatch.setenv('USER', 'foo.bar')
       assert user() == 'foo-bar'
-      monkeypatch.settenv('USER', 'foo_bar')
+      monkeypatch.setenv('USER', 'foo_bar')
       assert user() == 'foo-bar'
 
 def describe_validate_env_var():

--- a/test/unit/test_lib/test_common.py
+++ b/test/unit/test_lib/test_common.py
@@ -1,7 +1,7 @@
 import os
 import pytest
 
-from hokusai.lib.common import user, validate_env_var
+from hokusai.lib.common import user, validate_key_value
 from hokusai.lib.exceptions import HokusaiError
 
 def describe_user():
@@ -24,11 +24,11 @@ def describe_user():
       monkeypatch.setenv('USER', 'foo_bar')
       assert user() == 'foo-bar'
 
-def describe_validate_env_var():
+def describe_validate_key_value():
   def describe_form_good():
     def it_does_not_error():
-      validate_env_var('foo=bar')
+      validate_key_value('foo=bar')
   def describe_form_bad():
     def it_errors():
       with pytest.raises(HokusaiError):
-        validate_env_var('foobar')
+        validate_key_value('foobar')

--- a/test/unit/test_lib/test_common.py
+++ b/test/unit/test_lib/test_common.py
@@ -1,0 +1,23 @@
+import os
+
+from hokusai.lib.common import user
+
+def describe_user():
+  def describe_user_not_set_in_env():
+    def it_returns_none():
+      del os.environ['USER']
+      assert user() == None
+  def describe_user_set_in_env():
+    def it_returns_what_is_set():
+      os.environ['USER'] = 'foo'
+      assert user() == 'foo'
+      os.environ['USER'] = ''
+      assert user() == ''
+    def it_replaces_upper_case_with_lower_case():
+      os.environ['USER'] = 'FOO'
+      assert user() == 'foo'
+    def it_replaces_non_alpha_numeric_char_with_dash():
+      os.environ['USER'] = 'foo.bar'
+      assert user() == 'foo-bar'
+      os.environ['USER'] = 'foo_bar'
+      assert user() == 'foo-bar'

--- a/test/unit/test_lib/test_common.py
+++ b/test/unit/test_lib/test_common.py
@@ -7,7 +7,7 @@ from hokusai.lib.exceptions import HokusaiError
 def describe_user():
   def describe_user_not_set_in_env():
     def it_returns_none(monkeypatch):
-      monkeypatch.delenv('USER')
+      monkeypatch.delenv('USER', raising=False)
       assert user() == None
   def describe_user_set_in_env():
     def it_returns_what_is_set(monkeypatch):

--- a/test/unit/test_lib/test_common.py
+++ b/test/unit/test_lib/test_common.py
@@ -1,6 +1,8 @@
 import os
+import pytest
 
-from hokusai.lib.common import user
+from hokusai.lib.common import user, validate_env_var
+from hokusai.lib.exceptions import HokusaiError
 
 def describe_user():
   def describe_user_not_set_in_env():
@@ -21,3 +23,12 @@ def describe_user():
       assert user() == 'foo-bar'
       os.environ['USER'] = 'foo_bar'
       assert user() == 'foo-bar'
+
+def describe_validate_env_var():
+  def describe_form_good():
+    def it_does_not_error():
+      validate_env_var('foo=bar')
+  def describe_form_bad():
+    def it_errors():
+      with pytest.raises(HokusaiError):
+        validate_env_var('foobar')

--- a/test/unit/test_lib/test_common.py
+++ b/test/unit/test_lib/test_common.py
@@ -16,7 +16,7 @@ def describe_user():
       monkeypatch.setenv('USER', '')
       assert user() == ''
     def it_replaces_upper_case_with_lower_case(monkeypatch):
-      monkeypatch.setenv('USER', 'foo')
+      monkeypatch.setenv('USER', 'FOO')
       assert user() == 'foo'
     def it_replaces_non_alpha_numeric_char_with_dash(monkeypatch):
       monkeypatch.setenv('USER', 'foo.bar')

--- a/test/unit/test_lib/test_common.py
+++ b/test/unit/test_lib/test_common.py
@@ -6,22 +6,22 @@ from hokusai.lib.exceptions import HokusaiError
 
 def describe_user():
   def describe_user_not_set_in_env():
-    def it_returns_none():
-      del os.environ['USER']
+    def it_returns_none(monkeypatch):
+      monkeypatch.delenv('USER')
       assert user() == None
   def describe_user_set_in_env():
-    def it_returns_what_is_set():
-      os.environ['USER'] = 'foo'
+    def it_returns_what_is_set(monkeypatch):
+      monkeypatch.settenv('USER', 'foo')
       assert user() == 'foo'
-      os.environ['USER'] = ''
+      monkeypatch.settenv('USER', '')
       assert user() == ''
     def it_replaces_upper_case_with_lower_case():
-      os.environ['USER'] = 'FOO'
+      monkeypatch.settenv('USER', 'foo')
       assert user() == 'foo'
     def it_replaces_non_alpha_numeric_char_with_dash():
-      os.environ['USER'] = 'foo.bar'
+      monkeypatch.settenv('USER', 'foo.bar')
       assert user() == 'foo-bar'
-      os.environ['USER'] = 'foo_bar'
+      monkeypatch.settenv('USER', 'foo_bar')
       assert user() == 'foo-bar'
 
 def describe_validate_env_var():

--- a/test/unit/test_services/fixtures/command_runner.py
+++ b/test/unit/test_services/fixtures/command_runner.py
@@ -26,3 +26,32 @@ def mock_spec():
       'nodeSelector': {'fooconstraint': 'bar'}
     }
   }
+
+@pytest.fixture
+def mock_tty_spec():
+  return {
+    'apiVersion': 'v1',
+    'spec': {
+      'containers': [
+        {
+          'args': ['foocmd'],
+          'name': 'hello-hokusai-run-jxu-abcde',
+          'image': 'foo:footag',
+          'imagePullPolicy': 'Always',
+          'env': [{'name': 'foo', 'value': 'bar'}],
+          'envFrom': [
+              {
+                'configMapRef': {'name': 'hello-environment'}
+              },
+              {
+                'secretRef': {'name': 'hello', 'optional': True}
+              }
+          ],
+          "stdin": True,
+          "stdinOnce": True,
+          "tty": True
+        }
+      ],
+      'nodeSelector': {'fooconstraint': 'bar'}
+    }
+  }

--- a/test/unit/test_services/fixtures/command_runner.py
+++ b/test/unit/test_services/fixtures/command_runner.py
@@ -1,0 +1,20 @@
+import pytest
+
+@pytest.fixture
+def mock_spec():
+  return {
+    'args': ['foocmd'],
+    'name': 'hello-hokusai-run-jxu-abcde',
+    'image': 'foo:footag',
+    'imagePullPolicy': 'Always',
+    'env': [],
+    'envFrom':
+      [
+        {
+          'configMapRef': {'name': 'hello-environment'}
+        },
+        {
+          'secretRef': {'name': 'hello', 'optional': True}
+        }
+      ]
+  }

--- a/test/unit/test_services/fixtures/command_runner.py
+++ b/test/unit/test_services/fixtures/command_runner.py
@@ -8,7 +8,7 @@ def mock_spec():
       'containers': [
         {
           'args': ['foocmd'],
-          'name': 'hello-hokusai-run-jxu-abcde',
+          'name': 'hello-hokusai-run-foouser-abcde',
           'image': 'foo:footag',
           'imagePullPolicy': 'Always',
           'env': [{'name': 'foo', 'value': 'bar'}],
@@ -35,7 +35,7 @@ def mock_tty_spec():
       'containers': [
         {
           'args': ['foocmd'],
-          'name': 'hello-hokusai-run-jxu-abcde',
+          'name': 'hello-hokusai-run-foouser-abcde',
           'image': 'foo:footag',
           'imagePullPolicy': 'Always',
           'env': [{'name': 'foo', 'value': 'bar'}],

--- a/test/unit/test_services/fixtures/command_runner.py
+++ b/test/unit/test_services/fixtures/command_runner.py
@@ -3,18 +3,26 @@ import pytest
 @pytest.fixture
 def mock_spec():
   return {
-    'args': ['foocmd'],
-    'name': 'hello-hokusai-run-jxu-abcde',
-    'image': 'foo:footag',
-    'imagePullPolicy': 'Always',
-    'env': [],
-    'envFrom':
-      [
+    'apiVersion': 'v1',
+    'spec': {
+      'containers': [
         {
-          'configMapRef': {'name': 'hello-environment'}
-        },
-        {
-          'secretRef': {'name': 'hello', 'optional': True}
+          'args': ['foocmd'],
+          'name': 'hello-hokusai-run-jxu-abcde',
+          'image': 'foo:footag',
+          'imagePullPolicy': 'Always',
+          'env': [{'name': 'foo', 'value': 'bar'}],
+          'envFrom':
+            [
+              {
+                'configMapRef': {'name': 'hello-environment'}
+              },
+              {
+                'secretRef': {'name': 'hello', 'optional': True}
+              }
+            ]
         }
-      ]
+      ],
+      'nodeSelector': {'fooconstraint': 'bar'}
+    }
   }

--- a/test/unit/test_services/fixtures/ecr.py
+++ b/test/unit/test_services/fixtures/ecr.py
@@ -1,0 +1,8 @@
+import pytest
+
+@pytest.fixture
+def mock_ecr_class():
+  class mock_ECR:
+    def __init__(self):
+      self.project_repo = 'foo'
+  return mock_ECR

--- a/test/unit/test_services/test_command_runner.py
+++ b/test/unit/test_services/test_command_runner.py
@@ -114,15 +114,6 @@ def describe_command_runner():
       spec = runner._overrides_container('foocmd', ('foo=bar',), 'footag')
       assert spec == mock_spec['spec']['containers'][0]
 
-  def describe_overrides_containers():
-    def it_generates_spec(mocker, mock_ecr_class, mock_spec, monkeypatch):
-      monkeypatch.setenv('USER', 'foouser')
-      mocker.patch('hokusai.services.command_runner.ECR').side_effect = mock_ecr_class
-      mocker.patch('hokusai.services.command_runner.k8s_uuid', return_value = 'abcde')
-      runner = CommandRunner('staging')
-      spec = runner._overrides_containers('foocmd', ('foo=bar',), 'footag')
-      assert spec == mock_spec['spec']['containers']
-
   def describe_overrides_spec():
     def it_generates_spec(mocker, mock_ecr_class, mock_spec, monkeypatch):
       monkeypatch.setenv('USER', 'foouser')

--- a/test/unit/test_services/test_command_runner.py
+++ b/test/unit/test_services/test_command_runner.py
@@ -1,0 +1,14 @@
+import os
+
+from hokusai.services.command_runner import CommandRunner
+from hokusai.services.ecr import ECR
+
+def describe_command_runner():
+  def describe_init():
+    def it_inits():
+      os.environ['USER'] = 'foo'
+      runner = CommandRunner('staging')
+      assert runner.context == 'staging'
+      assert type(runner.ecr) == ECR
+      assert '-hokusai-run-foo' in runner.pod_name
+      assert '-hokusai-run-foo' in runner.container_name

--- a/test/unit/test_services/test_command_runner.py
+++ b/test/unit/test_services/test_command_runner.py
@@ -152,3 +152,36 @@ def describe_command_runner():
           f'--rm'
         )
       ])
+  def describe_run():
+    def describe_tty():
+      def it_runs(mocker, mock_ecr_class, mock_spec):
+        mocker.patch('hokusai.services.command_runner.k8s_uuid', return_value = 'abcde')
+        mocker.patch('hokusai.services.command_runner.ECR').side_effect = mock_ecr_class
+        runner = CommandRunner('staging')
+        mocker.patch.object(runner, '_run_tty')
+        spy = mocker.spy(runner, '_run_tty')
+        runner.run('footag', 'foocmd', tty=True, env=('foo=bar',), constraint=('fooconstraint=bar',))
+        assert spy.call_count == 1
+        spy.assert_has_calls([
+          mocker.call(
+            'foocmd',
+            'foo:footag',
+            mock_spec
+          )
+        ])
+    def describe_no_tty():
+      def it_runs(mocker, mock_ecr_class, mock_spec):
+        mocker.patch('hokusai.services.command_runner.k8s_uuid', return_value = 'abcde')
+        mocker.patch('hokusai.services.command_runner.ECR').side_effect = mock_ecr_class
+        runner = CommandRunner('staging')
+        mocker.patch.object(runner, '_run_no_tty')
+        spy = mocker.spy(runner, '_run_no_tty')
+        runner.run('footag', 'foocmd', tty=False, env=('foo=bar',), constraint=('fooconstraint=bar',))
+        assert spy.call_count == 1
+        spy.assert_has_calls([
+          mocker.call(
+            'foocmd',
+            'foo:footag',
+            mock_spec
+          )
+        ])

--- a/test/unit/test_services/test_command_runner.py
+++ b/test/unit/test_services/test_command_runner.py
@@ -4,6 +4,7 @@ import hokusai.services.command_runner
 
 from hokusai.services.command_runner import CommandRunner
 from hokusai.services.ecr import ECR
+from test.unit.test_services.fixtures.ecr import mock_ecr_class
 
 def describe_command_runner():
   def describe_init():
@@ -23,20 +24,12 @@ def describe_command_runner():
       assert spy.call_count == 1
   def describe_image_name():
     def describe_separator_is_at_sign():
-      def it_does_not_add_at_sign(mocker):
-        class mock_ECR:
-          def __init__(self):
-            self.project_repo = 'foo'
-            pass
-        mocker.patch('hokusai.services.command_runner.ECR').side_effect = mock_ECR
+      def it_does_not_add_at_sign(mocker, mock_ecr_class):
+        mocker.patch('hokusai.services.command_runner.ECR').side_effect = mock_ecr_class
         runner = CommandRunner('staging')
         assert runner._image_name('123') == 'foo:123'
     def describe_separator_is_colon():
-      def it_adds_at_sign(mocker):
-        class mock_ECR:
-          def __init__(self):
-            self.project_repo = 'foo'
-            pass
-        mocker.patch('hokusai.services.command_runner.ECR').side_effect = mock_ECR
+      def it_adds_at_sign(mocker, mock_ecr_class):
+        mocker.patch('hokusai.services.command_runner.ECR').side_effect = mock_ecr_class
         runner = CommandRunner('staging')
         assert runner._image_name('123:456') == 'foo@123:456'

--- a/test/unit/test_services/test_command_runner.py
+++ b/test/unit/test_services/test_command_runner.py
@@ -7,6 +7,7 @@ from hokusai.lib.exceptions import HokusaiError
 from hokusai.services.command_runner import CommandRunner
 from hokusai.services.ecr import ECR
 from test.unit.test_services.fixtures.ecr import mock_ecr_class
+from test.unit.test_services.fixtures.command_runner import mock_spec
 
 def describe_command_runner():
   def describe_init():
@@ -83,3 +84,10 @@ def describe_command_runner():
       with pytest.raises(HokusaiError):
         runner = CommandRunner('staging')
         runner._set_constraint({}, ('foo bar',))
+  def describe_overrides_container():
+    def it_generates_spec(mocker, mock_ecr_class, mock_spec):
+      mocker.patch('hokusai.services.command_runner.ECR').side_effect = mock_ecr_class
+      mocker.patch('hokusai.services.command_runner.k8s_uuid', return_value = 'abcde')
+      runner = CommandRunner('staging')
+      spec = runner._overrides_container('foocmd', (), 'footag')
+      assert spec == mock_spec

--- a/test/unit/test_services/test_command_runner.py
+++ b/test/unit/test_services/test_command_runner.py
@@ -62,13 +62,13 @@ def describe_command_runner():
           }
         ]
       }
-  def describe_append_constraint():
+  def describe_set_constraint():
     def it_sets():
       runner = CommandRunner('staging')
-      spec = runner._append_constraint({}, ('foo=bar',))
+      spec = runner._set_constraint({}, ('foo=bar',))
       assert spec == {'nodeSelector': {'foo': 'bar'}}
     def it_overwrites():
       runner = CommandRunner('staging')
       spec = {'nodeSelector': {'foo': 'bar'}}
-      spec = runner._append_constraint(spec, ('bar=foo',))
+      spec = runner._set_constraint(spec, ('bar=foo',))
       assert spec == {'nodeSelector': {'bar': 'foo'}}

--- a/test/unit/test_services/test_command_runner.py
+++ b/test/unit/test_services/test_command_runner.py
@@ -43,3 +43,22 @@ def describe_command_runner():
       spec = {'env': [{'name': 'foo', 'value': 'bar'}]}
       spec = runner._set_env(spec, ('bar=foo',))
       assert spec == {'env': [{'name': 'bar', 'value': 'foo'}]}
+  def describe_set_envfrom():
+    def it_sets():
+      runner = CommandRunner('staging')
+      spec = runner._set_envfrom({})
+      assert spec == {
+        'envFrom': [
+          {
+            'configMapRef': {
+              'name': 'hello-environment'
+            }
+          },
+          {
+            'secretRef': {
+              'name': 'hello',
+              'optional': True
+            }
+          }
+        ]
+      }

--- a/test/unit/test_services/test_command_runner.py
+++ b/test/unit/test_services/test_command_runner.py
@@ -91,5 +91,26 @@ def describe_command_runner():
       mocker.patch('hokusai.services.command_runner.ECR').side_effect = mock_ecr_class
       mocker.patch('hokusai.services.command_runner.k8s_uuid', return_value = 'abcde')
       runner = CommandRunner('staging')
-      spec = runner._overrides_container('foocmd', (), 'footag')
+      spec = runner._overrides_container('foocmd', ('foo=bar',), 'footag')
+      assert spec == mock_spec['spec']['containers'][0]
+  def describe_overrrides_containers():
+    def it_generates_spec(mocker, mock_ecr_class, mock_spec):
+      mocker.patch('hokusai.services.command_runner.ECR').side_effect = mock_ecr_class
+      mocker.patch('hokusai.services.command_runner.k8s_uuid', return_value = 'abcde')
+      runner = CommandRunner('staging')
+      spec = runner._overrrides_containers('foocmd', ('foo=bar',), 'footag')
+      assert spec == mock_spec['spec']['containers']
+  def describe_overrides_spec():
+    def it_generates_spec(mocker, mock_ecr_class, mock_spec):
+      mocker.patch('hokusai.services.command_runner.ECR').side_effect = mock_ecr_class
+      mocker.patch('hokusai.services.command_runner.k8s_uuid', return_value = 'abcde')
+      runner = CommandRunner('staging')
+      spec = runner._overrides_spec('foocmd', ('fooconstraint=bar',), ('foo=bar',), 'footag')
+      assert spec == mock_spec['spec']
+  def describe_overrides():
+    def it_generates_spec(mocker, mock_ecr_class, mock_spec):
+      mocker.patch('hokusai.services.command_runner.ECR').side_effect = mock_ecr_class
+      mocker.patch('hokusai.services.command_runner.k8s_uuid', return_value = 'abcde')
+      runner = CommandRunner('staging')
+      spec = runner._overrides('foocmd', ('fooconstraint=bar',), ('foo=bar',), 'footag')
       assert spec == mock_spec

--- a/test/unit/test_services/test_command_runner.py
+++ b/test/unit/test_services/test_command_runner.py
@@ -11,19 +11,21 @@ from test.unit.test_services.fixtures.command_runner import mock_spec
 
 def describe_command_runner():
   def describe_init():
-    def it_inits(monkeypatch):
+    def it_inits(mocker, monkeypatch):
       monkeypatch.setenv('USER', 'foo')
+      mocker.patch('hokusai.services.command_runner.k8s_uuid', return_value = 'abcde')
       runner = CommandRunner('staging')
       assert runner.context == 'staging'
       assert type(runner.ecr) == ECR
-      assert '-hokusai-run-foo' in runner.pod_name
-      assert '-hokusai-run-foo' in runner.container_name
+      assert runner.pod_name == 'hello-hokusai-run-foo-abcde'
+      assert runner.container_name == 'hello-hokusai-run-foo-abcde'
   def describe_name():
     def it_returns_name(mocker, monkeypatch):
       monkeypatch.setenv('USER', 'foo')
+      mocker.patch('hokusai.services.command_runner.k8s_uuid', return_value = 'abcde')
       runner = CommandRunner('staging')
       spy = mocker.spy(hokusai.services.command_runner, 'k8s_uuid')
-      assert 'hello-hokusai-run-foo-' in runner._name()
+      assert runner._name() == 'hello-hokusai-run-foo-abcde'
       assert spy.call_count == 1
   def describe_image_name():
     def describe_separator_is_at_sign():

--- a/test/unit/test_services/test_command_runner.py
+++ b/test/unit/test_services/test_command_runner.py
@@ -36,7 +36,7 @@ def describe_command_runner():
         assert spy.call_count == 1
     def describe_user_unset_in_env():
       def it_returns_name(mocker, monkeypatch):
-        monkeypatch.delenv('USER')
+        monkeypatch.delenv('USER', raising=False)
         mocker.patch('hokusai.services.command_runner.k8s_uuid', return_value = 'abcde')
         runner = CommandRunner('staging')
         spy = mocker.spy(hokusai.services.command_runner, 'k8s_uuid')

--- a/test/unit/test_services/test_command_runner.py
+++ b/test/unit/test_services/test_command_runner.py
@@ -62,3 +62,13 @@ def describe_command_runner():
           }
         ]
       }
+  def describe_append_constraint():
+    def it_sets():
+      runner = CommandRunner('staging')
+      spec = runner._append_constraint({}, ('foo=bar',))
+      assert spec == {'nodeSelector': {'foo': 'bar'}}
+    def it_overwrites():
+      runner = CommandRunner('staging')
+      spec = {'nodeSelector': {'foo': 'bar'}}
+      spec = runner._append_constraint(spec, ('bar=foo',))
+      assert spec == {'nodeSelector': {'bar': 'foo'}}

--- a/test/unit/test_services/test_command_runner.py
+++ b/test/unit/test_services/test_command_runner.py
@@ -33,3 +33,13 @@ def describe_command_runner():
         mocker.patch('hokusai.services.command_runner.ECR').side_effect = mock_ecr_class
         runner = CommandRunner('staging')
         assert runner._image_name('123:456') == 'foo@123:456'
+  def describe_set_env():
+    def it_sets():
+      runner = CommandRunner('staging')
+      spec = runner._set_env({}, ('foo=bar',))
+      assert spec == {'env': [{'name': 'foo', 'value': 'bar'}]}
+    def it_overwrites():
+      runner = CommandRunner('staging')
+      spec = {'env': [{'name': 'foo', 'value': 'bar'}]}
+      spec = runner._set_env(spec, ('bar=foo',))
+      assert spec == {'env': [{'name': 'bar', 'value': 'foo'}]}

--- a/test/unit/test_services/test_command_runner.py
+++ b/test/unit/test_services/test_command_runner.py
@@ -26,13 +26,22 @@ def describe_command_runner():
       assert runner.container_name == 'hello-hokusai-run-foo-abcde'
 
   def describe_name():
-    def it_returns_name(mocker, monkeypatch):
-      monkeypatch.setenv('USER', 'foo')
-      mocker.patch('hokusai.services.command_runner.k8s_uuid', return_value = 'abcde')
-      runner = CommandRunner('staging')
-      spy = mocker.spy(hokusai.services.command_runner, 'k8s_uuid')
-      assert runner._name() == 'hello-hokusai-run-foo-abcde'
-      assert spy.call_count == 1
+    def describe_user_set_in_env():
+      def it_returns_name(mocker, monkeypatch):
+        monkeypatch.setenv('USER', 'foo')
+        mocker.patch('hokusai.services.command_runner.k8s_uuid', return_value = 'abcde')
+        runner = CommandRunner('staging')
+        spy = mocker.spy(hokusai.services.command_runner, 'k8s_uuid')
+        assert runner._name() == 'hello-hokusai-run-foo-abcde'
+        assert spy.call_count == 1
+    def describe_user_unset_in_env():
+      def it_returns_name(mocker, monkeypatch):
+        monkeypatch.delenv('USER')
+        mocker.patch('hokusai.services.command_runner.k8s_uuid', return_value = 'abcde')
+        runner = CommandRunner('staging')
+        spy = mocker.spy(hokusai.services.command_runner, 'k8s_uuid')
+        assert runner._name() == 'hello-hokusai-run-abcde'
+        assert spy.call_count == 1
 
   def describe_image_name():
     def describe_tag_has_no_colon():

--- a/test/unit/test_services/test_command_runner.py
+++ b/test/unit/test_services/test_command_runner.py
@@ -114,13 +114,13 @@ def describe_command_runner():
       spec = runner._overrides_container('foocmd', ('foo=bar',), 'footag')
       assert spec == mock_spec['spec']['containers'][0]
 
-  def describe_overrrides_containers():
+  def describe_overrides_containers():
     def it_generates_spec(mocker, mock_ecr_class, mock_spec, monkeypatch):
       monkeypatch.setenv('USER', 'foouser')
       mocker.patch('hokusai.services.command_runner.ECR').side_effect = mock_ecr_class
       mocker.patch('hokusai.services.command_runner.k8s_uuid', return_value = 'abcde')
       runner = CommandRunner('staging')
-      spec = runner._overrrides_containers('foocmd', ('foo=bar',), 'footag')
+      spec = runner._overrides_containers('foocmd', ('foo=bar',), 'footag')
       assert spec == mock_spec['spec']['containers']
 
   def describe_overrides_spec():

--- a/test/unit/test_services/test_command_runner.py
+++ b/test/unit/test_services/test_command_runner.py
@@ -21,3 +21,22 @@ def describe_command_runner():
       spy = mocker.spy(hokusai.services.command_runner, 'k8s_uuid')
       assert 'hello-hokusai-run-foo-' in runner._name()
       assert spy.call_count == 1
+  def describe_image_name():
+    def describe_separator_is_at_sign():
+      def it_does_not_add_at_sign(mocker):
+        class mock_ECR:
+          def __init__(self):
+            self.project_repo = 'foo'
+            pass
+        mocker.patch('hokusai.services.command_runner.ECR').side_effect = mock_ECR
+        runner = CommandRunner('staging')
+        assert runner._image_name('123') == 'foo:123'
+    def describe_separator_is_colon():
+      def it_adds_at_sign(mocker):
+        class mock_ECR:
+          def __init__(self):
+            self.project_repo = 'foo'
+            pass
+        mocker.patch('hokusai.services.command_runner.ECR').side_effect = mock_ECR
+        runner = CommandRunner('staging')
+        assert runner._image_name('123:456') == 'foo@123:456'

--- a/test/unit/test_services/test_command_runner.py
+++ b/test/unit/test_services/test_command_runner.py
@@ -1,14 +1,23 @@
 import os
 
+import hokusai.services.command_runner
+
 from hokusai.services.command_runner import CommandRunner
 from hokusai.services.ecr import ECR
 
 def describe_command_runner():
   def describe_init():
-    def it_inits():
-      os.environ['USER'] = 'foo'
+    def it_inits(monkeypatch):
+      monkeypatch.setenv('USER', 'foo')
       runner = CommandRunner('staging')
       assert runner.context == 'staging'
       assert type(runner.ecr) == ECR
       assert '-hokusai-run-foo' in runner.pod_name
       assert '-hokusai-run-foo' in runner.container_name
+  def describe_name():
+    def it_returns_name(mocker, monkeypatch):
+      monkeypatch.setenv('USER', 'foo')
+      runner = CommandRunner('staging')
+      spy = mocker.spy(hokusai.services.command_runner, 'k8s_uuid')
+      assert 'hello-hokusai-run-foo-' in runner._name()
+      assert spy.call_count == 1

--- a/test/unit/test_services/test_command_runner.py
+++ b/test/unit/test_services/test_command_runner.py
@@ -24,6 +24,7 @@ def describe_command_runner():
       assert type(runner.ecr) == ECR
       assert runner.pod_name == 'hello-hokusai-run-foo-abcde'
       assert runner.container_name == 'hello-hokusai-run-foo-abcde'
+
   def describe_name():
     def it_returns_name(mocker, monkeypatch):
       monkeypatch.setenv('USER', 'foo')
@@ -32,17 +33,19 @@ def describe_command_runner():
       spy = mocker.spy(hokusai.services.command_runner, 'k8s_uuid')
       assert runner._name() == 'hello-hokusai-run-foo-abcde'
       assert spy.call_count == 1
+
   def describe_image_name():
-    def describe_separator_is_at_sign():
-      def it_does_not_add_at_sign(mocker, mock_ecr_class):
+    def describe_tag_has_no_colon():
+      def it_uses_colon_as_separator(mocker, mock_ecr_class):
         mocker.patch('hokusai.services.command_runner.ECR').side_effect = mock_ecr_class
         runner = CommandRunner('staging')
         assert runner._image_name('123') == 'foo:123'
-    def describe_separator_is_colon():
-      def it_adds_at_sign(mocker, mock_ecr_class):
+    def describe_tag_has_colon():
+      def it_uses_at_sign_as_separator(mocker, mock_ecr_class):
         mocker.patch('hokusai.services.command_runner.ECR').side_effect = mock_ecr_class
         runner = CommandRunner('staging')
         assert runner._image_name('123:456') == 'foo@123:456'
+
   def describe_set_env():
     def it_sets():
       runner = CommandRunner('staging')
@@ -77,6 +80,7 @@ def describe_command_runner():
           }
         ]
       }
+
   def describe_set_constraint():
     def it_sets():
       runner = CommandRunner('staging')
@@ -91,6 +95,7 @@ def describe_command_runner():
       with pytest.raises(HokusaiError):
         runner = CommandRunner('staging')
         runner._set_constraint({}, ('foo bar',))
+
   def describe_overrides_container():
     def it_generates_spec(mocker, mock_ecr_class, mock_spec):
       mocker.patch('hokusai.services.command_runner.ECR').side_effect = mock_ecr_class
@@ -98,6 +103,7 @@ def describe_command_runner():
       runner = CommandRunner('staging')
       spec = runner._overrides_container('foocmd', ('foo=bar',), 'footag')
       assert spec == mock_spec['spec']['containers'][0]
+
   def describe_overrrides_containers():
     def it_generates_spec(mocker, mock_ecr_class, mock_spec):
       mocker.patch('hokusai.services.command_runner.ECR').side_effect = mock_ecr_class
@@ -105,6 +111,7 @@ def describe_command_runner():
       runner = CommandRunner('staging')
       spec = runner._overrrides_containers('foocmd', ('foo=bar',), 'footag')
       assert spec == mock_spec['spec']['containers']
+
   def describe_overrides_spec():
     def it_generates_spec(mocker, mock_ecr_class, mock_spec):
       mocker.patch('hokusai.services.command_runner.ECR').side_effect = mock_ecr_class
@@ -112,6 +119,7 @@ def describe_command_runner():
       runner = CommandRunner('staging')
       spec = runner._overrides_spec('foocmd', ('fooconstraint=bar',), ('foo=bar',), 'footag')
       assert spec == mock_spec['spec']
+
   def describe_overrides():
     def it_generates_spec(mocker, mock_ecr_class, mock_spec):
       mocker.patch('hokusai.services.command_runner.ECR').side_effect = mock_ecr_class
@@ -119,6 +127,7 @@ def describe_command_runner():
       runner = CommandRunner('staging')
       spec = runner._overrides('foocmd', ('fooconstraint=bar',), ('foo=bar',), 'footag')
       assert spec == mock_spec
+
   def describe_run_no_tty():
     def it_runs(mocker, mock_ecr_class, mock_spec, monkeypatch):
       monkeypatch.setenv('USER', 'foo')
@@ -135,6 +144,7 @@ def describe_command_runner():
           '--restart=Never --rm'
         )
       ])
+
   def describe_run_tty():
     def it_runs(mocker, mock_ecr_class, mock_tty_spec, monkeypatch):
       monkeypatch.setenv('USER', 'foo')
@@ -152,6 +162,7 @@ def describe_command_runner():
           f'--rm'
         )
       ])
+
   def describe_run():
     def describe_tty():
       def it_runs(mocker, mock_ecr_class, mock_spec):

--- a/test/unit/test_services/test_command_runner.py
+++ b/test/unit/test_services/test_command_runner.py
@@ -106,7 +106,7 @@ def describe_command_runner():
         runner._set_constraint({}, ('foo bar',))
 
   def describe_overrides_container():
-    def it_generates_spec(mocker, mock_ecr_class, mock_spec):
+    def it_generates_spec(mocker, mock_ecr_class, mock_spec, monkeypatch):
       monkeypatch.setenv('USER', 'foouser')
       mocker.patch('hokusai.services.command_runner.ECR').side_effect = mock_ecr_class
       mocker.patch('hokusai.services.command_runner.k8s_uuid', return_value = 'abcde')
@@ -115,7 +115,7 @@ def describe_command_runner():
       assert spec == mock_spec['spec']['containers'][0]
 
   def describe_overrrides_containers():
-    def it_generates_spec(mocker, mock_ecr_class, mock_spec):
+    def it_generates_spec(mocker, mock_ecr_class, mock_spec, monkeypatch):
       monkeypatch.setenv('USER', 'foouser')
       mocker.patch('hokusai.services.command_runner.ECR').side_effect = mock_ecr_class
       mocker.patch('hokusai.services.command_runner.k8s_uuid', return_value = 'abcde')
@@ -124,7 +124,7 @@ def describe_command_runner():
       assert spec == mock_spec['spec']['containers']
 
   def describe_overrides_spec():
-    def it_generates_spec(mocker, mock_ecr_class, mock_spec):
+    def it_generates_spec(mocker, mock_ecr_class, mock_spec, monkeypatch):
       monkeypatch.setenv('USER', 'foouser')
       mocker.patch('hokusai.services.command_runner.ECR').side_effect = mock_ecr_class
       mocker.patch('hokusai.services.command_runner.k8s_uuid', return_value = 'abcde')
@@ -133,7 +133,7 @@ def describe_command_runner():
       assert spec == mock_spec['spec']
 
   def describe_overrides():
-    def it_generates_spec(mocker, mock_ecr_class, mock_spec):
+    def it_generates_spec(mocker, mock_ecr_class, mock_spec, monkeypatch):
       monkeypatch.setenv('USER', 'foouser')
       mocker.patch('hokusai.services.command_runner.ECR').side_effect = mock_ecr_class
       mocker.patch('hokusai.services.command_runner.k8s_uuid', return_value = 'abcde')
@@ -178,7 +178,8 @@ def describe_command_runner():
 
   def describe_run():
     def describe_tty():
-      def it_runs(mocker, mock_ecr_class, mock_spec):
+      def it_runs(mocker, mock_ecr_class, mock_spec, monkeypatch):
+        monkeypatch.setenv('USER', 'foouser')
         mocker.patch('hokusai.services.command_runner.k8s_uuid', return_value = 'abcde')
         mocker.patch('hokusai.services.command_runner.ECR').side_effect = mock_ecr_class
         runner = CommandRunner('staging')
@@ -194,7 +195,8 @@ def describe_command_runner():
           )
         ])
     def describe_no_tty():
-      def it_runs(mocker, mock_ecr_class, mock_spec):
+      def it_runs(mocker, mock_ecr_class, mock_spec, monkeypatch):
+        monkeypatch.setenv('USER', 'foouser')
         mocker.patch('hokusai.services.command_runner.k8s_uuid', return_value = 'abcde')
         mocker.patch('hokusai.services.command_runner.ECR').side_effect = mock_ecr_class
         runner = CommandRunner('staging')

--- a/test/unit/test_services/test_command_runner.py
+++ b/test/unit/test_services/test_command_runner.py
@@ -17,22 +17,22 @@ from test.unit.test_services.fixtures.command_runner import (
 def describe_command_runner():
   def describe_init():
     def it_inits(mocker, monkeypatch):
-      monkeypatch.setenv('USER', 'foo')
+      monkeypatch.setenv('USER', 'foouser')
       mocker.patch('hokusai.services.command_runner.k8s_uuid', return_value = 'abcde')
       runner = CommandRunner('staging')
       assert runner.context == 'staging'
       assert type(runner.ecr) == ECR
-      assert runner.pod_name == 'hello-hokusai-run-foo-abcde'
-      assert runner.container_name == 'hello-hokusai-run-foo-abcde'
+      assert runner.pod_name == 'hello-hokusai-run-foouser-abcde'
+      assert runner.container_name == 'hello-hokusai-run-foouser-abcde'
 
   def describe_name():
     def describe_user_set_in_env():
       def it_returns_name(mocker, monkeypatch):
-        monkeypatch.setenv('USER', 'foo')
+        monkeypatch.setenv('USER', 'foouser')
         mocker.patch('hokusai.services.command_runner.k8s_uuid', return_value = 'abcde')
         runner = CommandRunner('staging')
         spy = mocker.spy(hokusai.services.command_runner, 'k8s_uuid')
-        assert runner._name() == 'hello-hokusai-run-foo-abcde'
+        assert runner._name() == 'hello-hokusai-run-foouser-abcde'
         assert spy.call_count == 1
     def describe_user_unset_in_env():
       def it_returns_name(mocker, monkeypatch):
@@ -107,6 +107,7 @@ def describe_command_runner():
 
   def describe_overrides_container():
     def it_generates_spec(mocker, mock_ecr_class, mock_spec):
+      monkeypatch.setenv('USER', 'foouser')
       mocker.patch('hokusai.services.command_runner.ECR').side_effect = mock_ecr_class
       mocker.patch('hokusai.services.command_runner.k8s_uuid', return_value = 'abcde')
       runner = CommandRunner('staging')
@@ -115,6 +116,7 @@ def describe_command_runner():
 
   def describe_overrrides_containers():
     def it_generates_spec(mocker, mock_ecr_class, mock_spec):
+      monkeypatch.setenv('USER', 'foouser')
       mocker.patch('hokusai.services.command_runner.ECR').side_effect = mock_ecr_class
       mocker.patch('hokusai.services.command_runner.k8s_uuid', return_value = 'abcde')
       runner = CommandRunner('staging')
@@ -123,6 +125,7 @@ def describe_command_runner():
 
   def describe_overrides_spec():
     def it_generates_spec(mocker, mock_ecr_class, mock_spec):
+      monkeypatch.setenv('USER', 'foouser')
       mocker.patch('hokusai.services.command_runner.ECR').side_effect = mock_ecr_class
       mocker.patch('hokusai.services.command_runner.k8s_uuid', return_value = 'abcde')
       runner = CommandRunner('staging')
@@ -131,6 +134,7 @@ def describe_command_runner():
 
   def describe_overrides():
     def it_generates_spec(mocker, mock_ecr_class, mock_spec):
+      monkeypatch.setenv('USER', 'foouser')
       mocker.patch('hokusai.services.command_runner.ECR').side_effect = mock_ecr_class
       mocker.patch('hokusai.services.command_runner.k8s_uuid', return_value = 'abcde')
       runner = CommandRunner('staging')
@@ -139,7 +143,7 @@ def describe_command_runner():
 
   def describe_run_no_tty():
     def it_runs(mocker, mock_ecr_class, mock_spec, monkeypatch):
-      monkeypatch.setenv('USER', 'foo')
+      monkeypatch.setenv('USER', 'foouser')
       mocker.patch('hokusai.services.command_runner.k8s_uuid', return_value = 'abcde')
       mocker.patch('hokusai.services.command_runner.ECR').side_effect = mock_ecr_class
       mocker.patch('hokusai.services.command_runner.returncode', return_value=0)
@@ -148,7 +152,7 @@ def describe_command_runner():
       runner._run_no_tty('foocmd', 'imagex', mock_spec)
       spy.assert_has_calls([
         mocker.call(
-          f'run hello-hokusai-run-foo-abcde --attach --image=imagex ' +
+          f'run hello-hokusai-run-foouser-abcde --attach --image=imagex ' +
           f'--overrides={pipes.quote(json.dumps(mock_spec))} ' +
           '--restart=Never --rm'
         )
@@ -156,7 +160,7 @@ def describe_command_runner():
 
   def describe_run_tty():
     def it_runs(mocker, mock_ecr_class, mock_tty_spec, monkeypatch):
-      monkeypatch.setenv('USER', 'foo')
+      monkeypatch.setenv('USER', 'foouser')
       mocker.patch('hokusai.services.command_runner.k8s_uuid', return_value = 'abcde')
       mocker.patch('hokusai.services.command_runner.ECR').side_effect = mock_ecr_class
       mocker.patch('hokusai.services.command_runner.shout', return_value=0)
@@ -165,7 +169,7 @@ def describe_command_runner():
       runner._run_tty('foocmd', 'imagex', mock_tty_spec)
       spy.assert_has_calls([
         mocker.call(
-          f'run hello-hokusai-run-foo-abcde -t -i --image=imagex ' +
+          f'run hello-hokusai-run-foouser-abcde -t -i --image=imagex ' +
           f'--restart=Never ' +
           f'--overrides={pipes.quote(json.dumps(mock_tty_spec))} ' +
           f'--rm'

--- a/test/unit/test_services/test_command_runner.py
+++ b/test/unit/test_services/test_command_runner.py
@@ -1,7 +1,9 @@
 import os
+import pytest
 
 import hokusai.services.command_runner
 
+from hokusai.lib.exceptions import HokusaiError
 from hokusai.services.command_runner import CommandRunner
 from hokusai.services.ecr import ECR
 from test.unit.test_services.fixtures.ecr import mock_ecr_class
@@ -43,6 +45,11 @@ def describe_command_runner():
       spec = {'env': [{'name': 'foo', 'value': 'bar'}]}
       spec = runner._set_env(spec, ('bar=foo',))
       assert spec == {'env': [{'name': 'bar', 'value': 'foo'}]}
+    def it_raises_on_bad_form():
+      with pytest.raises(HokusaiError):
+        runner = CommandRunner('staging')
+        runner._set_env({}, ('foo bar',))
+
   def describe_set_envfrom():
     def it_sets():
       runner = CommandRunner('staging')
@@ -72,3 +79,7 @@ def describe_command_runner():
       spec = {'nodeSelector': {'foo': 'bar'}}
       spec = runner._set_constraint(spec, ('bar=foo',))
       assert spec == {'nodeSelector': {'bar': 'foo'}}
+    def it_raises_on_bad_form():
+      with pytest.raises(HokusaiError):
+        runner = CommandRunner('staging')
+        runner._set_constraint({}, ('foo bar',))


### PR DESCRIPTION
[PHIRE-224]

- CommandRunner#run to load project's k8s secret if it exists. It does so by inserting a `secretRef` field when generating k8s container spec. The k8s secret may or may not exist, therefore, `optional: True` is also specified. CommandRunner#run is downstream to `hokusai staging/production/review_app run ...`, so with this in place, we will be able to [migrate a project's secrets from k8s configmap to Vault](https://artsyproduct.atlassian.net/browse/PHIRE-170?focusedCommentId=58698).

Related improvements:
- Currently, CommandRunner#run performs a bunch of tasks un-related to each other, and there are no unit tests, which makes updating scary. So:
  - Break down the function.
  - Move the following functions to lib, since they are not closely related to CommandRunner:
    - Obtaining user name from Env.
    - Validating key/value of Env var and nodeSelector constraint.
  - Add unit tests in Pytest format.

[PHIRE-224]: https://artsyproduct.atlassian.net/browse/PHIRE-224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ