### PR TITLE
fix: circleci ubuntu image deprecation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
 
   test_integration:
     machine:
-      image: ubuntu-2004:202201-02
+      image: ubuntu-2204:2024.04.4
     environment:
       KUBECTL_VERSION: v1.22.17
       K8S_VERSION: v1.22.17

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,6 +133,7 @@ jobs:
           name: setup hokusai global config file
           command: |
             cp test/integration/fixtures/ci_hokusai_global_config.yml ${HOME}/.hokusai.yml
+      - run: pyenv install 3.10
       - run: pyenv local 3.10
       - run: make hokusai
       - run: pyenv rehash

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,7 @@ jobs:
           name: setup hokusai global config file
           command: |
             cp test/integration/fixtures/ci_hokusai_global_config.yml ${HOME}/.hokusai.yml
-      - run: pyenv local 3.10.2
+      - run: pyenv local 3.10
       - run: make hokusai
       - run: pyenv rehash
       - run: make integration


### PR DESCRIPTION
`ubuntu-2004:202201-02` is [no longer supported by CircleCI](https://discuss.circleci.com/t/linux-image-deprecations-and-eol-for-2024/50177).

Last `main` [build failure](ubuntu-2004:202201-02) [failed](https://app.circleci.com/pipelines/github/artsy/hokusai/1282/workflows/f928972a-61f6-4f87-a6a9-ba7b10974d21/jobs/5515) with:

```
This job was rejected because the image 'ubuntu-2004:202201-02' is [unavailable](https://discuss.circleci.com/t/linux-image-deprecations-and-eol-for-2024/)
```

Let's bump to [ubuntu-2204:2024.04.4](https://circleci.com/developer/machine/image/ubuntu-2204).

New image does not have Python 3.10.2. Let's have `pyenv` install Python 3.10.