### PR TITLE
fix: naming conflict between command lib and command param

### DIFF
--- a/hokusai/cli/dev.py
+++ b/hokusai/cli/dev.py
@@ -71,17 +71,17 @@ def logs(follow, tail, filename, verbose):
 
 
 @dev.command(context_settings=CONTEXT_SETTINGS)
-@click.argument('command')
+@click.argument('container_command')
 @click.option('--service-name', type=click.STRING, help="The service name to launch the container as (default: the name 'project-name' in `hokusai/config.yml`)")
 @click.option('--stop', type=click.BOOL, is_flag=True, help='Stop all services after running the command')
 @click.option('-f', '--filename', type=click.STRING, help='Use the given docker-compose Yaml file (default ./hokusai/development.yml.j2)')
 @click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
-def run(command, service_name, stop, filename, verbose):
+def run(container_command, service_name, stop, filename, verbose):
   """Run a command in a new container in the development environment defined in ./hokusai/development.yml"""
   set_verbosity(verbose)
   command(
     hokusai.dev_run,
-    command,
+    container_command,
     service_name,
     stop,
     filename

--- a/hokusai/cli/production.py
+++ b/hokusai/cli/production.py
@@ -86,19 +86,19 @@ def status(resources, pods, describe, top, filename, verbose):
 
 
 @production.command(context_settings=CONTEXT_SETTINGS)
-@click.argument('command', type=click.STRING)
+@click.argument('container_command', type=click.STRING)
 @click.option('--tty', type=click.BOOL, is_flag=True, help='Attach the terminal')
 @click.option('--tag', type=click.STRING, help='The image tag to run (defaults to "production")')
 @click.option('--env', type=click.STRING, multiple=True, help='Environment variables in the form of "KEY=VALUE"')
 @click.option('--constraint', type=click.STRING, multiple=True, help='Constrain command to run on nodes matching labels in the form of "key=value"')
 @click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
-def run(command, tty, tag, env, constraint, verbose):
+def run(container_command, tty, tag, env, constraint, verbose):
   """Launch a new container and run a command"""
   set_verbosity(verbose)
   command(
     hokusai.run,
     KUBE_CONTEXT,
-    command,
+    container_command,
     tty,
     tag,
     env,

--- a/hokusai/cli/review_app.py
+++ b/hokusai/cli/review_app.py
@@ -96,13 +96,13 @@ def status(app_name, resources, pods, describe, top, verbose):
 
 @review_app.command(context_settings=CONTEXT_SETTINGS)
 @click.argument('app_name', type=click.STRING)
-@click.argument('command', type=click.STRING)
+@click.argument('container_command', type=click.STRING)
 @click.option('--tty', type=click.BOOL, is_flag=True, help='Attach the terminal')
 @click.option('--tag', type=click.STRING, help='The image tag to run (defaults to APP_NAME)')
 @click.option('--env', type=click.STRING, multiple=True, help='Environment variables in the form of "KEY=VALUE"')
 @click.option('--constraint', type=click.STRING, multiple=True, help='Constrain command to run on nodes matching labels in the form of "key=value"')
 @click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
-def run(app_name, command, tty, tag, env, constraint, verbose):
+def run(app_name, container_command, tty, tag, env, constraint, verbose):
   """Launch a new container and run a command"""
   set_verbosity(verbose)
   if tag is None:
@@ -110,7 +110,7 @@ def run(app_name, command, tty, tag, env, constraint, verbose):
   command(
     hokusai.run,
     KUBE_CONTEXT,
-    command,
+    container_command,
     tty,
     tag,
     env,

--- a/hokusai/cli/staging.py
+++ b/hokusai/cli/staging.py
@@ -86,19 +86,19 @@ def status(resources, pods, describe, top, filename, verbose):
 
 
 @staging.command(context_settings=CONTEXT_SETTINGS)
-@click.argument('command', type=click.STRING)
+@click.argument('container_command', type=click.STRING)
 @click.option('--tty', type=click.BOOL, is_flag=True, help='Attach the terminal')
 @click.option('--tag', type=click.STRING, help='The image tag to run (defaults to "staging")')
 @click.option('--env', type=click.STRING, multiple=True, help='Environment variables in the form of "KEY=VALUE"')
 @click.option('--constraint', type=click.STRING, multiple=True, help='Constrain command to run on nodes matching labels in the form of "key=value"')
 @click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
-def run(command, tty, tag, env, constraint, verbose):
+def run(container_command, tty, tag, env, constraint, verbose):
   """Launch a new container and run a command"""
   set_verbosity(verbose)
   command(
     hokusai.run,
     KUBE_CONTEXT,
-    command,
+    container_command,
     tty,
     tag,
     env,

--- a/hokusai/commands/development.py
+++ b/hokusai/commands/development.py
@@ -77,7 +77,7 @@ def dev_logs(follow, tail, filename):
 
   shout("COMPOSE_COMPATIBILITY=true docker-compose -f %s -p hokusai logs%s" % (docker_compose_yml, opts), print_output=True)
 
-def dev_run(command, service_name, stop, filename):
+def dev_run(container_command, service_name, stop, filename):
   if filename is None:
     yaml_template = TemplateSelector().get(os.path.join(CWD, HOKUSAI_CONFIG_DIR, DEVELOPMENT_YML_FILE))
   else:
@@ -89,7 +89,7 @@ def dev_run(command, service_name, stop, filename):
   if service_name is None:
     service_name = config.project_name
 
-  shout("COMPOSE_COMPATIBILITY=true docker-compose -f %s -p hokusai run %s %s" % (docker_compose_yml, service_name, command), print_output=True)
+  shout("COMPOSE_COMPATIBILITY=true docker-compose -f %s -p hokusai run %s %s" % (docker_compose_yml, service_name, container_command), print_output=True)
 
   if stop:
     shout("COMPOSE_COMPATIBILITY=true docker-compose -f %s -p hokusai stop" % docker_compose_yml, print_output=True)

--- a/hokusai/lib/command.py
+++ b/hokusai/lib/command.py
@@ -6,11 +6,11 @@ from hokusai.lib.common import print_red
 from hokusai.lib.exceptions import CalledProcessError, HokusaiError
 from hokusai.lib.config import config
 
-def command(command, *args, config_check=True, **kwargs):
+def command(container_command, *args, config_check=True, **kwargs):
   try:
     if config_check:
       config.check()
-    result = command(*args, **kwargs)
+    result = container_command(*args, **kwargs)
     if result is None:
       sys.exit(0)
     else:


### PR DESCRIPTION
[Discovered this naming conflict during local Beta testing](https://artsy.slack.com/archives/CA8SANW3W/p1704470007870669).

```
artsy:hokusai-sandbox jxu$ hokusai version
2.0.0+fd09bac
artsy:hokusai-sandbox jxu$ hokusai staging run --tty sh
Traceback (most recent call last):
  File "hokusai", line 15, in <module>
  File "click/core.py", line 1130, in __call__
  File "click/core.py", line 1055, in main
  File "click/core.py", line 1657, in invoke
  File "click/core.py", line 1657, in invoke
  File "click/core.py", line 1404, in invoke
  File "click/core.py", line 760, in invoke
  File "hokusai/cli/staging.py", line 98, in run
TypeError: 'str' object is not callable
[4334] Failed to execute script 'hokusai' due to unhandled exception!
```