### PR TITLE
feat: run integration tests against k8s 1.22.17

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
       image: ubuntu-2004:202201-02
     environment:
       KUBECTL_VERSION: v1.20.15
-      K8S_VERSION: v1.21.14
+      K8S_VERSION: v1.22.17
       KUBECONFIG: /home/circleci/.kube/config
       MINIKUBE_VERSION: v1.31.2
       MINIKUBE_WANTUPDATENOTIFICATION: false

--- a/scripts/integration_test_local.sh
+++ b/scripts/integration_test_local.sh
@@ -14,7 +14,7 @@
 
 ## prepare env
 
-export K8S_VERSION=v1.21.14
+export K8S_VERSION=v1.22.17
 export KUBE_CONFIG_PATH=${HOME}/.kube/config
 export KUBE_CONFIG_BACKUP_PATH=${HOME}/.kube/config.bak
 export AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query "Account" --output text)


### PR DESCRIPTION
In preparation of upgrading Artsy Kubernetes clusters from v1.21.14 to [v1.22.17](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.22.md).