### PR TITLE
feat: add confirmation prompt and --assume-yes flag to delete commands

### DIFF
--- a/hokusai/cli/production.py
+++ b/hokusai/cli/production.py
@@ -4,7 +4,8 @@ import hokusai
 
 from hokusai.cli.base import base
 from hokusai.lib.command import command
-from hokusai.lib.common import set_verbosity, CONTEXT_SETTINGS
+from hokusai.lib.common import set_verbosity, CONTEXT_SETTINGS, confirm_delete_resources
+from hokusai.lib.config import config
 
 KUBE_CONTEXT = 'production'
 
@@ -33,9 +34,16 @@ def create(filename, environment, verbose):
 @production.command(context_settings=CONTEXT_SETTINGS)
 @click.option('-f', '--filename', type=click.STRING, help='Use the given Kubernetes Yaml file (default ./hokusai/production.yml)')
 @click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
-def delete(filename, verbose):
+@click.option('-y', '--assume-yes', type=click.BOOL, is_flag=True, help='Assume yes to confirmation prompt')
+def delete(filename, verbose, assume_yes):
   """Delete the Kubernetes resources defined in ./hokusai/production.yml"""
   set_verbosity(verbose)
+  
+  # Skip confirmation if --assume-yes is used
+  if not assume_yes:
+    if not confirm_delete_resources(config.project_name, KUBE_CONTEXT, filename):
+      return
+  
   command(
     hokusai.k8s_delete,
     KUBE_CONTEXT,

--- a/hokusai/cli/staging.py
+++ b/hokusai/cli/staging.py
@@ -4,7 +4,8 @@ import hokusai
 
 from hokusai.cli.base import base
 from hokusai.lib.command import command
-from hokusai.lib.common import set_verbosity, CONTEXT_SETTINGS
+from hokusai.lib.common import set_verbosity, CONTEXT_SETTINGS, confirm_delete_resources
+from hokusai.lib.config import config
 
 KUBE_CONTEXT = 'staging'
 
@@ -33,9 +34,16 @@ def create(filename, environment, verbose):
 @staging.command(context_settings=CONTEXT_SETTINGS)
 @click.option('-f', '--filename', type=click.STRING, help='Use the given Kubernetes Yaml file (default ./hokusai/staging.yml)')
 @click.option('-v', '--verbose', type=click.BOOL, is_flag=True, help='Verbose output')
-def delete(filename, verbose):
+@click.option('-y', '--assume-yes', type=click.BOOL, is_flag=True, help='Assume yes to confirmation prompt')
+def delete(filename, verbose, assume_yes):
   """Delete the Kubernetes resources defined in ./hokusai/staging.yml"""
   set_verbosity(verbose)
+  
+  # Skip confirmation if --assume-yes is used
+  if not assume_yes:
+    if not confirm_delete_resources(config.project_name, KUBE_CONTEXT, filename):
+      return
+  
   command(
     hokusai.k8s_delete,
     KUBE_CONTEXT,

--- a/hokusai/lib/common.py
+++ b/hokusai/lib/common.py
@@ -2,6 +2,7 @@
 
 import os
 
+import click
 import json
 import platform
 import random
@@ -380,3 +381,26 @@ def write_temp_file(data, dir):
 def yaml_content_with_header(content_string):
   ''' return content with yaml header prepended '''
   return YAML_HEADER + content_string
+
+def confirm_delete_resources(project_name, environment, yaml_file):
+  ''' Display confirmation prompt for destructive delete operations '''
+  print_smart("\n" + "="*60)
+  print_red("⚠️  DESTRUCTIVE ACTION WARNING", newline_before=False, newline_after=False)
+  print_smart("="*60)
+  
+  print_smart(f"Project:     {project_name}")
+  print_smart(f"Environment: {environment}")
+  if yaml_file is not None:
+    print_smart(f"Config file: {yaml_file}")
+  print_smart("")
+  print_yellow("This will permanently delete Kubernetes resources", newline_before=False, newline_after=False)
+  print_yellow("for this project in the specified environment.", newline_before=False, newline_after=False)
+  print_smart("")
+  print_smart("This action CANNOT be undone!")
+  print_smart("="*60)
+  
+  if not click.confirm("Do you want to continue with the deletion?"):
+    print_smart("Deletion cancelled.")
+    return False
+    
+  return True

--- a/test/integration/test_staging.py
+++ b/test/integration/test_staging.py
@@ -79,7 +79,7 @@ def describe_refresh():
 def describe_delete():
   def it_reports_deleted():
     resp = subprocess.run(
-      'hokusai staging delete',
+      'hokusai staging delete --assume-yes',
       capture_output=True,
       shell=True,
       text=True,


### PR DESCRIPTION
Add interactive confirmation prompt to `hokusai production delete` and `hokusai staging delete` commands to prevent accidental deletion of Kubernetes resources. The prompt displays the project name, environment, and YAML file being used.

- Add --assume-yes/-y flag to bypass confirmation for automation
- Update integration test to use --assume-yes flag
- Confirmation message shows context: project, environment, and file path (if provided).

cc/ @brainbicycle 

**Example Invocation with Interactive Prompt**

<img width="1884" height="1170" alt="Screenshot 2025-09-10 at 15 05 03" src="https://github.com/user-attachments/assets/12a297f5-db2b-4d6c-b540-013ce40c871e" />
