### PR TITLE
feat: fallback to "docker compose" when docker-compose not found

### DIFF
--- a/hokusai/cli/base.py
+++ b/hokusai/cli/base.py
@@ -97,8 +97,10 @@ def test(build, cleanup, filename, service_name, verbose):
 
 
 @base.command(context_settings=CONTEXT_SETTINGS)
-def check():
+@click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
+def check(verbose):
   """Check Hokusai dependencies and configuration"""
+  set_verbosity(verbose)
   command(
     hokusai.check
   )

--- a/hokusai/commands/check.py
+++ b/hokusai/commands/check.py
@@ -3,12 +3,13 @@ import botocore.exceptions as botoexceptions
 import os
 
 from hokusai import CWD
-from hokusai.lib.common import get_region_name, print_red, print_green, shout
+from hokusai.lib.common import get_region_name, print_red, print_green, print_yellow, shout
 from hokusai.lib.config import HOKUSAI_CONFIG_DIR, BUILD_YAML_FILE, TEST_YML_FILE, DEVELOPMENT_YML_FILE, config
 from hokusai.lib.exceptions import CalledProcessError, HokusaiError
 from hokusai.lib.template_selector import TemplateSelector
 from hokusai.services.ecr import ECR
 from hokusai.services.kubectl import Kubectl
+from hokusai.services.docker import Docker
 
 def check():
   return_code = 0
@@ -32,12 +33,8 @@ def check():
     check_err('docker')
     return_code += 1
 
-  try:
-    shout('which docker-compose')
-    check_ok('docker-compose')
-  except CalledProcessError:
-    check_err('docker-compose')
-    return_code += 1
+  compose_command = Docker.compose_command()
+  check_ok(compose_command)
 
   try:
     shout('which kubectl')

--- a/hokusai/commands/check.py
+++ b/hokusai/commands/check.py
@@ -34,7 +34,10 @@ def check():
     return_code += 1
 
   compose_command = Docker.compose_command()
-  check_ok(compose_command)
+  print_green(
+    '\u2714 ' +
+    f'Will use "{compose_command}" command for Docker Compose'
+  )
 
   try:
     shout('which kubectl')

--- a/hokusai/commands/check.py
+++ b/hokusai/commands/check.py
@@ -3,13 +3,13 @@ import botocore.exceptions as botoexceptions
 import os
 
 from hokusai import CWD
-from hokusai.lib.common import get_region_name, print_red, print_green, print_yellow, shout
+from hokusai.lib.common import get_region_name, print_green, print_red, shout
 from hokusai.lib.config import HOKUSAI_CONFIG_DIR, BUILD_YAML_FILE, TEST_YML_FILE, DEVELOPMENT_YML_FILE, config
 from hokusai.lib.exceptions import CalledProcessError, HokusaiError
 from hokusai.lib.template_selector import TemplateSelector
+from hokusai.services.docker import Docker
 from hokusai.services.ecr import ECR
 from hokusai.services.kubectl import Kubectl
-from hokusai.services.docker import Docker
 
 def check():
   return_code = 0

--- a/hokusai/commands/check.py
+++ b/hokusai/commands/check.py
@@ -5,9 +5,9 @@ import os
 from hokusai import CWD
 from hokusai.lib.common import get_region_name, print_green, print_red, shout
 from hokusai.lib.config import HOKUSAI_CONFIG_DIR, BUILD_YAML_FILE, TEST_YML_FILE, DEVELOPMENT_YML_FILE, config
+from hokusai.lib.docker_compose_helpers import detect_compose_command
 from hokusai.lib.exceptions import CalledProcessError, HokusaiError
 from hokusai.lib.template_selector import TemplateSelector
-from hokusai.services.docker import Docker
 from hokusai.services.ecr import ECR
 from hokusai.services.kubectl import Kubectl
 
@@ -33,7 +33,7 @@ def check():
     check_err('docker')
     return_code += 1
 
-  compose_command = Docker.detect_compose_command()
+  compose_command = detect_compose_command()
   print_green(
     '\u2714 ' +
     f'Will use "{compose_command}" command for Docker Compose'

--- a/hokusai/commands/check.py
+++ b/hokusai/commands/check.py
@@ -33,7 +33,7 @@ def check():
     check_err('docker')
     return_code += 1
 
-  compose_command = Docker.compose_command()
+  compose_command = Docker.detect_compose_command()
   print_green(
     '\u2714 ' +
     f'Will use "{compose_command}" command for Docker Compose'

--- a/hokusai/commands/development.py
+++ b/hokusai/commands/development.py
@@ -1,14 +1,14 @@
 import os
 import signal
 
-from hokusai.lib.config import HOKUSAI_CONFIG_DIR, config
+from hokusai.lib.config import HOKUSAI_CONFIG_DIR, DEVELOPMENT_YML_FILE, config
 from hokusai.lib.common import print_green, shout, EXIT_SIGNALS
 from hokusai.services.docker import Docker
 from hokusai.lib.docker_compose_helpers import generate_compose_command, get_yaml_template
 
 
 def dev_start(build, detach, filename):
-  compose_command = generate_compose_command(filename)
+  compose_command = generate_compose_command(filename, default_yaml_file=DEVELOPMENT_YML_FILE)
   def cleanup(*args):
     shout(
       f'{compose_command} -p hokusai stop',
@@ -18,7 +18,7 @@ def dev_start(build, detach, filename):
     signal.signal(sig, cleanup)
   opts = ''
   if build:
-    yaml_template = get_yaml_template(filename)
+    yaml_template = get_yaml_template(filename, default_yaml_file=DEVELOPMENT_YML_FILE)
     Docker().build(filename=yaml_template)
   if detach:
     opts += ' -d'
@@ -32,21 +32,21 @@ def dev_start(build, detach, filename):
     print_green("Run `hokousai dev stop` to shut down, or `hokusai dev logs --follow` to tail output.")
 
 def dev_stop(filename):
-  compose_command = generate_compose_command(filename)
+  compose_command = generate_compose_command(filename, default_yaml_file=DEVELOPMENT_YML_FILE)
   shout(
     f'{compose_command} -p hokusai stop',
     print_output=True
   )
 
 def dev_status(filename):
-  compose_command = generate_compose_command(filename)
+  compose_command = generate_compose_command(filename, default_yaml_file=DEVELOPMENT_YML_FILE)
   shout(
     f'{compose_command} -p hokusai ps',
     print_output=True
   )
 
 def dev_logs(follow, tail, filename):
-  compose_command = generate_compose_command(filename)
+  compose_command = generate_compose_command(filename, default_yaml_file=DEVELOPMENT_YML_FILE)
   opts = ''
   if follow:
     opts += ' --follow'
@@ -58,7 +58,7 @@ def dev_logs(follow, tail, filename):
   )
 
 def dev_run(container_command, service_name, stop, filename):
-  compose_command = generate_compose_command(filename)
+  compose_command = generate_compose_command(filename, default_yaml_file=DEVELOPMENT_YML_FILE)
   if service_name is None:
     service_name = config.project_name
   shout(
@@ -72,7 +72,7 @@ def dev_run(container_command, service_name, stop, filename):
     )
 
 def dev_clean(filename):
-  compose_command = generate_compose_command(filename)
+  compose_command = generate_compose_command(filename, default_yaml_file=DEVELOPMENT_YML_FILE)
   shout(
     f'{compose_command} -p hokusai stop',
     print_output=True

--- a/hokusai/commands/development.py
+++ b/hokusai/commands/development.py
@@ -1,14 +1,17 @@
 import os
 import signal
 
-from hokusai.lib.config import HOKUSAI_CONFIG_DIR, DEVELOPMENT_YML_FILE, config
-from hokusai.lib.common import print_green, shout, EXIT_SIGNALS
-from hokusai.services.docker import Docker
+from hokusai.lib.common import EXIT_SIGNALS, print_green, shout
+from hokusai.lib.config import DEVELOPMENT_YML_FILE, config
 from hokusai.lib.docker_compose_helpers import generate_compose_command, get_yaml_template
+from hokusai.services.docker import Docker
 
 
 def dev_start(build, detach, filename):
-  compose_command = generate_compose_command(filename, default_yaml_file=DEVELOPMENT_YML_FILE)
+  compose_command = generate_compose_command(
+    filename,
+    default_yaml_file=DEVELOPMENT_YML_FILE
+  )
   def cleanup(*args):
     shout(
       f'{compose_command} -p hokusai stop',
@@ -18,35 +21,51 @@ def dev_start(build, detach, filename):
     signal.signal(sig, cleanup)
   opts = ''
   if build:
-    yaml_template = get_yaml_template(filename, default_yaml_file=DEVELOPMENT_YML_FILE)
+    yaml_template = get_yaml_template(
+      filename,
+      default_yaml_file=DEVELOPMENT_YML_FILE
+    )
     Docker().build(filename=yaml_template)
   if detach:
     opts += ' -d'
   if not detach:
-    print_green("Starting development environment... Press Ctrl+C to stop.")
+    print_green(
+      "Starting development environment... Press Ctrl+C to stop."
+    )
   shout(
     f'{compose_command} -p hokusai up{opts}',
     print_output=True
   )
   if detach:
-    print_green("Run `hokousai dev stop` to shut down, or `hokusai dev logs --follow` to tail output.")
+    print_green(
+      "Run `hokousai dev stop` to shut down, or `hokusai dev logs --follow` to tail output."
+    )
 
 def dev_stop(filename):
-  compose_command = generate_compose_command(filename, default_yaml_file=DEVELOPMENT_YML_FILE)
+  compose_command = generate_compose_command(
+    filename,
+    default_yaml_file=DEVELOPMENT_YML_FILE
+  )
   shout(
     f'{compose_command} -p hokusai stop',
     print_output=True
   )
 
 def dev_status(filename):
-  compose_command = generate_compose_command(filename, default_yaml_file=DEVELOPMENT_YML_FILE)
+  compose_command = generate_compose_command(
+    filename,
+    default_yaml_file=DEVELOPMENT_YML_FILE
+  )
   shout(
     f'{compose_command} -p hokusai ps',
     print_output=True
   )
 
 def dev_logs(follow, tail, filename):
-  compose_command = generate_compose_command(filename, default_yaml_file=DEVELOPMENT_YML_FILE)
+  compose_command = generate_compose_command(
+    filename,
+    default_yaml_file=DEVELOPMENT_YML_FILE
+  )
   opts = ''
   if follow:
     opts += ' --follow'
@@ -58,7 +77,10 @@ def dev_logs(follow, tail, filename):
   )
 
 def dev_run(container_command, service_name, stop, filename):
-  compose_command = generate_compose_command(filename, default_yaml_file=DEVELOPMENT_YML_FILE)
+  compose_command = generate_compose_command(
+    filename,
+    default_yaml_file=DEVELOPMENT_YML_FILE
+  )
   if service_name is None:
     service_name = config.project_name
   shout(
@@ -72,7 +94,10 @@ def dev_run(container_command, service_name, stop, filename):
     )
 
 def dev_clean(filename):
-  compose_command = generate_compose_command(filename, default_yaml_file=DEVELOPMENT_YML_FILE)
+  compose_command = generate_compose_command(
+    filename,
+    default_yaml_file=DEVELOPMENT_YML_FILE
+  )
   shout(
     f'{compose_command} -p hokusai stop',
     print_output=True

--- a/hokusai/commands/development.py
+++ b/hokusai/commands/development.py
@@ -1,107 +1,83 @@
 import os
 import signal
 
-from hokusai import CWD
-from hokusai.lib.config import HOKUSAI_CONFIG_DIR, DEVELOPMENT_YML_FILE, config
+from hokusai.lib.config import HOKUSAI_CONFIG_DIR, config
 from hokusai.lib.common import print_green, shout, EXIT_SIGNALS
-from hokusai.lib.exceptions import HokusaiError
 from hokusai.services.docker import Docker
-from hokusai.lib.template_selector import TemplateSelector
-from hokusai.lib.docker_compose_helpers import follow_extends
-from hokusai.services.yaml_spec import YamlSpec
+from hokusai.lib.docker_compose_helpers import generate_compose_command, get_yaml_template
+
 
 def dev_start(build, detach, filename):
-  if filename is None:
-    yaml_template = TemplateSelector().get(os.path.join(CWD, HOKUSAI_CONFIG_DIR, DEVELOPMENT_YML_FILE))
-  else:
-    yaml_template = TemplateSelector().get(filename)
-
-  docker_compose_yml = YamlSpec(yaml_template).to_file()
-  follow_extends(docker_compose_yml)
-
+  compose_command = generate_compose_command(filename)
   def cleanup(*args):
-    shout("COMPOSE_COMPATIBILITY=true docker-compose -f %s -p hokusai stop" % docker_compose_yml, print_output=True)
+    shout(
+      f'{compose_command} -p hokusai stop',
+      print_output=True
+    )
   for sig in EXIT_SIGNALS:
     signal.signal(sig, cleanup)
-
   opts = ''
   if build:
+    yaml_template = get_yaml_template(filename)
     Docker().build(filename=yaml_template)
   if detach:
     opts += ' -d'
-
   if not detach:
     print_green("Starting development environment... Press Ctrl+C to stop.")
-
-  shout("COMPOSE_COMPATIBILITY=true docker-compose -f %s -p hokusai up%s" % (docker_compose_yml, opts), print_output=True)
-
+  shout(
+    f'{compose_command} -p hokusai up{opts}',
+    print_output=True
+  )
   if detach:
     print_green("Run `hokousai dev stop` to shut down, or `hokusai dev logs --follow` to tail output.")
 
 def dev_stop(filename):
-  if filename is None:
-    yaml_template = TemplateSelector().get(os.path.join(CWD, HOKUSAI_CONFIG_DIR, DEVELOPMENT_YML_FILE))
-  else:
-    yaml_template = TemplateSelector().get(filename)
-
-  docker_compose_yml = YamlSpec(yaml_template).to_file()
-  follow_extends(docker_compose_yml)
-
-  shout("COMPOSE_COMPATIBILITY=true docker-compose -f %s -p hokusai stop" % docker_compose_yml, print_output=True)
+  compose_command = generate_compose_command(filename)
+  shout(
+    f'{compose_command} -p hokusai stop',
+    print_output=True
+  )
 
 def dev_status(filename):
-  if filename is None:
-    yaml_template = TemplateSelector().get(os.path.join(CWD, HOKUSAI_CONFIG_DIR, DEVELOPMENT_YML_FILE))
-  else:
-    yaml_template = TemplateSelector().get(filename)
-
-  docker_compose_yml = YamlSpec(yaml_template).to_file()
-  follow_extends(docker_compose_yml)
-
-  shout("COMPOSE_COMPATIBILITY=true docker-compose -f %s -p hokusai ps" % docker_compose_yml, print_output=True)
+  compose_command = generate_compose_command(filename)
+  shout(
+    f'{compose_command} -p hokusai ps',
+    print_output=True
+  )
 
 def dev_logs(follow, tail, filename):
-  if filename is None:
-    yaml_template = TemplateSelector().get(os.path.join(CWD, HOKUSAI_CONFIG_DIR, DEVELOPMENT_YML_FILE))
-  else:
-    yaml_template = TemplateSelector().get(filename)
-
-  docker_compose_yml = YamlSpec(yaml_template).to_file()
-  follow_extends(docker_compose_yml)
-
+  compose_command = generate_compose_command(filename)
   opts = ''
   if follow:
     opts += ' --follow'
   if tail:
     opts += " --tail=%i" % tail
-
-  shout("COMPOSE_COMPATIBILITY=true docker-compose -f %s -p hokusai logs%s" % (docker_compose_yml, opts), print_output=True)
+  shout(
+    f'{compose_command} -p hokusai logs{opts}',
+    print_output=True
+  )
 
 def dev_run(container_command, service_name, stop, filename):
-  if filename is None:
-    yaml_template = TemplateSelector().get(os.path.join(CWD, HOKUSAI_CONFIG_DIR, DEVELOPMENT_YML_FILE))
-  else:
-    yaml_template = TemplateSelector().get(filename)
-
-  docker_compose_yml = YamlSpec(yaml_template).to_file()
-  follow_extends(docker_compose_yml)
-
+  compose_command = generate_compose_command(filename)
   if service_name is None:
     service_name = config.project_name
-
-  shout("COMPOSE_COMPATIBILITY=true docker-compose -f %s -p hokusai run %s %s" % (docker_compose_yml, service_name, container_command), print_output=True)
-
+  shout(
+    f'{compose_command} -p hokusai run {service_name} {container_command}',
+    print_output=True
+  )
   if stop:
-    shout("COMPOSE_COMPATIBILITY=true docker-compose -f %s -p hokusai stop" % docker_compose_yml, print_output=True)
+    shout(
+      f'{compose_command} -p hokusai stop',
+      print_output=True
+    )
 
 def dev_clean(filename):
-  if filename is None:
-    yaml_template = TemplateSelector().get(os.path.join(CWD, HOKUSAI_CONFIG_DIR, DEVELOPMENT_YML_FILE))
-  else:
-    yaml_template = TemplateSelector().get(filename)
-
-  docker_compose_yml = YamlSpec(yaml_template).to_file()
-  follow_extends(docker_compose_yml)
-
-  shout("COMPOSE_COMPATIBILITY=true docker-compose -f %s -p hokusai stop" % docker_compose_yml, print_output=True)
-  shout("COMPOSE_COMPATIBILITY=true docker-compose -f %s -p hokusai rm --force" % docker_compose_yml, print_output=True)
+  compose_command = generate_compose_command(filename)
+  shout(
+    f'{compose_command} -p hokusai stop',
+    print_output=True
+  )
+  shout(
+    f'{compose_command} -p hokusai rm --force',
+    print_output=True
+  )

--- a/hokusai/commands/test.py
+++ b/hokusai/commands/test.py
@@ -1,16 +1,18 @@
 import os
 import signal
 
-from hokusai import CWD
-from hokusai.lib.config import config, TEST_YML_FILE
-from hokusai.lib.common import print_green, print_red, shout, EXIT_SIGNALS
+from hokusai.lib.common import EXIT_SIGNALS, print_green, print_red, shout
+from hokusai.lib.config import TEST_YML_FILE, config
+from hokusai.lib.docker_compose_helpers import generate_compose_command, get_yaml_template
 from hokusai.lib.exceptions import CalledProcessError, HokusaiError
 from hokusai.services.docker import Docker
-from hokusai.lib.docker_compose_helpers import generate_compose_command, get_yaml_template
 
 
 def test(build, cleanup, filename, service_name):
-  compose_command = generate_compose_command(filename, default_yaml_file=TEST_YML_FILE)
+  compose_command = generate_compose_command(
+    filename,
+    default_yaml_file=TEST_YML_FILE
+  )
 
   def on_cleanup(*args):
     shout(
@@ -24,14 +26,20 @@ def test(build, cleanup, filename, service_name):
       signal.signal(sig, on_cleanup)
 
   if build:
-    yaml_template = get_yaml_template(filename, default_yaml_file=TEST_YML_FILE)
+    yaml_template = get_yaml_template(
+      filename,
+      default_yaml_file=TEST_YML_FILE
+    )
     Docker().build(filename=yaml_template)
 
   if service_name is None:
     service_name = config.project_name
 
   opts = " --abort-on-container-exit --exit-code-from %s" % service_name
-  print_green("Starting test environment... Press Ctrl+C to stop.", newline_after=True)
+  print_green(
+    "Starting test environment... Press Ctrl+C to stop.",
+    newline_after=True
+  )
   try:
     return_code = int(
       shout(
@@ -45,7 +53,10 @@ def test(build, cleanup, filename, service_name):
     raise HokusaiError('Tests Failed')
 
   if return_code:
-    raise HokusaiError('Tests Failed - Exit Code: %s\n' % return_code, return_code=return_code)
+    raise HokusaiError(
+      'Tests Failed - Exit Code: %s\n' % return_code,
+      return_code=return_code
+    )
   else:
     print_green("Tests Passed")
 

--- a/hokusai/commands/test.py
+++ b/hokusai/commands/test.py
@@ -7,37 +7,40 @@ from hokusai.lib.common import print_green, print_red, shout, EXIT_SIGNALS
 from hokusai.lib.exceptions import CalledProcessError, HokusaiError
 from hokusai.services.docker import Docker
 from hokusai.lib.template_selector import TemplateSelector
-from hokusai.lib.docker_compose_helpers import follow_extends
+from hokusai.lib.docker_compose_helpers import generate_compose_command, get_yaml_template
 from hokusai.services.yaml_spec import YamlSpec
 
-def test(build, cleanup, filename, service_name):
-  if filename is None:
-    yaml_template = TemplateSelector().get(os.path.join(CWD, HOKUSAI_CONFIG_DIR, TEST_YML_FILE))
-  else:
-    yaml_template = TemplateSelector().get(filename)
 
-  docker_compose_yml = YamlSpec(yaml_template).to_file()
-  follow_extends(docker_compose_yml)
+def test(build, cleanup, filename, service_name):
+  compose_command = generate_compose_command(filename)
 
   def on_cleanup(*args):
-    shout("COMPOSE_COMPATIBILITY=true docker-compose -f %s -p hokusai stop" % docker_compose_yml)
-    shout("COMPOSE_COMPATIBILITY=true docker-compose -f %s -p hokusai rm --force" % docker_compose_yml)
-
+    shout(
+      f'{compose_command} -p hokusai stop',
+    )
+    shout(
+      f'{compose_command} -p hokusai rm --force',
+    )
   if cleanup:
     for sig in EXIT_SIGNALS:
       signal.signal(sig, on_cleanup)
 
   if build:
+    yaml_template = get_yaml_template(filename)
     Docker().build(filename=yaml_template)
 
   if service_name is None:
     service_name = config.project_name
 
   opts = " --abort-on-container-exit --exit-code-from %s" % service_name
-
   print_green("Starting test environment... Press Ctrl+C to stop.", newline_after=True)
   try:
-    return_code = int(shout("COMPOSE_COMPATIBILITY=true docker-compose -f %s -p hokusai up%s" % (docker_compose_yml, opts), print_output=True))
+    return_code = int(
+      shout(
+        f'{compose_command} -p hokusai up{opts}',
+        print_output=True
+      )
+    )
   except CalledProcessError as e:
     print_red("CalledProcessError return code: %s" % e.returncode)
     if cleanup: on_cleanup()

--- a/hokusai/commands/test.py
+++ b/hokusai/commands/test.py
@@ -2,17 +2,15 @@ import os
 import signal
 
 from hokusai import CWD
-from hokusai.lib.config import HOKUSAI_CONFIG_DIR, TEST_YML_FILE, config
+from hokusai.lib.config import config, TEST_YML_FILE
 from hokusai.lib.common import print_green, print_red, shout, EXIT_SIGNALS
 from hokusai.lib.exceptions import CalledProcessError, HokusaiError
 from hokusai.services.docker import Docker
-from hokusai.lib.template_selector import TemplateSelector
 from hokusai.lib.docker_compose_helpers import generate_compose_command, get_yaml_template
-from hokusai.services.yaml_spec import YamlSpec
 
 
 def test(build, cleanup, filename, service_name):
-  compose_command = generate_compose_command(filename)
+  compose_command = generate_compose_command(filename, default_yaml_file=TEST_YML_FILE)
 
   def on_cleanup(*args):
     shout(
@@ -26,7 +24,7 @@ def test(build, cleanup, filename, service_name):
       signal.signal(sig, on_cleanup)
 
   if build:
-    yaml_template = get_yaml_template(filename)
+    yaml_template = get_yaml_template(filename, default_yaml_file=TEST_YML_FILE)
     Docker().build(filename=yaml_template)
 
   if service_name is None:

--- a/hokusai/lib/docker_compose_helpers.py
+++ b/hokusai/lib/docker_compose_helpers.py
@@ -3,10 +3,11 @@ import os
 import yaml
 
 from hokusai import CWD
-from hokusai.lib.config import HOKUSAI_CONFIG_DIR
-from hokusai.lib.exceptions import HokusaiError
+from hokusai.lib.config import HOKUSAI_CONFIG_DIR, DEVELOPMENT_YML_FILE
 from hokusai.lib.template_selector import TemplateSelector
+from hokusai.services.docker import Docker
 from hokusai.services.yaml_spec import YamlSpec
+
 
 def follow_extends(docker_compose_yml):
   with open(docker_compose_yml, 'r') as f:
@@ -22,3 +23,29 @@ def follow_extends(docker_compose_yml):
       extended_template = TemplateSelector().get(extended_template_path)
       rendered_templates.append(YamlSpec(extended_template).to_file())
     return rendered_templates
+
+def generate_compose_command(filename):
+  ''' return Docker Compose command '''
+  docker_compose_yml = render_docker_compose_yml(filename)
+  return (
+    'COMPOSE_COMPATIBILITY=true ' +
+    Docker.compose_command() +
+    f' -f {docker_compose_yml}'
+  )
+
+def get_yaml_template(filename):
+  ''' return yaml template '''
+  if filename is None:
+    yaml_template = TemplateSelector().get(
+      os.path.join(CWD, HOKUSAI_CONFIG_DIR, DEVELOPMENT_YML_FILE)
+    )
+  else:
+    yaml_template = TemplateSelector().get(filename)
+  return yaml_template
+
+def render_docker_compose_yml(filename):
+  ''' return path of rendered Docker Compose yaml '''
+  yaml_template = get_yaml_template(filename)
+  docker_compose_yml = YamlSpec(yaml_template).to_file()
+  follow_extends(docker_compose_yml)
+  return docker_compose_yml

--- a/hokusai/lib/docker_compose_helpers.py
+++ b/hokusai/lib/docker_compose_helpers.py
@@ -5,7 +5,6 @@ import yaml
 from hokusai import CWD
 from hokusai.lib.config import HOKUSAI_CONFIG_DIR, DEVELOPMENT_YML_FILE
 from hokusai.lib.template_selector import TemplateSelector
-from hokusai.services.docker import Docker
 from hokusai.services.yaml_spec import YamlSpec
 
 
@@ -26,7 +25,11 @@ def follow_extends(docker_compose_yml):
 
 def generate_compose_command(filename, default_yaml_file):
   ''' return Docker Compose command '''
+  # this import when done globally causes circular import error
+  from hokusai.services.docker import Docker
   docker_compose_yml = render_docker_compose_yml(filename, default_yaml_file)
+  # docker-compose v2 switched to using '-' as separator in image name, resulting in 'hokusai-<project>'
+  # COMPOSE_COMPATIBILITY=true forces v2 to use '_', resulting in 'hokusai_<project>', matching v1
   return (
     'COMPOSE_COMPATIBILITY=true ' +
     Docker.compose_command() +

--- a/hokusai/lib/docker_compose_helpers.py
+++ b/hokusai/lib/docker_compose_helpers.py
@@ -3,7 +3,7 @@ import os
 import yaml
 
 from hokusai import CWD
-from hokusai.lib.config import HOKUSAI_CONFIG_DIR, DEVELOPMENT_YML_FILE
+from hokusai.lib.config import HOKUSAI_CONFIG_DIR
 from hokusai.lib.template_selector import TemplateSelector
 from hokusai.services.yaml_spec import YamlSpec
 
@@ -27,9 +27,14 @@ def generate_compose_command(filename, default_yaml_file):
   ''' return Docker Compose command '''
   # this import when done globally causes circular import error
   from hokusai.services.docker import Docker
-  docker_compose_yml = render_docker_compose_yml(filename, default_yaml_file)
-  # docker-compose v2 switched to using '-' as separator in image name, resulting in 'hokusai-<project>'
-  # COMPOSE_COMPATIBILITY=true forces v2 to use '_', resulting in 'hokusai_<project>', matching v1
+  docker_compose_yml = render_docker_compose_yml(
+    filename,
+    default_yaml_file
+  )
+  # docker-compose v2 switched to using '-' as separator in image name,
+  # resulting in 'hokusai-<project>'
+  # COMPOSE_COMPATIBILITY=true forces v2 to use '_',
+  # resulting in 'hokusai_<project>', matching v1
   return (
     'COMPOSE_COMPATIBILITY=true ' +
     Docker.compose_command() +
@@ -40,7 +45,11 @@ def get_yaml_template(filename, default_yaml_file):
   ''' return yaml template '''
   if filename is None:
     yaml_template = TemplateSelector().get(
-      os.path.join(CWD, HOKUSAI_CONFIG_DIR, default_yaml_file)
+      os.path.join(
+        CWD,
+        HOKUSAI_CONFIG_DIR,
+        default_yaml_file
+      )
     )
   else:
     yaml_template = TemplateSelector().get(filename)

--- a/hokusai/lib/docker_compose_helpers.py
+++ b/hokusai/lib/docker_compose_helpers.py
@@ -24,28 +24,28 @@ def follow_extends(docker_compose_yml):
       rendered_templates.append(YamlSpec(extended_template).to_file())
     return rendered_templates
 
-def generate_compose_command(filename):
+def generate_compose_command(filename, default_yaml_file):
   ''' return Docker Compose command '''
-  docker_compose_yml = render_docker_compose_yml(filename)
+  docker_compose_yml = render_docker_compose_yml(filename, default_yaml_file)
   return (
     'COMPOSE_COMPATIBILITY=true ' +
     Docker.compose_command() +
     f' -f {docker_compose_yml}'
   )
 
-def get_yaml_template(filename):
+def get_yaml_template(filename, default_yaml_file):
   ''' return yaml template '''
   if filename is None:
     yaml_template = TemplateSelector().get(
-      os.path.join(CWD, HOKUSAI_CONFIG_DIR, DEVELOPMENT_YML_FILE)
+      os.path.join(CWD, HOKUSAI_CONFIG_DIR, default_yaml_file)
     )
   else:
     yaml_template = TemplateSelector().get(filename)
   return yaml_template
 
-def render_docker_compose_yml(filename):
+def render_docker_compose_yml(filename, default_yaml_file):
   ''' return path of rendered Docker Compose yaml '''
-  yaml_template = get_yaml_template(filename)
+  yaml_template = get_yaml_template(filename, default_yaml_file)
   docker_compose_yml = YamlSpec(yaml_template).to_file()
   follow_extends(docker_compose_yml)
   return docker_compose_yml

--- a/hokusai/services/docker.py
+++ b/hokusai/services/docker.py
@@ -5,34 +5,11 @@ from hokusai.lib.config import HOKUSAI_CONFIG_DIR, BUILD_YAML_FILE, config
 from hokusai.lib.common import shout, get_verbosity, print_yellow, print_green
 from hokusai.lib.template_selector import TemplateSelector
 from hokusai.services.yaml_spec import YamlSpec
-
 from hokusai.lib.exceptions import CalledProcessError
+from hokusai.lib.docker_compose_helpers import generate_compose_command
+
 
 class Docker:
-  def build(self, filename=None):
-    if filename is None:
-      yaml_template = TemplateSelector().get(os.path.join(CWD, HOKUSAI_CONFIG_DIR, BUILD_YAML_FILE))
-    else:
-      yaml_template = TemplateSelector().get(filename)
-
-    docker_compose_yml = YamlSpec(yaml_template).to_file()
-
-    # docker-compose v2 switched to using '-' as separator in image name, resulting in 'hokusai-<project>'
-    # COMPOSE_COMPATIBILITY=true forces v2 to use '_', resulting in 'hokusai_<project>', matching v1
-    env_vars = "DOCKER_DEFAULT_PLATFORM=linux/amd64 COMPOSE_COMPATIBILITY=true"
-
-    compose_command = f"docker compose -f {docker_compose_yml} -p hokusai build"
-    compose_options = "--progress plain"
-    build_command = f"{env_vars} {compose_command} {compose_options}"
-
-    if config.pre_build:
-      build_command = "%s && %s" % (config.pre_build, build_command)
-
-    if config.post_build:
-      build_command = "%s && %s" % (build_command, config.post_build)
-
-    shout(build_command, print_output=True)
-
   @classmethod
   def compose_command(cls):
     ''' decide what command to use for Docker Compose '''
@@ -49,3 +26,14 @@ class Docker:
         )
       command_to_use = 'docker compose'
     return command_to_use
+
+  def build(self, filename=None):
+    env_vars = "DOCKER_DEFAULT_PLATFORM=linux/amd64"
+    compose_command = generate_compose_command(filename, default_yaml_file=BUILD_YAML_FILE)
+    opts = "--progress plain"
+    build_command = f'{env_vars} {compose_command} -p hokusai build {opts}'
+    if config.pre_build:
+      build_command = "%s && %s" % (config.pre_build, build_command)
+    if config.post_build:
+      build_command = "%s && %s" % (build_command, config.post_build)
+    shout(build_command, print_output=True)

--- a/hokusai/services/docker.py
+++ b/hokusai/services/docker.py
@@ -1,12 +1,9 @@
 import os
 
-from hokusai import CWD
-from hokusai.lib.config import HOKUSAI_CONFIG_DIR, BUILD_YAML_FILE, config
-from hokusai.lib.common import shout, get_verbosity, print_yellow, print_green
-from hokusai.lib.template_selector import TemplateSelector
-from hokusai.services.yaml_spec import YamlSpec
-from hokusai.lib.exceptions import CalledProcessError
+from hokusai.lib.common import get_verbosity, print_green, print_yellow, shout
+from hokusai.lib.config import BUILD_YAML_FILE, config
 from hokusai.lib.docker_compose_helpers import generate_compose_command
+from hokusai.lib.exceptions import CalledProcessError
 
 
 class Docker:
@@ -22,14 +19,17 @@ class Docker:
     except CalledProcessError:
       if get_verbosity():
         print_yellow(
-          'docker-compose command not found. Will use "docker compose".'
+          'docker-compose command not found. Will use "docker compose" assuming it exists.'
         )
       command_to_use = 'docker compose'
     return command_to_use
 
   def build(self, filename=None):
     env_vars = "DOCKER_DEFAULT_PLATFORM=linux/amd64"
-    compose_command = generate_compose_command(filename, default_yaml_file=BUILD_YAML_FILE)
+    compose_command = generate_compose_command(
+      filename,
+      default_yaml_file=BUILD_YAML_FILE
+    )
     opts = "--progress plain"
     build_command = f'{env_vars} {compose_command} -p hokusai build {opts}'
     if config.pre_build:

--- a/hokusai/services/docker.py
+++ b/hokusai/services/docker.py
@@ -1,29 +1,11 @@
 import os
 
-from hokusai.lib.common import get_verbosity, print_green, print_yellow, shout
+from hokusai.lib.common import shout
 from hokusai.lib.config import BUILD_YAML_FILE, config
 from hokusai.lib.docker_compose_helpers import generate_compose_command
-from hokusai.lib.exceptions import CalledProcessError
 
 
 class Docker:
-  @classmethod
-  def detect_compose_command(cls):
-    ''' decide what command to use for Docker Compose '''
-    command_to_use = ''
-    try:
-      shout('which docker-compose')
-      if get_verbosity():
-        print_green('Found docker-compose.')
-      command_to_use = 'docker-compose'
-    except CalledProcessError:
-      if get_verbosity():
-        print_yellow(
-          'docker-compose command not found. Will use "docker compose" assuming it exists.'
-        )
-      command_to_use = 'docker compose'
-    return command_to_use
-
   def build(self, filename=None):
     env_vars = "DOCKER_DEFAULT_PLATFORM=linux/amd64"
     compose_command = generate_compose_command(

--- a/hokusai/services/docker.py
+++ b/hokusai/services/docker.py
@@ -2,7 +2,7 @@ import os
 
 from hokusai import CWD
 from hokusai.lib.config import HOKUSAI_CONFIG_DIR, BUILD_YAML_FILE, config
-from hokusai.lib.common import shout, get_verbosity
+from hokusai.lib.common import shout, get_verbosity, print_yellow
 from hokusai.lib.template_selector import TemplateSelector
 from hokusai.services.yaml_spec import YamlSpec
 
@@ -35,15 +35,17 @@ class Docker:
 
   @classmethod
   def compose_command(cls):
-    ''' Decide what command to use for Docker Compose '''
+    ''' decide what command to use for Docker Compose '''
     command_to_use = ''
     try:
       shout('which docker-compose')
       if get_verbosity():
-        print('Found docker-compose.')
+        print_green('Found docker-compose.')
       command_to_use = 'docker-compose'
     except CalledProcessError:
       if get_verbosity():
-        print('docker-compose command not found. Will use "docker compose"')
+        print_yellow(
+          'docker-compose command not found. Will use "docker compose".'
+        )
       command_to_use = 'docker compose'
     return command_to_use

--- a/hokusai/services/docker.py
+++ b/hokusai/services/docker.py
@@ -8,7 +8,7 @@ from hokusai.lib.exceptions import CalledProcessError
 
 class Docker:
   @classmethod
-  def compose_command(cls):
+  def detect_compose_command(cls):
     ''' decide what command to use for Docker Compose '''
     command_to_use = ''
     try:

--- a/hokusai/services/docker.py
+++ b/hokusai/services/docker.py
@@ -2,7 +2,7 @@ import os
 
 from hokusai import CWD
 from hokusai.lib.config import HOKUSAI_CONFIG_DIR, BUILD_YAML_FILE, config
-from hokusai.lib.common import shout, get_verbosity, print_yellow
+from hokusai.lib.common import shout, get_verbosity, print_yellow, print_green
 from hokusai.lib.template_selector import TemplateSelector
 from hokusai.services.yaml_spec import YamlSpec
 


### PR DESCRIPTION
To solve https://github.com/artsy/hokusai/issues/433

`docker compose` seems to be able to do everything `docker-compose` does.

This PR recommends that when `docker-compose` is not available, use `docker compose`. The following Hokusai commands use Docker Compose:
- `hokusai build`
- `hokusai dev`
- `hokusai test`

This PR includes the following refactors:

- Add verbosity option to `hokusai check` command.
- The responsibility of discovering `docker-compose` command is moved from `hokusai check` command to `Docker` class.
- All invocations of `docker-compose` are changed to invoke whichever command `Docker` class decides.
- The following spaghetti is moved into helpers:
  ```
    if filename is None:
      yaml_template = TemplateSelector().get(os.path.join(CWD, HOKUSAI_CONFIG_DIR, DEVELOPMENT_YML_FILE))
    else:
      yaml_template = TemplateSelector().get(filename)

    docker_compose_yml = YamlSpec(yaml_template).to_file()
  ```
- Minor formatting improvements.
