### PR TITLE
fix: release_dockerhub CI step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ DIST_DIR ?= dist/
 PROJECT = github.com/artsy/hokusai
 VERSION ?= $(shell cat hokusai/VERSION)
 MINOR_VERSION ?= $(shell cat hokusai/VERSION | awk -F"." '{ print $$1"."$$2 }')
+RELEASE_MINOR_VERSION ?= $(shell cat hokusai/VERSION | awk -F"." '{ print $$1"."$$2 }')
 ARTIFACT_LABEL ?= $(shell cat hokusai/VERSION)
 BINARY_SUFFIX ?= -$(ARTIFACT_LABEL)-$(shell uname -s)-$(shell uname -m)
 


### PR DESCRIPTION
v2.1.0 [Dockerhub release](https://app.circleci.com/pipelines/github/artsy/hokusai/1198/workflows/63036c42-fc04-4743-9a25-da50696b9440/jobs/5119?invite=true#step-108-118_47) failed because `RELEASE_MINOR_VERSION` is missing in Makefile.

Add it back.