### PR TITLE
Switch CI MacOS builds to M1 and continue to build x86_64 binary

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,8 @@ jobs:
       - run: pyenv rehash
       - run: make test
       - run: coverage report
-      - run: make pyinstaller-build-onedir ARTIFACT_LABEL=beta
+      - run: make pyinstaller-build-onedir ARTIFACT_LABEL=test
+      - run: make publish-to-s3 ARTIFACT_LABEL=test
 
   test_integration:
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -420,6 +420,8 @@ workflows:
             branches:
               ignore: release
       - test_macos:
+          context:
+          - hokusai
           filters:
             branches:
               ignore: release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,7 @@ jobs:
           name: install awscli
           command: |
             curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"
+            sudo softwareupdate --install-rosetta --agree-to-license
             sudo installer -pkg AWSCLIV2.pkg -target /
       - run: make hokusai
       - run: pyenv rehash
@@ -184,6 +185,7 @@ jobs:
           name: install awscli
           command: |
             curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"
+            sudo softwareupdate --install-rosetta --agree-to-license
             sudo installer -pkg AWSCLIV2.pkg -target /
       - run: make hokusai
       - run: pyenv rehash
@@ -290,6 +292,7 @@ jobs:
           name: install awscli
           command: |
             curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"
+            sudo softwareupdate --install-rosetta --agree-to-license
             sudo installer -pkg AWSCLIV2.pkg -target /
       - run: make hokusai
       - run: pyenv rehash

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,24 +157,9 @@ jobs:
     steps:
       - checkout
       - run:
-          name: install openssl, pyenv
+          name: build hokusai
           command: |
-            brew install openssl pyenv
-            echo -e '\neval "$(pyenv init --path)"' >> ~/.bash_profile
-      - run:
-          name: install python
-          command: |
-            pyenv install 3.10
-            pyenv local 3.10
-            pip install --upgrade pip
-      - run:
-          name: install awscli
-          command: |
-            curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"
-            sudo softwareupdate --install-rosetta --agree-to-license
-            sudo installer -pkg AWSCLIV2.pkg -target /
-      - run: make hokusai
-      - run: pyenv rehash
+            ./scripts/ci_macos_build_hokusai.sh
       - run: scripts/update_version_file.sh
       - run: make pyinstaller-build-onedir ARTIFACT_LABEL=beta
       - run: make publish-to-s3 ARTIFACT_LABEL=beta
@@ -264,24 +249,9 @@ jobs:
     steps:
       - checkout
       - run:
-          name: install openssl, pyenv
+          name: build hokusai
           command: |
-            brew install openssl pyenv
-            echo -e '\neval "$(pyenv init --path)"' >> ~/.bash_profile
-      - run:
-          name: install python
-          command: |
-            pyenv install 3.10
-            pyenv local 3.10
-            pip install --upgrade pip
-      - run:
-          name: install awscli
-          command: |
-            curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"
-            sudo softwareupdate --install-rosetta --agree-to-license
-            sudo installer -pkg AWSCLIV2.pkg -target /
-      - run: make hokusai
-      - run: pyenv rehash
+            ./scripts/ci_macos_build_hokusai.sh
       - run: scripts/update_version_file.sh
       - run: make pyinstaller-build-onedir ARTIFACT_LABEL=$(cat hokusai/VERSION)
       - run: make pyinstaller-build-onedir ARTIFACT_LABEL=latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,35 +18,9 @@ jobs:
     steps:
       - checkout
       - run:
-          name: install rosetta
+          name: build hokusai
           command: |
-            sudo softwareupdate --install-rosetta --agree-to-license
-      - run:
-          name: install x86_64 homebrew
-          command: |
-            arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-      - run:
-          name: set PATH for subsequent steps
-          command: |
-            echo 'export PATH="/usr/local/bin:$PATH"' >> "$BASH_ENV"
-      - run:
-          name: install openssl, pyenv, xz
-          command: |
-            brew install openssl pyenv xz
-            echo -e '\neval "$(pyenv init --path)"' >> ~/.bash_profile
-      - run:
-          name: install python
-          command: |
-            arch -x86_64 pyenv install 3.10
-            pyenv local 3.10
-            pip install --upgrade pip
-      - run:
-          name: install awscli
-          command: |
-            curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"
-            sudo installer -pkg AWSCLIV2.pkg -target /
-      - run: make hokusai
-      - run: pyenv rehash
+            ./scripts/ci_macos_build_hokusai.sh
       - run: make test
       - run: coverage report
       - run: make pyinstaller-build-onedir ARTIFACT_LABEL=test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
       - run:
           name: install python
           command: |
-            pyenv install 3.10
+            arch -x86_64 pyenv install 3.10
             pyenv local 3.10
             pip install --upgrade pip
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,9 +30,9 @@ jobs:
           command: |
             echo 'export PATH="/usr/local/bin:$PATH"' >> "$BASH_ENV"
       - run:
-          name: install openssl, pyenv
+          name: install openssl, pyenv, xz
           command: |
-            brew install openssl pyenv
+            brew install openssl pyenv xz
             echo -e '\neval "$(pyenv init --path)"' >> ~/.bash_profile
       - run:
           name: install python

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,7 @@ jobs:
   test_macos:
     macos:
       xcode: "15.3.0"
+    resource_class: macos.m1.medium.gen1
     steps:
       - checkout
       - run:
@@ -165,6 +166,7 @@ jobs:
   release_beta_s3_macos:
     macos:
       xcode: "15.3.0"
+    resource_class: macos.m1.medium.gen1
     steps:
       - checkout
       - run:
@@ -270,6 +272,7 @@ jobs:
   release_s3_macos:
     macos:
       xcode: "15.3.0"
+      resource_class: macos.m1.medium.gen1
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,18 @@ jobs:
     steps:
       - checkout
       - run:
+          name: install rosetta
+          command: |
+            sudo softwareupdate --install-rosetta --agree-to-license
+      - run:
+          name: install x86_64 homebrew
+          command: |
+            arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+      - run:
+          name: set PATH for subsequent steps
+          command: |
+            echo 'export PATH="/usr/local/bin:$PATH"' >> "$BASH_ENV"
+      - run:
           name: install openssl, pyenv
           command: |
             brew install openssl pyenv
@@ -32,7 +44,6 @@ jobs:
           name: install awscli
           command: |
             curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"
-            sudo softwareupdate --install-rosetta --agree-to-license
             sudo installer -pkg AWSCLIV2.pkg -target /
       - run: make hokusai
       - run: pyenv rehash

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ pyinstaller-build-onefile: # for linux
 # for mac (because build-onefile's binary runs too slow on mac)
 pyinstaller-build-onedir:
 	pyinstaller \
+	  --target-architecture=x86_64 \
 	  --distpath=$(DIST_DIR) \
 	  --workpath=/tmp/build/ \
 	  hokusai_onedir.spec

--- a/scripts/ci_macos_build_hokusai.sh
+++ b/scripts/ci_macos_build_hokusai.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# build Hokusai in CI environment
+# for use on Apple silicon MacOS
+
+set -xeo pipefail
+
+# install rosetta
+sudo softwareupdate --install-rosetta --agree-to-license
+
+# install x86 homebrew
+arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+# set PATH to x86 executables
+export PATH="/usr/local/bin:$PATH"
+
+# install pyenv
+brew install pyenv
+echo -e '\neval "$(pyenv init --path)"' >> ~/.bash_profile
+
+# install python pre-reqs
+brew install openssl xz
+
+# install python
+arch -x86_64 pyenv install 3.10
+pyenv local 3.10
+pip install --upgrade pip
+
+# install awscli
+curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"
+sudo installer -pkg AWSCLIV2.pkg -target /
+
+# build hokusai
+make hokusai
+pyenv rehash

--- a/scripts/ci_macos_build_hokusai.sh
+++ b/scripts/ci_macos_build_hokusai.sh
@@ -6,30 +6,30 @@
 set -xeo pipefail
 
 # install rosetta
-sudo softwareupdate --install-rosetta --agree-to-license
+time sudo softwareupdate --install-rosetta --agree-to-license
 
 # install x86 homebrew
-arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+time arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
 # set PATH to x86 executables
 export PATH="/usr/local/bin:$PATH"
 
 # install pyenv
-brew install pyenv
+time brew install pyenv
 echo -e '\neval "$(pyenv init --path)"' >> ~/.bash_profile
 
 # install python pre-reqs
-brew install openssl xz
+time brew install openssl xz
 
 # install python
-arch -x86_64 pyenv install 3.10
+time arch -x86_64 pyenv install 3.10
 pyenv local 3.10
-pip install --upgrade pip
+time pip install --upgrade pip
 
 # install awscli
-curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"
-sudo installer -pkg AWSCLIV2.pkg -target /
+time curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"
+time sudo installer -pkg AWSCLIV2.pkg -target /
 
 # build hokusai
-make hokusai
+time make hokusai
 pyenv rehash


### PR DESCRIPTION
Currently, CI MacOS builds run on Intel MacOS and they output x86_64 binaries which work on Intel MacOS as well as on Apple silicon MacOS that has [Rosetta](https://support.apple.com/en-us/102527) installed.

CircleCI is [deprecating Intel MacOS](https://discuss.circleci.com/t/macos-intel-support-deprecation-in-january-2024/48718). Going forward, the builds have to run on Apple silicon.

A binary built on Apple silicon does not work on Intel. When running an Apple-silicon-built binary on Intel, this error occurs:
```
artsy:hokusai-m1 jxu$ ./hokusai
-bash: ./hokusai: Bad CPU type in executable
```

In this PR, we do two things. First, we switch the builds to Apple silicon (M1), in anticipation of CircleCI's deprecation. Second, we make the builds output x86_64 binaries, so that we continue to have a single binary that works on both platforms.