### PR TITLE
fix: setuptools version too old for setuptools_scm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,6 +101,7 @@ jobs:
       - checkout
       - setup_remote_docker
       - run: apk add curl docker-cli git make
+      - run: pip install setuptools --upgrade
       - run: pip install setuptools_scm
       - run: make build-docker-image
 
@@ -148,6 +149,7 @@ jobs:
       - checkout
       - setup_remote_docker
       - run: apk add curl docker-cli git make
+      - run: pip install setuptools --upgrade
       - run: pip install setuptools_scm
       - run: make build-docker-image
       - run: echo "$DOCKERHUB_PASSWORD" | docker login --username "$DOCKERHUB_USERNAME" --password-stdin
@@ -252,6 +254,7 @@ jobs:
       - checkout
       - setup_remote_docker
       - run: apk add curl docker-cli git make
+      - run: pip install setuptools --upgrade
       - run: pip install setuptools_scm
       - run: scripts/create_release_tag.sh
       - run: make build-docker-image


### PR DESCRIPTION
Running setuptools_scm in Docker image build [fails with](https://app.circleci.com/pipelines/github/artsy/hokusai/1043/workflows/576755d9-7872-4903-85ce-aa37769b6256/jobs/4453):

```
python -m setuptools_scm
/usr/local/lib/python3.9/site-packages/setuptools_scm/_integration/setuptools.py:30: RuntimeWarning: 
ERROR: setuptools==58.1.0 is used in combination with setuptools_scm>=8.x
```

The build [pip installs setuptools_scm](https://github.com/artsy/hokusai/blob/b33c41c48674269b2b42ef8e8852157589341ba7/.circleci/config.yml#L104), gets v8. The error message suggests v8 requires a setuptools package version > 58.1.0, yet pip install does not bump setuptools accordingly. This suggests that this dependency requirement is present in setuptools_scm's code but not in its packaging, thus eluding Pip.

We will workaround this by upgrading setuptools first, then install setuptools_scm.

Tested in Alpine container:

```
/ # cat /etc/issue
Welcome to Alpine Linux 3.15
Kernel \r on an \m (\l)

/ # pip list | grep setuptools
setuptools        58.1.0
setuptools-scm    8.0.4

/ # pip install setuptools --upgrade
Requirement already satisfied: setuptools in /usr/local/lib/python3.9/site-packages (58.1.0)
Collecting setuptools
  Downloading setuptools-68.2.2-py3-none-any.whl (807 kB)
     |████████████████████████████████| 807 kB 4.2 MB/s
Installing collected packages: setuptools
  Attempting uninstall: setuptools
    Found existing installation: setuptools 58.1.0
    Uninstalling setuptools-58.1.0:
      Successfully uninstalled setuptools-58.1.0
Successfully installed setuptools-68.2.2

/ # git clone https://github.com:artsy/hokusai.git
Cloning into 'hokusai'...

/ # cd hokusai

/hokusai # python -m setuptools_scm
1.4.1.dev2+gb33c41c
```
