### PR TITLE
feat: review_app setup to copy a configmap or serviceaccount ref only once

### DIFF
--- a/hokusai/lib/common.py
+++ b/hokusai/lib/common.py
@@ -290,6 +290,12 @@ def smart_str(s, newline_before=False, newline_after=False):
 
   return s
 
+def sorted_unique_list(list1):
+  ''' return sorted list of unique elements in list1 '''
+  return sorted(
+    set(list1)
+  )
+
 def unlink_file_if_not_debug(path):
   ''' if DEBUG is off, unlink specified file '''
   if not os.environ.get('DEBUG'):

--- a/hokusai/services/yaml_spec.py
+++ b/hokusai/services/yaml_spec.py
@@ -7,6 +7,7 @@ from botocore.exceptions import NoCredentialsError
 
 from hokusai.lib.common import (
   print_yellow,
+  sorted_unique_list,
   unlink_file_if_not_debug,
   write_temp_file
 )
@@ -27,22 +28,22 @@ class YamlSpec:
     atexit.register(self.cleanup)
 
   def all_deployments_configmap_refs(self):
-    ''' return list of configmaps referenced in deployments '''
+    ''' return list of unique configmaps referenced in deployments '''
     configmap_refs = []
     deployment_specs = self.get_resources_by_kind('Deployment')
     for spec in deployment_specs:
       configmap_refs += self.deployment_configmap_refs(spec)
-    return configmap_refs
+    return sorted_unique_list(configmap_refs)
 
   def all_deployments_sa_refs(self):
-    ''' return list of service accounts referenced in deployments '''
+    ''' return list of unique service accounts referenced in deployments '''
     sa_refs = []
     deployment_specs = self.get_resources_by_kind('Deployment')
     for spec in deployment_specs:
       sa_ref = self.deployment_sa_ref(spec)
       if sa_ref is not None:
         sa_refs += [sa_ref]
-    return sa_refs
+    return sorted_unique_list(sa_refs)
 
   def cleanup(self):
     unlink_file_if_not_debug(self.tmp_filename)
@@ -56,7 +57,7 @@ class YamlSpec:
       return None
 
   def deployment_configmap_refs(self, deployment_spec):
-    ''' return list of configmaps referenced in a deployment '''
+    ''' return list of unique configmaps referenced in a deployment '''
     configmap_refs = []
     pod_spec = deployment_spec['spec']['template']['spec']
     if 'initContainers' in pod_spec:
@@ -65,14 +66,14 @@ class YamlSpec:
     if 'containers' in pod_spec:
       container_specs = pod_spec['containers']
       configmap_refs += self.containers_configmap_refs(container_specs)
-    return configmap_refs
+    return sorted_unique_list(configmap_refs)
 
   def containers_configmap_refs(self, container_specs):
-    ''' return list of configmaps referenced in container specs '''
+    ''' return list of unique configmaps referenced in container specs '''
     configmap_refs = []
     for spec in container_specs:
       configmap_refs += self.container_configmap_refs(spec)
-    return configmap_refs
+    return sorted_unique_list(configmap_refs)
 
   def container_configmap_refs(self, container_spec):
     ''' return list of configmaps referenced in a container spec '''
@@ -83,7 +84,7 @@ class YamlSpec:
           configmap_refs += [
             envfrom_spec['configMapRef']['name']
           ]
-    return configmap_refs
+    return sorted(configmap_refs)
 
   def extract_pod_spec(self, deployment_name):
     ''' extract pod spec from spec of specified deployment '''

--- a/test/unit/test_lib/test_common.py
+++ b/test/unit/test_lib/test_common.py
@@ -17,6 +17,7 @@ from hokusai.lib.common import (
   get_platform,
   key_value_list_to_dict,
   local_to_local,
+  sorted_unique_list,
   unlink_file_if_not_debug,
   uri_to_local,
   user,
@@ -206,6 +207,32 @@ def describe_local_to_local():
       source = os.path.join(tmp_path, 'a.yml')
       with pytest.raises(FileNotFoundError):
         local_to_local(source, tmp_path, 'b.yml')
+
+def describe_sorted_unique_list():
+  def it_returns_empty_list_when_input_list_is_empty():
+    list1 = []
+    assert sorted_unique_list(list1) == []
+  def it_returns_identical_list_when_input_list_is_good():
+    list1 = [
+      'a',
+      'b',
+      'c'
+    ]
+    assert sorted_unique_list(list1) == list1
+  def it_returns_sorted_unique_list():
+    list1 = [
+      'c',
+      'b',
+      'a',
+      'a'
+    ]
+    returned_list = sorted_unique_list(list1)
+    assert returned_list == [
+      'a',
+      'b',
+      'c'
+    ]
+    assert isinstance(returned_list, list)
 
 def describe_unlink_file_if_not_debug():
   def describe_debug_on():

--- a/test/unit/test_services/fixtures/yaml_spec.py
+++ b/test/unit/test_services/fixtures/yaml_spec.py
@@ -43,6 +43,11 @@ def mock_hokusai_yaml():
                     },
                   },
                   {
+                    'configMapRef': {
+                      'name': 'foo-common-configmap'
+                    },
+                  },
+                  {
                     'someOtherRef': {
                       'name': 'foo-deployment1-blah'
                     }
@@ -82,7 +87,12 @@ def mock_hokusai_yaml():
                     'configMapRef': {
                       'name': 'foo-deployment2-configmap'
                     },
-                  }
+                  },
+                  {
+                    'configMapRef': {
+                      'name': 'foo-common-configmap'
+                    },
+                  },
                 ]
               }
             ],

--- a/test/unit/test_services/test_yaml_spec.py
+++ b/test/unit/test_services/test_yaml_spec.py
@@ -35,10 +35,11 @@ def describe_yaml_spec():
       obj = YamlSpec('test/fixtures/kubernetes-config.yml')
       mocker.patch.object(obj, 'get_resources_by_kind', return_value=mock_hokusai_yaml[slice(5)])
       assert obj.all_deployments_configmap_refs() == [
-        'foo-deployment1-init-container-configmap',
+        'foo-common-configmap',
         'foo-deployment1-configmap1',
         'foo-deployment1-configmap2',
         'foo-deployment1-container2-configmap',
+        'foo-deployment1-init-container-configmap',
         'foo-deployment2-configmap'
       ]
 
@@ -63,8 +64,9 @@ def describe_yaml_spec():
       assert obj.container_configmap_refs(
         mock_hokusai_yaml[0]['spec']['template']['spec']['containers'][0]
       ) == [
+        'foo-common-configmap',
         'foo-deployment1-configmap1',
-        'foo-deployment1-configmap2'
+        'foo-deployment1-configmap2',
       ]
     def it_returns_empty_list_when_envfrom_empty(mocker, mock_hokusai_yaml):
       mocker.patch('hokusai.services.yaml_spec.ECR', return_value='foo')
@@ -92,6 +94,7 @@ def describe_yaml_spec():
       assert obj.containers_configmap_refs(
         mock_hokusai_yaml[0]['spec']['template']['spec']['containers']
       ) == [
+        'foo-common-configmap',
         'foo-deployment1-configmap1',
         'foo-deployment1-configmap2',
         'foo-deployment1-container2-configmap'
@@ -106,10 +109,11 @@ def describe_yaml_spec():
       assert obj.deployment_configmap_refs(
         mock_hokusai_yaml[0]
       ) == [
-        'foo-deployment1-init-container-configmap',
+        'foo-common-configmap',
         'foo-deployment1-configmap1',
         'foo-deployment1-configmap2',
-        'foo-deployment1-container2-configmap'
+        'foo-deployment1-container2-configmap',
+        'foo-deployment1-init-container-configmap'
       ]
 
   def describe_deployment_sa_ref():


### PR DESCRIPTION
Small improvement over https://github.com/artsy/hokusai/pull/426.

When a [project](https://github.com/artsy/force/blob/9c892d22ce8b3735c595d03d262496ab23335f81/hokusai/staging.yml#L52) has multiple Deployments and they [reference the same configmap](https://github.com/artsy/force/blob/9c892d22ce8b3735c595d03d262496ab23335f81/hokusai/staging.yml#L144), `review_app setup` copies the configmap multiple times, example:

```
artsy:force jxu$ /Users/jxu/.pyenv/versions/hokusai/bin/hokusai review_app setup jian-test-force
namespace/jian-test-force created
Created hokusai/jian-test-force.yml
Copying force-environment ConfigMap to jian-test-force namespace...
configmap/force-environment created
Copying force-environment ConfigMap to jian-test-force namespace...
configmap/force-environment unchanged
```

This PR removes the redundant copying.