### PR TITLE
ci: pin both golang and tcnksm/ghr

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -268,12 +268,12 @@ jobs:
 
   release_github:
     docker:
-      - image: golang:1.25
+      - image: golang:1.26
     steps:
       - checkout
       - run: apt-get -qq update
       - run: apt-get -qq install awscli
-      - run: go install github.com/tcnksm/ghr@latest
+      - run: go install github.com/tcnksm/ghr@v0.18.3
       - run: scripts/update_version_file.sh
       - run: make publish-to-github ARTIFACT_LABEL=$(cat hokusai/VERSION)
 


### PR DESCRIPTION
By pinning versions for both golang and the tcnksm/ghr dependency, we can avoid surprisingly golang incompatibility errors:

```
go: downloading github.com/tcnksm/ghr v0.18.3
go: github.com/tcnksm/ghr@latest: github.com/tcnksm/ghr@v0.18.3 requires go >= 1.26.0 (running go 1.25.10; GOTOOLCHAIN=local)

Exited with code exit status 1
```