### PR TITLE
feat: minikube k8s can pull from ECR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,6 +107,27 @@ jobs:
             kubectl --context production version
             kubectl --context production cluster-info
       - run:
+          name: log into ECR
+          command: |
+            aws_account_id=$(aws sts get-caller-identity --query "Account" --output text)
+            aws ecr get-login-password --region "$AWS_DEFAULT_REGION" | \
+              docker login --username AWS \
+                --password-stdin ${aws_account_id}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com
+      - run:
+          name: setup regcred for staging minikube/k8s
+          command: |
+            kubectl --context staging create secret generic regcred \
+              --from-file=.dockerconfigjson=${HOME}/.docker/config.json \
+              --type=kubernetes.io/dockerconfigjson
+            kubectl --context staging patch serviceaccount default -p '{"imagePullSecrets": [{"name": "regcred"}]}'
+      - run:
+          name: setup regcred for production minikube/k8s
+          command: |
+            kubectl --context production create secret generic regcred \
+              --from-file=.dockerconfigjson=${HOME}/.docker/config.json \
+              --type=kubernetes.io/dockerconfigjson
+            kubectl --context production patch serviceaccount default -p '{"imagePullSecrets": [{"name": "regcred"}]}'
+      - run:
           name: fix RBAC
           command: |
             # make default account cluster-admin

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
       - image: python:3.9.10
     steps:
       - checkout
-      - run: make dependencies
+      - run: make hokusai
       - run: make test
       - run: coverage report
       - run: make pyinstaller-build-onefile ARTIFACT_LABEL=beta
@@ -32,7 +32,7 @@ jobs:
           command: |
             curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"
             sudo installer -pkg AWSCLIV2.pkg -target /
-      - run: make dependencies
+      - run: make hokusai
       - run: pyenv rehash
       - run: make test
       - run: coverage report
@@ -121,7 +121,7 @@ jobs:
           command: |
             cp test/integration/fixtures/ci_hokusai_global_config.yml ${HOME}/.hokusai.yml
       - run: pyenv local 3.10.2
-      - run: make dependencies
+      - run: make hokusai
       - run: pyenv rehash
       - run: make integration
       - run: coverage report
@@ -143,7 +143,7 @@ jobs:
       - checkout
       - run: apt-get -qq update
       - run: apt-get -qq install awscli
-      - run: make dependencies
+      - run: make hokusai
       - run: scripts/update_version_file.sh
       - run: make pyinstaller-build-onefile ARTIFACT_LABEL=beta
       - run: make publish-to-s3 ARTIFACT_LABEL=beta
@@ -169,7 +169,7 @@ jobs:
           command: |
             curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"
             sudo installer -pkg AWSCLIV2.pkg -target /
-      - run: make dependencies
+      - run: make hokusai
       - run: pyenv rehash
       - run: scripts/update_version_file.sh
       - run: make pyinstaller-build-onedir ARTIFACT_LABEL=beta
@@ -244,7 +244,7 @@ jobs:
       - checkout
       - run: apt-get -qq update
       - run: apt-get -qq install awscli
-      - run: make dependencies
+      - run: make hokusai
       - run: scripts/update_version_file.sh
       - run: make pyinstaller-build-onefile ARTIFACT_LABEL=$(cat hokusai/VERSION)
       - run: make pyinstaller-build-onefile ARTIFACT_LABEL=latest
@@ -272,7 +272,7 @@ jobs:
           command: |
             curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"
             sudo installer -pkg AWSCLIV2.pkg -target /
-      - run: make dependencies
+      - run: make hokusai
       - run: pyenv rehash
       - run: scripts/update_version_file.sh
       - run: make pyinstaller-build-onedir ARTIFACT_LABEL=$(cat hokusai/VERSION)
@@ -309,7 +309,7 @@ jobs:
       - image: python:3.9.10
     steps:
       - checkout
-      - run: make dependencies
+      - run: make hokusai
       - run: scripts/update_version_file.sh
       - run: make publish-to-pip
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,6 +87,7 @@ jobs:
             done
             kubectl --context staging version
             kubectl --context staging cluster-info
+            kubectl --context staging get pods --all-namespaces
       - run:
           name: start production minikube cluster
           command: |
@@ -106,6 +107,7 @@ jobs:
             done
             kubectl --context production version
             kubectl --context production cluster-info
+            kubectl --context production get pods --all-namespaces
       - run:
           name: log into ECR
           command: |
@@ -127,11 +129,6 @@ jobs:
               --from-file=.dockerconfigjson=${HOME}/.docker/config.json \
               --type=kubernetes.io/dockerconfigjson
             kubectl --context production patch serviceaccount default -p '{"imagePullSecrets": [{"name": "regcred"}]}'
-      - run:
-          name: dump cluster-info
-          command: |
-            kubectl cluster-info
-            kubectl get pods --all-namespaces
       - run:
           name: setup hokusai global config file
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,11 +128,6 @@ jobs:
               --type=kubernetes.io/dockerconfigjson
             kubectl --context production patch serviceaccount default -p '{"imagePullSecrets": [{"name": "regcred"}]}'
       - run:
-          name: fix RBAC
-          command: |
-            # make default account cluster-admin
-            kubectl create clusterrolebinding add-on-cluster-admin --clusterrole cluster-admin --serviceaccount=kube-system:default
-      - run:
           name: dump cluster-info
           command: |
             kubectl cluster-info

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dependencies test integration integration-local pyinstaller-build-onefile pyinstaller-build-onedir publish-to-s3 publish-to-s3-canonical build-docker-image publish-to-dockerhub-beta publish-to-dockerhub-canonical-and-latest publish-to-pip publish-to-github clean
+.PHONY: hokusai test integration integration-local pyinstaller-build-onefile pyinstaller-build-onedir publish-to-s3 publish-to-s3-canonical build-docker-image publish-to-dockerhub-beta publish-to-dockerhub-canonical-and-latest publish-to-pip publish-to-github clean
 
 # a var passed in as an argument to 'make' command moots its ?= assgiment
 AWS ?= $(shell which aws)
@@ -10,7 +10,7 @@ RELEASE_MINOR_VERSION ?= $(shell cat hokusai/VERSION | awk -F"." '{ print $$1"."
 ARTIFACT_LABEL ?= $(shell cat hokusai/VERSION)
 BINARY_SUFFIX ?= -$(ARTIFACT_LABEL)-$(shell uname -s)-$(shell uname -m)
 
-dependencies:
+hokusai:
 	pip install --upgrade pip
 	# pin version due to https://github.com/python-poetry/poetry/issues/7184
 	pip install poetry==1.2.2 --quiet --ignore-installed

--- a/poetry.lock
+++ b/poetry.lock
@@ -953,31 +953,6 @@ files = [
 ]
 
 [[package]]
-name = "nh3"
-version = "0.2.15"
-description = "Python bindings to the ammonia HTML sanitization library."
-optional = false
-python-versions = "*"
-files = [
-    {file = "nh3-0.2.15-cp37-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:9c0d415f6b7f2338f93035bba5c0d8c1b464e538bfbb1d598acd47d7969284f0"},
-    {file = "nh3-0.2.15-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:6f42f99f0cf6312e470b6c09e04da31f9abaadcd3eb591d7d1a88ea931dca7f3"},
-    {file = "nh3-0.2.15-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ac19c0d68cd42ecd7ead91a3a032fdfff23d29302dbb1311e641a130dfefba97"},
-    {file = "nh3-0.2.15-cp37-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5f0d77272ce6d34db6c87b4f894f037d55183d9518f948bba236fe81e2bb4e28"},
-    {file = "nh3-0.2.15-cp37-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:8d595df02413aa38586c24811237e95937ef18304e108b7e92c890a06793e3bf"},
-    {file = "nh3-0.2.15-cp37-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:86e447a63ca0b16318deb62498db4f76fc60699ce0a1231262880b38b6cff911"},
-    {file = "nh3-0.2.15-cp37-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3277481293b868b2715907310c7be0f1b9d10491d5adf9fce11756a97e97eddf"},
-    {file = "nh3-0.2.15-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:60684857cfa8fdbb74daa867e5cad3f0c9789415aba660614fe16cd66cbb9ec7"},
-    {file = "nh3-0.2.15-cp37-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:3b803a5875e7234907f7d64777dfde2b93db992376f3d6d7af7f3bc347deb305"},
-    {file = "nh3-0.2.15-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:0d02d0ff79dfd8208ed25a39c12cbda092388fff7f1662466e27d97ad011b770"},
-    {file = "nh3-0.2.15-cp37-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:f3b53ba93bb7725acab1e030bc2ecd012a817040fd7851b332f86e2f9bb98dc6"},
-    {file = "nh3-0.2.15-cp37-abi3-musllinux_1_2_i686.whl", hash = "sha256:b1e97221cedaf15a54f5243f2c5894bb12ca951ae4ddfd02a9d4ea9df9e1a29d"},
-    {file = "nh3-0.2.15-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a5167a6403d19c515217b6bcaaa9be420974a6ac30e0da9e84d4fc67a5d474c5"},
-    {file = "nh3-0.2.15-cp37-abi3-win32.whl", hash = "sha256:427fecbb1031db085eaac9931362adf4a796428ef0163070c484b5a768e71601"},
-    {file = "nh3-0.2.15-cp37-abi3-win_amd64.whl", hash = "sha256:bc2d086fb540d0fa52ce35afaded4ea526b8fc4d3339f783db55c95de40ef02e"},
-    {file = "nh3-0.2.15.tar.gz", hash = "sha256:d1e30ff2d8d58fb2a14961f7aac1bbb1c51f9bdd7da727be35c63826060b0bf3"},
-]
-
-[[package]]
 name = "packaging"
 version = "21.3"
 description = "Core utilities for Python packages"
@@ -1839,4 +1814,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.11"
-content-hash = "5d3f83a12a32317a07f0b8f87c808a1bef3a5e34ff197f465434a3bd8f7a3aaf"
+content-hash = "953e6ce333df6b226d783cd8fa5c0076368c066786ee7f731d2927ae037d5ab1"

--- a/scripts/integration_test_local.sh
+++ b/scripts/integration_test_local.sh
@@ -1,13 +1,30 @@
-# run integration tests locally
+### run integration tests locally
+
+
+## requirements
+
+# - awscli
+# - coverage
+# - docker
+# - jq
+# - kubectl
+# - minikube
+# - pytest
+
+
+## prepare env
 
 export K8S_VERSION=v1.21.14
 export KUBE_CONFIG_PATH=${HOME}/.kube/config
 export KUBE_CONFIG_BACKUP_PATH=${HOME}/.kube/config.bak
-export BACKED_UP_KUBE_CONFIG=false
 export AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query "Account" --output text)
 export AWS_REGION=$(aws configure get region)
+export DOCKER_CONFIG_JSON_PATH=${HOME}/.docker/config.json
 
-function start_minikube(){
+
+## functions
+
+function start_minikube() {
   profile=$1
   minikube delete --profile "$profile"
   minikube start --profile "$profile" --kubernetes-version="$K8S_VERSION"
@@ -17,42 +34,82 @@ function start_minikube(){
   done
 }
 
-if ls "$KUBE_CONFIG_PATH"
-then
-  echo "Backing up $KUBE_CONFIG_PATH ..."
-  mv "$KUBE_CONFIG_PATH" "$KUBE_CONFIG_BACKUP_PATH"
-  export BACKED_UP_KUBE_CONFIG=true
-fi
+function create_real_docker_config_json() {
+  # on Mac, Docker config.json points to credsStore
+  # where the creds are really stored,
+  # create a file that has the creds inline
+  local dockercfg=$(mktemp ~/.docker/config.json.XXX)
+  local storetype=$(jq -r .credsStore < $DOCKER_CONFIG_JSON_PATH)
+  local registry=''
+  (
+    echo '{'
+    echo '    "auths": {'
+    for registry in $(docker-credential-$storetype list | jq -r 'to_entries[] | .key'); do
+      if [ ! -z "$FIRST" ]; then
+          echo '        },'
+      fi
+      FIRST='true'
+      credential=$(echo $registry | docker-credential-$storetype get | jq -jr '"\(.Username):\(.Secret)"' | base64)
+      echo '        "'$registry'": {'
+      echo '            "auth": "'$credential'"'
+    done
+    echo '        }'
+    echo '    }'
+    echo '}'
+  ) > $dockercfg
+  echo "$dockercfg"
+}
 
-start_minikube staging
-start_minikube production
+function back_up_kube_config() {
+  # don't let minikube overwrite user's real k8s kubeconfig
+  local backed_up_kube_config=''
+  if ls "$KUBE_CONFIG_PATH"
+  then
+    echo "Backing up $KUBE_CONFIG_PATH ..."
+    mv "$KUBE_CONFIG_PATH" "$KUBE_CONFIG_BACKUP_PATH"
+    backed_up_kube_config='true'
+  fi
+  echo "$backed_up_kube_config"
+}
 
-# create ecr image pull secret in minikube/k8s
-
-aws ecr get-login-password --region "$AWS_REGION" | \
-  docker login --username AWS \
-    --password-stdin ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com
-
-kubectl --context staging create secret generic regcred \
-  --from-file=.dockerconfigjson=${HOME}/.docker/config.json \
-  --type=kubernetes.io/dockerconfigjson
-
-kubectl --context staging patch serviceaccount default -p '{"imagePullSecrets": [{"name": "regcred"}]}'
-
-kubectl --context production create secret generic regcred \
-  --from-file=.dockerconfigjson=${HOME}/.docker/config.json \
-  --type=kubernetes.io/dockerconfigjson
-
-kubectl --context production patch serviceaccount default -p '{"imagePullSecrets": [{"name": "regcred"}]}'
-
-
-coverage run -m pytest test/integration
-
-minikube stop --profile staging
-minikube stop --profile production
-
-if [ "$BACKED_UP_KUBE_CONFIG" = "true" ]
-then
+function restore_kube_config() {
   echo "Restoring $KUBE_CONFIG_PATH ..."
   mv "$KUBE_CONFIG_BACKUP_PATH" "$KUBE_CONFIG_PATH"
+}
+
+function create_regcred() {
+  # create ecr image pull secret in minikube/k8s
+  aws ecr get-login-password --region "$AWS_REGION" | \
+    docker login --username AWS \
+      --password-stdin ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com
+  local dockercfg=$(create_real_docker_config_json)
+  # ensure file is deleted when script exits
+  trap "rm -f $dockercfg" EXIT
+  create_regcred_for_env 'staging' $dockercfg
+  create_regcred_for_env 'production' $dockercfg
+  rm -f "$dockercfg"
+}
+
+function create_regcred_for_env() {
+  local environment=$1
+  local dockercfg=$2
+  kubectl --context "$environment" create secret generic regcred \
+    --from-file=.dockerconfigjson="$dockercfg" \
+    --type=kubernetes.io/dockerconfigjson
+  kubectl --context "$environment" patch serviceaccount default -p '{"imagePullSecrets": [{"name": "regcred"}]}'
+}
+
+
+## main
+
+kube_config_is_backed_up=$(back_up_kube_config)
+start_minikube staging
+start_minikube production
+create_regcred
+coverage run -m pytest test/integration
+minikube stop --profile staging
+minikube stop --profile production
+if [ "$kube_config_is_backed_up" = "true" ]
+then
+  restore_kube_config
 fi

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -9,7 +9,7 @@ import pytest
 from hokusai.lib.common import ansi_escape
 
 
-TEST_GIT_REPO_NAME = 'hokusai-integration-test'
+NAME_OF_TEST_GIT_REPO = 'hokusai-integration-test'
 
 
 def exit_pytest_if_not_minikube(context):
@@ -41,18 +41,18 @@ def pytest_configure(config):
   # clone test git repo
   os.chdir('test/integration/fixtures')
   # skip cloning if already cloned and no force
-  if os.path.isdir(TEST_GIT_REPO_NAME) and os.environ.get('FORCE_CLONE') != '1':
+  if os.path.isdir(NAME_OF_TEST_GIT_REPO) and os.environ.get('FORCE_CLONE') != '1':
     return
-  shutil.rmtree(TEST_GIT_REPO_NAME, ignore_errors=True)
-  git.Git(".").clone(f"https://github.com/artsy/{TEST_GIT_REPO_NAME}.git")
+  shutil.rmtree(NAME_OF_TEST_GIT_REPO, ignore_errors=True)
+  git.Git(".").clone(f"https://github.com/artsy/{NAME_OF_TEST_GIT_REPO}.git")
 
 
 ## autouse fixtures
 
 @pytest.fixture(scope="session", autouse=True)
 def cd_into_test_git_repo():
-  os.chdir(TEST_GIT_REPO_NAME)
+  os.chdir(NAME_OF_TEST_GIT_REPO)
 
 @pytest.fixture(autouse=True)
-def test_git_repo_name():
-  return TEST_GIT_REPO_NAME
+def name_of_test_git_repo():
+  return NAME_OF_TEST_GIT_REPO

--- a/test/integration/test_base.py
+++ b/test/integration/test_base.py
@@ -13,8 +13,8 @@ from hokusai.lib.common import ansi_escape
 # working directory is set to repo dir, also in conftest.py
 
 def describe_git_repo_for_test():
-  def operating_in_test_git_repo_clone_dir(test_git_repo_name):
-    assert os.path.basename(os.getcwd()) == test_git_repo_name
+  def operating_in_test_git_repo_clone_dir(name_of_test_git_repo):
+    assert os.path.basename(os.getcwd()) == name_of_test_git_repo
   def operating_on_main_branch():
     repo = Repo(os.getcwd())
     heads = repo.heads

--- a/test/integration/test_staging.py
+++ b/test/integration/test_staging.py
@@ -62,22 +62,21 @@ def describe_update():
     assert 'Updated Kubernetes environment' in resp.stdout
 
 def describe_refresh():
-  def it_times_out():
-    # expect timeout due to minikube lacking ECR image pull permission
-    with pytest.raises(TimeoutExpired):
-      resp = subprocess.run(
-        'hokusai staging refresh',
-        capture_output=True,
-        shell=True,
-        text=True,
-        timeout=10
-      )
-      if resp.returncode != -9:
-        print(resp.stderr)
-      assert resp.returncode == -9
-      assert 'Refreshing hokusai-integration-test-web' in resp.stdout
-      assert 'Waiting for refresh to complete' in resp.stdout
-      assert 'Waiting for deployment "hokusai-integration-test-web" rollout to finish' in resp.stdout
+  def it_reports_success():
+    resp = subprocess.run(
+      'hokusai staging refresh',
+      capture_output=True,
+      shell=True,
+      text=True,
+      timeout=30
+    )
+    if resp.returncode != 0:
+      print(resp.stderr)
+    assert resp.returncode == 0
+    assert 'Refreshing hokusai-integration-test-web' in resp.stdout
+    assert 'Waiting for refresh to complete' in resp.stdout
+    assert 'Waiting for deployment "hokusai-integration-test-web" rollout to finish' in resp.stdout
+    assert 'deployment "hokusai-integration-test-web" successfully rolled out' in resp.stdout
 
 def describe_delete():
   def it_reports_deleted():


### PR DESCRIPTION
Mainly to close out the open comments in https://github.com/artsy/hokusai/pull/400.

- Let `hokusai staging refresh` test see to `successfully rolled out` output. ([Comment addressed](https://github.com/artsy/hokusai/pull/400#discussion_r1463428499) from previous PR)
- Let CI `test_integration` step and `scripts/integration_test_local.sh` create minikube/k8s regcred for pulling image from ECR.
- Rename `make dependencies` to `make hokusai`, since Poetry installs Hokusai. ([Comment addressed](https://github.com/artsy/hokusai/pull/400#discussion_r1459270493) from previous PR)
- Rename `test_git_repo_name` fixture. ([Comment addressed](https://github.com/artsy/hokusai/pull/400#discussion_r1463383716) from previous PR)