### PR TITLE
fix: setuptools_scm not writing _version.py

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,6 +103,7 @@ jobs:
       - run: apk add curl docker-cli git make
       - run: pip install setuptools --upgrade
       - run: pip install setuptools_scm
+      - run: pip install poetry
       - run: make build-docker-image
 
   release_beta_s3_linux:
@@ -151,6 +152,7 @@ jobs:
       - run: apk add curl docker-cli git make
       - run: pip install setuptools --upgrade
       - run: pip install setuptools_scm
+      - run: pip install poetry
       - run: make build-docker-image
       - run: echo "$DOCKERHUB_PASSWORD" | docker login --username "$DOCKERHUB_USERNAME" --password-stdin
       - run: make publish-to-dockerhub-beta
@@ -256,6 +258,7 @@ jobs:
       - run: apk add curl docker-cli git make
       - run: pip install setuptools --upgrade
       - run: pip install setuptools_scm
+      - run: pip install poetry
       - run: scripts/create_release_tag.sh
       - run: make build-docker-image
       - run: echo "$DOCKERHUB_PASSWORD" | docker login --username "$DOCKERHUB_USERNAME" --password-stdin

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,9 @@ publish-to-s3-canonical:
 	fi
 
 build-docker-image:
+	python -m setuptools_scm
 	poetry build
+	cat hokusai/_version.py
 	docker build . \
 	  --tag hokusai
 

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ publish-to-s3-canonical:
 	fi
 
 build-docker-image:
-	python -m setuptools_scm
+	poetry build
 	docker build . \
 	  --tag hokusai
 


### PR DESCRIPTION
Discovered that `python -m setuptools_scm` no longer respects [write_to](https://github.com/artsy/hokusai/blob/00af3b57fad769d57cfac77c95ad7dc5c5e8172c/pyproject.toml#L50), that is, it doesn't create `hokusai/_version.py` file anymore. We have to do `poetry build` now.