### PR TITLE
fix: run no tty not return return code

### DIFF
--- a/hokusai/services/command_runner.py
+++ b/hokusai/services/command_runner.py
@@ -164,4 +164,4 @@ class CommandRunner:
     if run_tty:
       self._run_tty(cmd, image_name, overrides)
     else:
-      self._run_no_tty(cmd, image_name, overrides)
+      return self._run_no_tty(cmd, image_name, overrides)

--- a/test/unit/test_services/test_command_runner.py
+++ b/test/unit/test_services/test_command_runner.py
@@ -191,9 +191,9 @@ def describe_command_runner():
         mocker.patch('hokusai.services.command_runner.k8s_uuid', return_value = 'abcde')
         mocker.patch('hokusai.services.command_runner.ECR').side_effect = mock_ecr_class
         runner = CommandRunner('staging')
-        mocker.patch.object(runner, '_run_no_tty')
+        mocker.patch.object(runner, '_run_no_tty', return_value=0)
         spy = mocker.spy(runner, '_run_no_tty')
-        runner.run('footag', 'foocmd', tty=False, env=('foo=bar',), constraint=('fooconstraint=bar',))
+        returncode = runner.run('footag', 'foocmd', tty=False, env=('foo=bar',), constraint=('fooconstraint=bar',))
         assert spy.call_count == 1
         spy.assert_has_calls([
           mocker.call(
@@ -202,3 +202,4 @@ def describe_command_runner():
             mock_spec
           )
         ])
+        assert returncode == 0


### PR DESCRIPTION
"Run no TTY" used to return returncode, but in the last refactor I [accidentally dropped the `return`](https://github.com/artsy/hokusai/pull/376/files#diff-65944c1c179b582e64c48923af70c36689b944e535ceb7496f3345acf3bb25beL70). This PR adds it back.

This error manifested in a [Force build](https://app.circleci.com/pipelines/github/artsy/force/53601/workflows/bd2801af-dd23-4338-a2cd-9eccae8c778f/jobs/401306) where a failed pre-deploy step did not fail the builid ([more context](https://artsy.slack.com/archives/C02BC3HEJ/p1696839623025949)).

