### PR TITLE
feat: overwrite homebrew formula even when version is published

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,6 +223,8 @@ jobs:
               export SHA256=$(sha256sum hokusai-beta-Darwin-x86_64.tar.gz | awk '{ print $1 }')
             fi
 
+            echo "SHA 256 sum is $SHA256"
+
             ssh-keyscan github.com >> ~/.ssh/known_hosts
             git clone git@github.com:artsy/homebrew-formulas.git
             cd ./homebrew-formulas
@@ -350,15 +352,14 @@ jobs:
               export SHA256=$(sha256sum hokusai-$VERSION-Darwin-x86_64.tar.gz | awk '{ print $1 }')
             fi
 
+            echo "SHA 256 sum is $SHA256"
+
             ssh-keyscan github.com >> ~/.ssh/known_hosts
             git clone git@github.com:artsy/homebrew-formulas.git
             cd ./homebrew-formulas
 
             if grep $VERSION ./Formula/hokusai.rb; then
-              echo "Formula version already set to $VERSION"
-              cd /tmp
-              rm -rf ./homebrew-formulas
-              exit 0
+              echo "Formula version already set to $VERSION. Overwriting it."
             fi
 
             echo "Bumping formula version to $VERSION"


### PR DESCRIPTION
The release pipeline's:

- release_s3_macos job: [Always uploads MacOS binary to S3](https://app.circleci.com/pipelines/github/artsy/hokusai/1292/workflows/1671d5d8-b77f-4a90-8b51-5facd5415f42/jobs/5593?invite=true#step-102-932_36). If the version already exists in S3, it is overwritten. Even when there is no code changes, every PyInstaller build results in a slightly different binary, so its SHA always changes.

- release_homebrew job: [Skips updating Homebrew Formula](https://app.circleci.com/pipelines/github/artsy/hokusai/1292/workflows/1671d5d8-b77f-4a90-8b51-5facd5415f42/jobs/5593?invite=true#step-102-932_36) if version already exists. This is bad because the Formula contains SHA of MacOS binary, and this SHA should be updated every time `release_s3_macos` is run. When `release_s3_macos` is run, creating a new binary in S3, yet the formula is not updated, we run into SHA mismatch:

```
$ brew install hokusai
...
==> Fetching artsy/formulas/hokusai
==> Downloading https://artsy-provisioning-public.s3.amazonaws.com/hokusai/hokusai-2.2.0-Darwin-x86_64.tar.gz
Already downloaded: /Users/sultan/Library/Caches/Homebrew/downloads/6114aa5ce6dd23b2118f879054265a906fa5f681b203fb3f87a9ae9d13dc6745--hokusai-2.2.0-Darwin-x86_64.tar.gz
Error: SHA256 mismatch
Expected: 4f5e6d4d1de444fdac982befd7094e10d46354cb42ddb3c385a5a046e95f0a6a
  Actual: f418aaced39ee899cea338b8a034ffcbcb37e6bc08975cebf36e5147856b5c47
```

The `Expected` is the SHA in the formula. `Actual` is the SHA calculated on the freshly built binary stored in S3.

This PR makes `release_homebrew` job overwrite formula when version already exists.