### PR TITLE
feat: hokusai review_app list command

### DIFF
--- a/hokusai/cli/review_app.py
+++ b/hokusai/cli/review_app.py
@@ -111,6 +111,14 @@ def deploy(app_name, tag, migration, constraint, git_remote, timeout, update_con
 
 
 @review_app.command(context_settings=CONTEXT_SETTINGS)
+@click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
+def list(verbose):
+  """List existing review apps of the project"""
+  set_verbosity(verbose)
+  hokusai.list_namespaces(KUBE_CONTEXT, labels=f'app-name={config.project_name},app-phase=review')
+
+
+@review_app.command(context_settings=CONTEXT_SETTINGS)
 @click.argument('app_name', type=click.STRING)
 @click.option('-d', '--deployment', type=click.STRING, help='Only refresh the given deployment')
 @click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')

--- a/hokusai/commands/__init__.py
+++ b/hokusai/commands/__init__.py
@@ -15,7 +15,7 @@ from hokusai.commands.pull import pull
 from hokusai.commands.run import run
 from hokusai.commands.setup import setup
 from hokusai.commands.kubernetes import k8s_create, k8s_update, k8s_delete, k8s_status, k8s_copy_config
-from hokusai.commands.namespace import create_new_app_yaml
+from hokusai.commands.namespace import create_new_app_yaml, list_namespaces
 from hokusai.commands.retag import retag
 from hokusai.commands.test import test
 from hokusai.commands.version import version

--- a/hokusai/commands/namespace.py
+++ b/hokusai/commands/namespace.py
@@ -1,14 +1,19 @@
 import os
-from collections import OrderedDict
+
+import json
 import yaml
+
+from collections import OrderedDict
 
 from hokusai import CWD
 from hokusai.lib.command import command
 from hokusai.lib.exceptions import HokusaiError
-from hokusai.lib.common import print_green, clean_string
+from hokusai.lib.common import print_green, clean_string, shout
+from hokusai.lib.config import HOKUSAI_CONFIG_DIR, config
 from hokusai.lib.constants import YAML_HEADER
-from hokusai.lib.config import HOKUSAI_CONFIG_DIR
+from hokusai.services.kubectl import Kubectl
 from hokusai.services.yaml_spec import YamlSpec
+
 
 @command()
 def create_new_app_yaml(source_file, app_name):
@@ -27,6 +32,7 @@ def create_new_app_yaml(source_file, app_name):
       ('metadata', {
         'name': clean_string(app_name),
         'labels': {
+          'app-name': config.project_name,
           'app-phase': 'review'
         }
       })
@@ -38,6 +44,13 @@ def create_new_app_yaml(source_file, app_name):
     yaml.safe_dump_all(yaml_content, output, default_flow_style=False)
 
   print_green("Created %s/%s.yml" % (HOKUSAI_CONFIG_DIR, app_name))
+
+def list_namespaces(context, labels=None):
+  ''' list Kubernetes namespaces that match the given labels '''
+  kctl = Kubectl(context)
+  namespaces = kctl.get_objects('namespaces', labels)
+  for ns in namespaces:
+    print(ns['metadata']['name'])
 
 def update_namespace(yaml_section, destination_namespace):
   if 'apiVersion' in yaml_section:

--- a/test/unit/test_commands/fixtures/kubectl.py
+++ b/test/unit/test_commands/fixtures/kubectl.py
@@ -1,0 +1,24 @@
+import pytest
+
+mock_namespaces_json = [
+  {
+    'metadata': {
+      'name': 'namespace1'
+    }
+  },
+  {
+    'metadata': {
+      'name': 'namespace2'
+    }
+  }
+]
+
+@pytest.fixture
+def mock_kubectl_obj():
+  class MockKubectl:
+    def __init__(self):
+      pass
+    def get_objects(self, obj, selector=None):
+      if obj == 'namespaces':
+        return mock_namespaces_json
+  return MockKubectl()

--- a/test/unit/test_commands/test_namespace.py
+++ b/test/unit/test_commands/test_namespace.py
@@ -1,0 +1,18 @@
+import hokusai.commands.namespace
+
+from hokusai.commands.namespace import list_namespaces
+
+from test.unit.test_commands.fixtures.kubectl import mock_kubectl_obj
+
+
+def describe_list_namespaces():
+  def it_lists(mocker, mock_kubectl_obj, capfd):
+    mocker.patch('hokusai.commands.namespace.Kubectl', return_value=mock_kubectl_obj)
+    spy = mocker.spy(mock_kubectl_obj, 'get_objects')
+    list_namespaces('staging', 'foo1=bar1')
+    assert spy.call_count == 1
+    spy.assert_has_calls([
+      mocker.call('namespaces', 'foo1=bar1')
+    ])
+    out, err = capfd.readouterr()
+    assert out == 'namespace1\nnamespace2\n'


### PR DESCRIPTION
Solves https://github.com/artsy/hokusai/issues/126

Introduce `hokusai review_app list` command which lists review apps of the project. It does so by listing Staging cluster namespaces that are labeled with:

- app-name=<...project-name...>
- app-phase=review

`app-phase` label is already being applied to review app namespaces. This PR introduces `app-name` label.

Example usage:
```
artsy:force jxu$ /Users/jxu/.pyenv/versions/hokusai/bin/hokusai review_app list
inbox2
```