### PR TITLE
feat: make kubectl-dir and kubectl-version optional in global config

### DIFF
--- a/hokusai/lib/global_config.py
+++ b/hokusai/lib/global_config.py
@@ -64,16 +64,18 @@ class HokusaiGlobalConfig:
   def validate_config(self):
     ''' sanity check config '''
     required_vars = [
-      'kubectl-version',
       'kubeconfig-dir',
       'kubeconfig-source-uri',
-      'kubectl-dir'
     ]
     for var in required_vars:
       if not var in self._config:
         raise HokusaiError(
           f'{var} is missing in Hokusai global config'
         )
+    if 'kubectl-dir' in self._config and 'kubectl-version' not in self._config:
+      raise HokusaiError(
+        'kubectl-version is required in Hokusai global config when kubectl-dir is set'
+      )
 
   @property
   def kubeconfig_dir(self):
@@ -85,8 +87,8 @@ class HokusaiGlobalConfig:
 
   @property
   def kubectl_dir(self):
-    return self._config['kubectl-dir']
+    return self._config.get('kubectl-dir')
 
   @property
   def kubectl_version(self):
-    return self._config['kubectl-version']
+    return self._config.get('kubectl-version')

--- a/hokusai/services/kubectl.py
+++ b/hokusai/services/kubectl.py
@@ -1,9 +1,11 @@
 import os
+import shutil
 
 import json
 import yaml
 
 from hokusai.lib.common import shout, unlink_file_if_not_debug
+from hokusai.lib.exceptions import HokusaiError
 from hokusai.lib.global_config import HokusaiGlobalConfig
 
 
@@ -13,9 +15,15 @@ class Kubectl:
     self.context = context
     self.namespace = namespace
     global_config = HokusaiGlobalConfig()
-    self.kubectl = os.path.join(
-      global_config.kubectl_dir, 'kubectl'
-    )
+    kubectl_dir = global_config.kubectl_dir
+    if kubectl_dir:
+      self.kubectl = os.path.join(kubectl_dir, 'kubectl')
+    else:
+      self.kubectl = shutil.which('kubectl')
+      if self.kubectl is None:
+        raise HokusaiError(
+          'kubectl not found on PATH and kubectl-dir is not set in Hokusai global config'
+        )
 
   def _apply_or_create(self, action, k8s_spec_file):
     ''' run kubectl apply or create on a k8s spec file '''

--- a/test/unit/test_lib/test_global_config.py
+++ b/test/unit/test_lib/test_global_config.py
@@ -61,6 +61,17 @@ def describe_hokusai_global_config():
       del config_obj._config['kubeconfig-dir']
       with pytest.raises(HokusaiError):
         config_obj.validate_config()
+    def it_raises_when_kubectl_dir_set_without_kubectl_version():
+      config_obj = HokusaiGlobalConfig()
+      config_obj._config['kubectl-dir'] = '/some/dir'
+      del config_obj._config['kubectl-version']
+      with pytest.raises(HokusaiError):
+        config_obj.validate_config()
+    def it_does_not_raise_when_kubectl_version_absent_without_kubectl_dir():
+      config_obj = HokusaiGlobalConfig()
+      del config_obj._config['kubectl-version']
+      del config_obj._config['kubectl-dir']
+      config_obj.validate_config()
     def it_does_not_raise_when_otherwise():
       config_obj = HokusaiGlobalConfig()
       config_obj.validate_config()


### PR DESCRIPTION
## Summary

Previously, kubectl-dir and kubectl-version were required fields in ~/.hokusai.yml, even for users who manage kubectl externally (e.g. via mise or brew). This meant the config held stale metadata that hokusai never actually used.

## Changes
- kubectl-dir is now optional. When unset, hokusai resolves kubectl from PATH via shutil.which, raising a clear error if it can't be found.
- kubectl-version is now optional. It remains required only when kubectl-dir is set (i.e. when hokusai is managing the kubectl binary and needs to know what version to
  download).