### PR TITLE
fix: sed doesn't work in circleci mac build

### DIFF
--- a/scripts/update_version_file.sh
+++ b/scripts/update_version_file.sh
@@ -34,4 +34,5 @@ echo "Setting $VERSION in hokusai/VERSION file..."
 echo $VERSION > hokusai/VERSION
 
 echo "Setting $VERSION in pyproject.toml file tool.poetry.version field..."
+# use -i.bak so it works with CircleCI Mac's sed
 sed -i.bak "s/999\.999\.999/$VERSION/" pyproject.toml

--- a/scripts/update_version_file.sh
+++ b/scripts/update_version_file.sh
@@ -34,4 +34,4 @@ echo "Setting $VERSION in hokusai/VERSION file..."
 echo $VERSION > hokusai/VERSION
 
 echo "Setting $VERSION in pyproject.toml file tool.poetry.version field..."
-sed -i "s/999.999.999/$VERSION/" pyproject.toml
+sed -i.bak "s/999\.999\.999/$VERSION/" pyproject.toml


### PR DESCRIPTION
The Sed command does not work in [Mac build](https://app.circleci.com/pipelines/github/artsy/hokusai/1125/workflows/447fc776-40ca-4027-87a5-8e9bbea7fa98/jobs/4812?invite=true#step-107-183_66). CircleCI Mac instance's `sed` requires creating a backup file when editing a file in place, and a file extension must be supplied.

Change the Sed command to `sed -i.bak ...` which creates a `.bak` backup file.

It works in Linux too.