### PR TITLE
feat: bump golang

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -266,7 +266,7 @@ jobs:
 
   release_github:
     docker:
-      - image: golang:1.19
+      - image: golang:1.23
     steps:
       - checkout
       - run: apt-get -qq update


### PR DESCRIPTION
To resolve [ghr install error](https://app.circleci.com/pipelines/github/artsy/hokusai/1435/workflows/f27f5f27-0de4-4d80-8d1f-498995bf9981/jobs/6264). Latest ghr version requires golang >= 1.23.