### PR TITLE
feat: expose review app create yaml command to cli

### DIFF
--- a/docs/Review_Apps.md
+++ b/docs/Review_Apps.md
@@ -1,131 +1,135 @@
-## Working with review apps
+# Working with review apps
 
-Hokusai provides a command for managing review apps. Review apps are useful for testing feature branches that are not yet ready to be deployed to staging but need to be tested in a staging-like environment.
+Hokusai provides commands for managing review apps. Review apps are useful for testing features that are not yet ready to be deployed to staging but need to be tested in a staging-like environment.
 
-In order to start a review app you will need to follow these steps:
+Perform the following steps in order to create a review app. `app-name` refers to name of the review app.
 
-1) Create a new review app
-    ```shell
-    hokusai review_app setup <name> # we recommend using branch name or PR number as name
-    ```
-    This command will create a new `<name>.yml` under `hokusai/` folder.
+## Prepare app
 
-2) Check the newly created `<name>.yml` file and make sure everything looks good. Note that we use Kubernetes [`namespace`](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/) for review apps. Basically each review app will end up being in its own namespace to not collide with staging.
+```
+hokusai review_app setup <app-name> # we recommend using branch name or PR number as name
+```
 
-3) Push an image with this review app tag:
+It creates a `<app-name>.yml` file under `hokusai/` folder. This is the review app Yaml.
 
-    ```shell
-    hokusai registry push --tag <name>
-    ```
+Check the file and make sure everything looks good. Note that we use Kubernetes [`namespace`](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/) for review apps, that is, each review app is created in a dedicated namespace.
 
-    If you have git-ignored files in your working directory (likely) you will have to force push with:
-    ```shell
-    hokusai registry push --force --tag <name>
-    ```
+## Push Docker image
 
-    It may be a good idea to skip updating the `latest` tag in the registry, which you can do with:
-    ```shell
-    hokusai registry push --skip-latest --tag <name>
-    ```
+Tag the image with review app's name.
 
-4) Make sure your review app deployment will use the image you just pushed. This can be done by modifying the new `<name>.yml` file.
+```
+hokusai registry push --tag <app-name>
+```
 
-    There will be a `containers` subsection of the configuration that specifies the `image` that should be pulled from AWS Elastic Container Registry when booting up your review app. Update the value of that `image` so that it points to your newly tagged image, rather than the default staging image for that project.
+If there are git-ignored files in the working directory, which is likely, force push:
 
-    Example:
-    ```yml
-    image: <aws-account-id>.dkr.ecr.us-east-1.amazonaws.com/volt:staging
+```
+hokusai registry push --force --tag <app-name>
+```
 
-    # must be changed to...
+`push` by default updates the `latest` tag in AWS ECR registry, which can be skipped by:
 
-    image: <aws-account-id>.dkr.ecr.us-east-1.amazonaws.com/volt:<name>
-    ```
-    ... where `<name>` is the review app name you've been using in previous steps, especially step 3.
+```
+hokusai registry push --skip-latest --tag <app-name>
+```
 
+Then, edit review app Yaml. Find the `containers` subsection of the configuration that specifies the `image` that should be pulled from AWS ECR when booting up your review app. Update the value of that `image` so that it points to your newly tagged image, rather than the default staging image for that project.
 
-5) Create new deployment on k8s based on your new local YAML config:
+For example, change:
 
-    ```shell
-    hokusai review_app create <name>
-    ```
+```
+image: <aws-account-id>.dkr.ecr.us-east-1.amazonaws.com/volt:staging
+```
 
-6) Copy the staging environment's `ConfigMap` to the new namespace:
+to:
 
-    ```shell
-    hokusai review_app env copy <name>
-    ```
+```
+image: <aws-account-id>.dkr.ecr.us-east-1.amazonaws.com/volt:<app-name>
+```
 
-7) If necessary, copy other `ConfigMaps` to the new namespace, for example:
+## Create Kubernetes resources
 
-    ```shell
-    hokusai review_app env copy <name> --configmap nginx-config
-    ```
+This step actually creates Kubernetes resources for the review app.
 
-8) Find and visit your staging app:
+```
+hokusai review_app create <app-name>
+```
 
-    - In the Kubernetes UI, find the "Namespace" dropdown in the main nav and select your chosen `<name>` from that menu
-    - Browse to the "Services" section
-    - In "Details", look for "External endpoints". These are your publicly accessible URLs.
-    - You may need to tweak the URL to use `https` instead of `http`
-    - You may need to accept a browser warning about a missing or bad certificate
+## Find and visit the app:
 
-    You can also view a summarized status of your review app with:
+- Go to https://kubernetes.stg.artsy.systems (VPN required).
+- Find the "Namespace" dropdown in the main nav and select `<app-name>`.
+- Browse to the "Services" section.
+- In "Details", look for "External endpoints". These are your publicly accessible URLs.
+- You may need to tweak the URL to use `https` instead of `http`.
+- You may need to accept a browser warning about a missing or bad certificate.
 
-    ```shell
-    hokusai review_app status <name>
-    ```
+You can also view a summarized status of your review app with:
 
-9) If you need to view or update environment variables:
+```
+hokusai review_app status <app-name>
+```
 
-    ```shell
-    hokusai review_app env get <name> FOO
-    hokusai review_app env set <name> FOO=BAR
-    ```
+## Update environment variables (optional)
 
-10) If you need to refresh your app, (e.g. after updating environment variables)
+```
+hokusai review_app env get <app-name> FOO
+hokusai review_app env set <app-name> FOO=BAR
+```
 
-    ```shell
-    hokusai review_app refresh <name>
-    ```
+## Refresh the app (optional)
 
-11) If you need to view logs for your app, (e.g. after a refresh or deploy)
+Must be done if environment variables are updated.
 
-    ```shell
-    hokusai review_app logs <name>
-    ```
+```
+hokusai review_app refresh <app-name>
+```
 
-12) If you need to get a shell in your app, (e.g. to launch a Rails console)
+## View pods' logs (optional)
 
-    ```shell
-    hokusai review_app run <name> <command> --tty
-    ```
+```
+hokusai review_app logs <app-name>
+```
 
-13) If you want to push subsequent changes to the review app,
+## Start a shell session (optional)
 
-    you can push a new build to the same tag with the `--overwrite` flag:
-    ```shell
-    hokusai registry push --overwrite --skip-latest --force --tag <name>
-    ```
+This launches a review app pod and opens a shell session (e.g. Rails console).
 
-    and you need to redeploy your app:
-    ```shell
-    hokusai review_app deploy <name> <name>
-    ```
+```
+hokusai review_app run <app-name> <command> --tty
+```
 
-14) If you have made changes to your review app's yaml file, you need to update the deployment:
+## Push code changes (optional)
 
-    ```shell
-    hokusai review_app deploy <name> <name> --update-config
-    ```
+When review app code is changed, update Docker image by:
 
-    or
+```
+hokusai registry push --overwrite --skip-latest --force --tag <app-name>
+```
 
-    ```shell
-    hokusai review_app update <name>
-    ```
+The re-deploy:
 
-15) Delete review app:
+```
+hokusai review_app deploy <app-name> <image-tag>
+```
 
-    ```shell
-    hokusai review_app delete <name>
-    ```
+## Push Yaml changes (optional)
+
+If review app Yaml is changed, do:
+
+```
+hokusai review_app deploy <app-name> <image-tag> --update-config
+```
+
+or
+
+```
+hokusai review_app update <app-name>
+```
+
+## Delete the app (optional)
+
+```
+hokusai review_app delete <app-name>
+```

--- a/docs/Review_Apps.md
+++ b/docs/Review_Apps.md
@@ -22,7 +22,7 @@ Tag the image with review app's name.
 hokusai registry push --tag <app-name>
 ```
 
-If there are git-ignored files in the working directory, which is likely, force push:
+If the working directory has any changed, untracked, or git-ignored files, Hokusai aborts the push in order to not copy any potentially sensitive files into the image. If you know the files are not sensitive or they are already covered by `.dockerignore` file, force the push by:
 
 ```
 hokusai registry push --force --tag <app-name>

--- a/hokusai/cli/review_app.py
+++ b/hokusai/cli/review_app.py
@@ -26,6 +26,26 @@ def review_app(context_settings=CONTEXT_SETTINGS):
   default='hokusai/staging.yml',
   help="The source yaml file from which to create the new resource file (default: hokusai/staging.yml)"
 )
+def create_yaml(app_name, verbose, source_file):
+  """Create Review App Yaml"""
+  set_verbosity(verbose)
+  command(
+    hokusai.create_yaml_for_cli,
+    source_file,
+    app_name
+  )
+
+
+@review_app.command(context_settings=CONTEXT_SETTINGS)
+@click.argument('app_name', type=click.STRING)
+@click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
+@click.option(
+  '-sf',
+  '--source-file',
+  type=click.STRING,
+  default='hokusai/staging.yml',
+  help="The source yaml file from which to create the new resource file (default: hokusai/staging.yml)"
+)
 def setup(app_name, verbose, source_file):
   """Setup a new Review App"""
   set_verbosity(verbose)

--- a/hokusai/commands/__init__.py
+++ b/hokusai/commands/__init__.py
@@ -15,7 +15,7 @@ from hokusai.commands.pull import pull
 from hokusai.commands.run import run
 from hokusai.commands.setup import setup
 from hokusai.commands.kubernetes import k8s_create, k8s_update, k8s_delete, k8s_status
-from hokusai.commands.review_app import delete_review_app, list_review_apps, setup_review_app
+from hokusai.commands.review_app import create_yaml_for_cli, delete_review_app, list_review_apps, setup_review_app
 from hokusai.commands.retag import retag
 from hokusai.commands.test import test
 from hokusai.commands.version import version

--- a/hokusai/commands/review_app.py
+++ b/hokusai/commands/review_app.py
@@ -69,7 +69,13 @@ def create_yaml(source_file, app_name):
   unlink_file_if_not_debug(tmp_path)
   path = f'{HOKUSAI_CONFIG_DIR}/{app_name}.yml'
   print_green(f'Created {path}')
+  # this return causes Hokusai to exit with 1
+  # so this function must be wrapped if called from CLI
   return path
+
+def create_yaml_for_cli(source_file, app_name):
+  ''' wrap create_yaml function '''
+  create_yaml(source_file, app_name)
 
 def delete_review_app(context, app_name, filename):
   ''' delete review app '''

--- a/test/integration/test_registry.py
+++ b/test/integration/test_registry.py
@@ -1,0 +1,21 @@
+import os
+import pytest
+import subprocess
+
+from subprocess import TimeoutExpired
+
+
+@pytest.mark.order(310)
+def describe_push():
+  def it_pushes():
+    resp = subprocess.run(
+      'hokusai registry push --force --overwrite',
+      capture_output=True,
+      shell=True,
+      text=True,
+      timeout=60
+    )
+    if resp.returncode != 0:
+      print(resp.stderr)
+    assert resp.returncode == 0
+    assert 'Pushed hokusai_hokusai-integration-test:latest' in resp.stdout

--- a/test/integration/test_review_app.py
+++ b/test/integration/test_review_app.py
@@ -4,6 +4,21 @@ import subprocess
 
 
 @pytest.mark.order(1010)
+def describe_create_yaml():
+  def it_creates_yaml():
+    resp = subprocess.run(
+      'hokusai review_app create-yaml a-review-app',
+      capture_output=True,
+      shell=True,
+      text=True,
+      timeout=10
+    )
+    if resp.returncode != 0:
+      print(resp.stderr)
+    assert resp.returncode == 0
+    assert 'Created hokusai/a-review-app.yml' in resp.stdout
+
+@pytest.mark.order(1020)
 def describe_setup():
   def it_sets_up():
     resp = subprocess.run(
@@ -22,7 +37,7 @@ def describe_setup():
     assert 'configmap/hokusai-integration-test-environment created' in resp.stdout
     assert 'serviceaccount/hokusai-integration-test created' in resp.stdout
 
-@pytest.mark.order(1020)
+@pytest.mark.order(1030)
 def describe_create():
   def it_creates_deployment():
     subprocess.run(
@@ -43,7 +58,7 @@ def describe_create():
     assert resp.returncode == 0
     assert 'deployment.apps/hokusai-integration-test-web created' in resp.stdout
 
-@pytest.mark.order(1030)
+@pytest.mark.order(1040)
 def describe_list():
   def it_lists_review_app():
     resp = subprocess.run(
@@ -58,7 +73,7 @@ def describe_list():
     assert resp.returncode == 0
     assert 'a-review-app' in resp.stdout
 
-@pytest.mark.order(1040)
+@pytest.mark.order(1050)
 def describe_delete():
   def it_deletes_review_app():
     resp = subprocess.run(

--- a/test/integration/test_review_app.py
+++ b/test/integration/test_review_app.py
@@ -6,13 +6,6 @@ import subprocess
 @pytest.mark.order(1010)
 def describe_setup():
   def it_sets_up():
-    subprocess.run(
-      'hokusai staging create',
-      capture_output=True,
-      shell=True,
-      text=True,
-      timeout=10
-    )
     resp = subprocess.run(
       'hokusai review_app setup a-review-app',
       capture_output=True,

--- a/test/integration/test_staging.py
+++ b/test/integration/test_staging.py
@@ -7,12 +7,6 @@ from subprocess import TimeoutExpired
 @pytest.mark.order(500)
 def describe_create():
   def it_reports_created():
-    subprocess.run(
-      'hokusai registry push --force',
-      shell=True,
-      text=True,
-      timeout=30
-    )
     resp = subprocess.run(
       'hokusai staging create',
       capture_output=True,


### PR DESCRIPTION
`review_app deploy` requires review app Yaml to exist. Currently, there is [automation](https://github.com/artsy/force/blob/add6c91015104bc62be61e313d125020090a21eb/scripts/update_review_app.sh#L15) that runs `review_app setup` just to create the Yaml. This automation is for updating a review app that was created prior. This no longer works because now `review_app setup` [copies configmap](https://github.com/artsy/hokusai/blob/13e7e3596b63a9925f61c8b3dc2989e26d4d79c1/hokusai/commands/review_app.py#L115), so that any configmap changes made are [overwritten](https://artsy.slack.com/archives/CA8SANW3W/p1727279164824129).

This PR adds CLI command for creating the Yaml so that those automation can switch to it.