### PR TITLE
fix: s3 filename for homebrew formula

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,7 +187,7 @@ jobs:
           command: |
             cd /tmp
 
-            wget https://artsy-provisioning-public.s3.amazonaws.com/hokusai/hokusai-beta-Darwin-x86_64.tar.gz
+            wget https://artsy-provisioning-public.s3.amazonaws.com/hokusai/hokusai-beta-Darwin-arm64.tar.gz
 
             export UNAME=$(uname)
             if [ $UNAME == "Darwin" ]; then
@@ -208,7 +208,7 @@ jobs:
             class HokusaiBeta < Formula
               desc 'Hokusai is a Docker + Kubernetes CLI for application developers'
               homepage 'https://github.com/artsy/hokusai'
-              url 'https://artsy-provisioning-public.s3.amazonaws.com/hokusai/hokusai-beta-Darwin-x86_64.tar.gz'
+              url 'https://artsy-provisioning-public.s3.amazonaws.com/hokusai/hokusai-beta-Darwin-arm64.tar.gz
               sha256 '$SHA256'
               version 'beta'
 
@@ -303,7 +303,7 @@ jobs:
 
             cd /tmp
 
-            wget https://artsy-provisioning-public.s3.amazonaws.com/hokusai/hokusai-$VERSION-Darwin-x86_64.tar.gz
+            wget https://artsy-provisioning-public.s3.amazonaws.com/hokusai/hokusai-$VERSION-Darwin-arm64.tar.gz
 
             export UNAME=$(uname)
             if [ $UNAME == "Darwin" ]; then
@@ -330,7 +330,7 @@ jobs:
             class Hokusai < Formula
               desc 'Hokusai is a Docker + Kubernetes CLI for application developers'
               homepage 'https://github.com/artsy/hokusai'
-              url 'https://artsy-provisioning-public.s3.amazonaws.com/hokusai/hokusai-$VERSION-Darwin-x86_64.tar.gz'
+              url 'https://artsy-provisioning-public.s3.amazonaws.com/hokusai/hokusai-$VERSION-Darwin-arm64.tar.gz'
               sha256 '$SHA256'
               version '$VERSION'
 


### PR DESCRIPTION
https://github.com/artsy/hokusai/pull/417 changed name of MacOS S3 artifacts, [breaking](https://app.circleci.com/pipelines/github/artsy/hokusai/1318/workflows/5a6a7a55-4d70-402a-b554-8fe69b98f0e5/jobs/5705?invite=true#step-102-77_45) Homebrew release steps.

This PR updates Homebrew steps with the new names.