### PR TITLE
fix: stray paren in command to describe deployments

### DIFF
--- a/hokusai/services/kubectl.py
+++ b/hokusai/services/kubectl.py
@@ -38,7 +38,7 @@ class Kubectl:
 
   def get_object(self, obj):
     ''' run kubectl get <object> '''
-    cmd = self.command(f'get {obj} -o json)')
+    cmd = self.command(f'get {obj} -o json')
     try:
       return json.loads(shout(cmd))
     except ValueError:

--- a/test/unit/test_services/test_kubectl.py
+++ b/test/unit/test_services/test_kubectl.py
@@ -48,7 +48,13 @@ def describe_kubectl():
         obj = Kubectl('staging')
         mock_return = { 'foo': 'bar' }
         mocker.patch('hokusai.services.kubectl.shout', return_value=json.dumps(mock_return))
+        spy = mocker.spy(hokusai.services.kubectl, 'shout')
         assert obj.get_object('pods') == mock_return
+        spy.assert_has_calls([
+          mocker.call(
+            '/tmp/.local/bin/kubectl --context staging get pods -o json'
+          )
+        ])
     def describe_value_error():
       def it_returns_none(mocker, mock_shout_raises):
         obj = Kubectl('staging')


### PR DESCRIPTION
As part of troubleshooting #inc-197, we encountered this old bug, seemingly from https://github.com/artsy/hokusai/pull/379.

```
hokusai production refresh --deployment gravity-sneakers
...
ERROR: /bin/sh: -c: line 0: syntax error near unexpected token `)'
```