### PR TITLE
feat: use tmp_path fixture in pytest tests

### DIFF
--- a/test/unit/test_commands/test_configure.py
+++ b/test/unit/test_commands/test_configure.py
@@ -1,6 +1,5 @@
 import os
 import pytest
-import tempfile
 
 import hokusai.commands.configure
 
@@ -74,30 +73,30 @@ def describe_install():
       assert install_kubectl_spy.call_count == 0
 
 def describe_install_kubectl():
-  def it_calls_properly(mocker):
+  def it_calls_properly(mocker, tmp_path):
     mocker.patch('hokusai.commands.configure.urlretrieve')
     retrieve_spy = mocker.spy(hokusai.commands.configure, 'urlretrieve')
     mocker.patch('hokusai.commands.configure.local_to_local')
     local_to_local_spy = mocker.spy(hokusai.commands.configure, 'local_to_local')
-    with tempfile.TemporaryDirectory() as tmpdir:
-      mocker.patch('hokusai.commands.configure.tempfile.mkdtemp', return_value=tmpdir)
-      install_kubectl('fooversion', 'foodir')
-      url = f'https://storage.googleapis.com/kubernetes-release/release/vfooversion/bin/{get_platform()}/amd64/kubectl'
-      download_to = os.path.join(tmpdir, 'kubectl')
-      retrieve_spy.assert_has_calls([
-        mocker.call(
-          url,
-          download_to
-        )
-      ])
-      local_to_local_spy.assert_has_calls([
-        mocker.call(
-          download_to,
-          'foodir',
-          'kubectl',
-          mode=0o770
-        )
-      ])
+    mocker.patch('hokusai.commands.configure.tempfile.mkdtemp', return_value=tmp_path)
+    install_kubectl('fooversion', 'foodir')
+    url = f'https://storage.googleapis.com/kubernetes-release/release/vfooversion/bin/{get_platform()}/amd64/kubectl'
+    download_to = os.path.join(tmp_path, 'kubectl')
+    retrieve_spy.assert_has_calls([
+      mocker.call(
+        url,
+        download_to
+      )
+    ])
+    local_to_local_spy.assert_has_calls([
+      mocker.call(
+        download_to,
+        'foodir',
+        'kubectl',
+        mode=0o770
+      )
+    ])
+
   def it_catches_exceptions(mocker, mock_urlretrieve_raise):
     mocker.patch('hokusai.commands.configure.urlretrieve').side_effect = mock_urlretrieve_raise
     with pytest.raises(Exception):

--- a/test/unit/test_lib/test_common.py
+++ b/test/unit/test_lib/test_common.py
@@ -1,6 +1,5 @@
 import os
 import pytest
-import tempfile
 
 from datetime import datetime
 from pathlib import Path
@@ -25,114 +24,106 @@ def describe_local_to_local():
   def describe_source_exists():
     def describe_target_exists():
       def describe_it_is_a_dir():
-        def it_errors():
-          with tempfile.TemporaryDirectory() as tmpdir:
-            source = os.path.join(tmpdir, 'a.yml')
-            spath = Path(source)
-            spath.touch()
-            target = os.path.join(tmpdir, 'foodir')
-            tpath = Path(target)
-            tpath.mkdir()
-            with pytest.raises(HokusaiError):
-              local_to_local(source, tmpdir, 'foodir')
+        def it_errors(tmp_path):
+          source = os.path.join(tmp_path, 'a.yml')
+          spath = Path(source)
+          spath.touch()
+          target = os.path.join(tmp_path, 'foodir')
+          tpath = Path(target)
+          tpath.mkdir()
+          with pytest.raises(HokusaiError):
+            local_to_local(source, tmp_path, 'foodir')
       def describe_it_is_a_file():
-        def it_backs_up_file_and_copies():
-          with tempfile.TemporaryDirectory() as tmpdir:
-            source = os.path.join(tmpdir, 'a.yml')
-            spath = Path(source)
-            spath.touch()
-            target = os.path.join(tmpdir, 'b.yml')
-            tpath = Path(target)
-            tpath.touch()
-            utc_yyyymmdd = datetime.utcnow().strftime("%Y%m%d")
-            backup = os.path.join(tmpdir, f'b.yml.backup.{utc_yyyymmdd}')
-            bpath = Path(backup)
-            local_to_local(source, tmpdir, 'b.yml')
-            assert tpath.is_file()
-            assert bpath.is_file()
+        def it_backs_up_file_and_copies(tmp_path):
+          source = os.path.join(tmp_path, 'a.yml')
+          spath = Path(source)
+          spath.touch()
+          target = os.path.join(tmp_path, 'b.yml')
+          tpath = Path(target)
+          tpath.touch()
+          utc_yyyymmdd = datetime.utcnow().strftime("%Y%m%d")
+          backup = os.path.join(tmp_path, f'b.yml.backup.{utc_yyyymmdd}')
+          bpath = Path(backup)
+          local_to_local(source, tmp_path, 'b.yml')
+          assert tpath.is_file()
+          assert bpath.is_file()
     def describe_target_does_not_exist():
       def describe_target_dir_exists():
-        def it_copies_and_sets_default_mode():
-          with tempfile.TemporaryDirectory() as tmpdir:
-            source = os.path.join(tmpdir, 'a.yml')
-            spath = Path(source)
-            spath.touch()
-            target = os.path.join(tmpdir, 'b.yml')
-            local_to_local(source, tmpdir, 'b.yml')
-            tpath = Path(target)
-            assert tpath.is_file()
-            assert os.stat(target).st_mode == int(0o100660) # the leading 10 means regular file
-        def it_copies_and_sets_custom_mode():
-          with tempfile.TemporaryDirectory() as tmpdir:
-            source = os.path.join(tmpdir, 'a.yml')
-            spath = Path(source)
-            spath.touch()
-            target = os.path.join(tmpdir, 'b.yml')
-            local_to_local(source, tmpdir, 'b.yml', mode=0o111)
-            tpath = Path(target)
-            assert tpath.is_file()
-            assert os.stat(target).st_mode == int(0o100111) # the leading 10 means regular file
-        def it_copies_to_home_dir(monkeypatch):
-          with tempfile.TemporaryDirectory() as tmpdir:
-            source = os.path.join(tmpdir, 'a.yml')
-            spath = Path(source)
-            spath.touch()
-            home_dir = os.path.join(tmpdir, 'myhome')
-            monkeypatch.setenv('HOME', home_dir)
-            target = os.path.join(home_dir, 'subdir', 'b.yml')
-            local_to_local(source, '~/subdir', 'b.yml')
-            tpath = Path(target)
-            assert tpath.is_file()
-            assert os.stat(target).st_mode == int(0o100660) # the leading 10 means regular file
+        def it_copies_and_sets_default_mode(tmp_path):
+          source = os.path.join(tmp_path, 'a.yml')
+          spath = Path(source)
+          spath.touch()
+          target = os.path.join(tmp_path, 'b.yml')
+          local_to_local(source, tmp_path, 'b.yml')
+          tpath = Path(target)
+          assert tpath.is_file()
+          assert os.stat(target).st_mode == int(0o100660) # the leading 10 means regular file
+        def it_copies_and_sets_custom_mode(tmp_path):
+          source = os.path.join(tmp_path, 'a.yml')
+          spath = Path(source)
+          spath.touch()
+          target = os.path.join(tmp_path, 'b.yml')
+          local_to_local(source, tmp_path, 'b.yml', mode=0o111)
+          tpath = Path(target)
+          assert tpath.is_file()
+          assert os.stat(target).st_mode == int(0o100111) # the leading 10 means regular file
+        def it_copies_to_home_dir(monkeypatch, tmp_path):
+          source = os.path.join(tmp_path, 'a.yml')
+          spath = Path(source)
+          spath.touch()
+          home_dir = os.path.join(tmp_path, 'myhome')
+          monkeypatch.setenv('HOME', home_dir)
+          target = os.path.join(home_dir, 'subdir', 'b.yml')
+          local_to_local(source, '~/subdir', 'b.yml')
+          tpath = Path(target)
+          assert tpath.is_file()
+          assert os.stat(target).st_mode == int(0o100660) # the leading 10 means regular file
       def describe_target_dir_missing():
         def describe_create_target_dir_true():
-          def it_copies():
-            with tempfile.TemporaryDirectory() as tmpdir:
-              source = os.path.join(tmpdir, 'a.yml')
-              spath = Path(source)
-              spath.touch()
-              target = os.path.join(tmpdir, 'missing', 'b.yml')
-              local_to_local(source, os.path.join(tmpdir, 'missing'), 'b.yml')
-              tpath = Path(target)
-              assert tpath.is_file()
+          def it_copies(tmp_path):
+            source = os.path.join(tmp_path, 'a.yml')
+            spath = Path(source)
+            spath.touch()
+            target = os.path.join(tmp_path, 'missing', 'b.yml')
+            local_to_local(source, os.path.join(tmp_path, 'missing'), 'b.yml')
+            tpath = Path(target)
+            assert tpath.is_file()
         def describe_create_target_dir_false():
-          def it_errors():
-            with tempfile.TemporaryDirectory() as tmpdir:
-              source = os.path.join(tmpdir, 'a.yml')
-              spath = Path(source)
-              spath.touch()
-              with pytest.raises(FileNotFoundError):
-                local_to_local(source, os.path.join(tmpdir, 'missing'), 'b.yml', create_target_dir=False)
+          def it_errors(tmp_path):
+            source = os.path.join(tmp_path, 'a.yml')
+            spath = Path(source)
+            spath.touch()
+            with pytest.raises(FileNotFoundError):
+              local_to_local(source, os.path.join(tmp_path, 'missing'), 'b.yml', create_target_dir=False)
   def describe_source_non_existent():
-    def it_errors():
-      with tempfile.TemporaryDirectory() as tmpdir:
-        source = os.path.join(tmpdir, 'a.yml')
-        with pytest.raises(FileNotFoundError):
-          local_to_local(source, tmpdir, 'b.yml')
+    def it_errors(tmp_path):
+      source = os.path.join(tmp_path, 'a.yml')
+      with pytest.raises(FileNotFoundError):
+        local_to_local(source, tmp_path, 'b.yml')
 
 def describe_uri_to_local():
   def describe_s3_scheme():
-    def it_calls_s3_interface_download(mocker, mock_s3_interface_class):
+    def it_calls_s3_interface_download(mocker, mock_s3_interface_class, tmp_path):
       mocker.patch('hokusai.lib.common.S3Interface').side_effect = mock_s3_interface_class
       s3_spy = mocker.spy(test.unit.test_lib.fixtures.common, 'download_for_spy')
       mocker.patch('hokusai.lib.common.local_to_local')
       local_to_local_spy = mocker.spy(hokusai.lib.common, 'local_to_local')
-      with tempfile.TemporaryDirectory() as tmpdir:
-        mocker.patch('hokusai.lib.common.tempfile.mkdtemp', return_value=tmpdir)
-        uri_to_local('s3://foobucket/bar/file.txt', tmpdir, 'file.txt')
-        s3_spy.assert_has_calls([
-          mocker.call(
-            's3://foobucket/bar/file.txt',
-            os.path.join(tmpdir, 'downloaded_file')
-          )
-        ])
-        local_to_local_spy.assert_has_calls([
-          mocker.call(
-            os.path.join(tmpdir, 'downloaded_file'),
-            tmpdir,
-            'file.txt'
-          )
-        ])
+      mocker.patch('hokusai.lib.common.tempfile.mkdtemp', return_value=tmp_path)
+      uri_to_local('s3://foobucket/bar/file.txt', tmp_path, 'file.txt')
+      s3_spy.assert_has_calls([
+        mocker.call(
+          's3://foobucket/bar/file.txt',
+          os.path.join(tmp_path, 'downloaded_file')
+        )
+      ])
+      local_to_local_spy.assert_has_calls([
+        mocker.call(
+          os.path.join(tmp_path, 'downloaded_file'),
+          tmp_path,
+          'file.txt'
+        )
+      ])
+
   def describe_no_scheme():
     def it_calls_local_to_local(mocker):
       mocker.patch('hokusai.lib.common.local_to_local')

--- a/test/unit/test_lib/test_config_loader.py
+++ b/test/unit/test_lib/test_config_loader.py
@@ -1,6 +1,5 @@
 import os
 import pytest
-import tempfile
 
 import hokusai.lib.config_loader
 
@@ -23,27 +22,26 @@ def describe_config_loader():
 
   def describe_load():
     def describe_yaml_type():
-      def it_calls(mocker):
+      def it_calls(mocker, tmp_path):
         mocker.patch('hokusai.lib.config_loader.uri_to_local')
         uri_to_local_spy = mocker.spy(hokusai.lib.config_loader, 'uri_to_local')
         loader = ConfigLoader('file:///test/fixtures/template_config.yml')
         mocker.patch.object(loader, '_load_from_file')
         load_from_file_spy = mocker.spy(loader, '_load_from_file')
-        with tempfile.TemporaryDirectory() as tmpdir:
-          mocker.patch('tempfile.mkdtemp', return_value=tmpdir)
-          config = loader.load()
-          uri_to_local_spy.assert_has_calls([
-            mocker.call(
-              'file:///test/fixtures/template_config.yml',
-              tmpdir,
-              'hokusai.yml'
-            )
-          ])
-          load_from_file_spy.assert_has_calls([
-            mocker.call(
-              os.path.join(tmpdir, 'hokusai.yml')
-            )
-          ])
+        mocker.patch('tempfile.mkdtemp', return_value=tmp_path)
+        config = loader.load()
+        uri_to_local_spy.assert_has_calls([
+          mocker.call(
+            'file:///test/fixtures/template_config.yml',
+            tmp_path,
+            'hokusai.yml'
+          )
+        ])
+        load_from_file_spy.assert_has_calls([
+          mocker.call(
+            os.path.join(tmp_path, 'hokusai.yml')
+          )
+        ])
       def it_catches_exceptions(mocker, mock_uri_to_local_raise):
         mocker.patch('hokusai.lib.config_loader.uri_to_local').side_effect = mock_uri_to_local_raise
         loader = ConfigLoader('file:///test/fixtures/template_config.yml')

--- a/test/unit/test_lib/test_global_config.py
+++ b/test/unit/test_lib/test_global_config.py
@@ -1,6 +1,5 @@
 import os
 import pytest
-import tempfile
 import yaml
 
 import hokusai.lib.global_config
@@ -47,17 +46,16 @@ def describe_hokusai_global_config():
       assert config_obj._config['kubeconfig-source-uri'] == '/fake/path/to/kube/config'
 
   def describe_save():
-    def it_saves(monkeypatch):
+    def it_saves(monkeypatch, tmp_path):
       config_file = os.path.join(os.environ['HOME'], '.hokusai.yml')
       config_obj = HokusaiGlobalConfig()
       config_obj.merge(kubeconfig_dir='foodir')
-      with tempfile.TemporaryDirectory() as tmpdir:
-        file_path = os.path.join(tmpdir, '.hokusai.yml')
-        monkeypatch.setattr(hokusai.lib.global_config, "local_global_config", file_path)
-        config_obj.save()
-        with open(file_path, 'r') as f:
-          struct = yaml.safe_load(f.read())
-          assert struct['kubeconfig-dir'] == 'foodir'
+      file_path = os.path.join(tmp_path, '.hokusai.yml')
+      monkeypatch.setattr(hokusai.lib.global_config, "local_global_config", file_path)
+      config_obj.save()
+      with open(file_path, 'r') as f:
+        struct = yaml.safe_load(f.read())
+        assert struct['kubeconfig-dir'] == 'foodir'
 
   def describe_validate_config():
     def it_raises_when_required_var_missing():


### PR DESCRIPTION
Replace this clunky construct:

```
with tempfile.TemporaryDirectory() as tmpdir
```

with pytest's [tmp_path fixture](https://docs.pytest.org/en/7.1.x/how-to/tmp_path.html).